### PR TITLE
Moving PULL_REQUEST_TEMPLATE.md to .github dir

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,8 @@
+### Description
+_Describe what this change achieves._
+
+### Issues Resolved
+_List any issues this PR will resolve, e.g. Closes [...]._ 
+
+By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
+For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,0 @@
-### Description
-_Describe what this change achieves._
-
-### Issues Resolved
-_List any issues this PR will resolve, e.g. Closes [...]._ 
-
-By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
-For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).


### PR DESCRIPTION
### Description
standardizes location of PULL_REQUEST_TEMPLATE.md. Triggers backport

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
