### PR TITLE
Add windows-latest back to test-and-build workflow

### DIFF
--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -11,13 +11,13 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
-      - name: Check LongPathsEnabled
+      - name: Enable core.longpaths on Windows
         if: ${{ matrix.os == 'windows-latest' }}
-        run: (Get-ItemProperty "HKLM:System\CurrentControlSet\Control\FileSystem").LongPathsEnabled
+        run: git config --global core.longpaths true
 
       - name: Checkout Dashboards Search Relevance plugin
         uses: actions/checkout@v2


### PR DESCRIPTION
Set the git config for core.longpaths to "true" to enable long file paths on Windows, as that was blocking us from checking out OpenSearch-Dashboards.

Signed-off-by: Michael Froh <froh@amazon.com>

### Description
Fixes Windows build by enabling core.longpaths Git setting.

### Issues Resolved
Closes [#16 ](https://github.com/opensearch-project/dashboards-search-relevance/issues/16)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
