### PR TITLE
Make srdash compatible with default build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,11 +5,11 @@
   "license": "Apache-2.0",
   "scripts": {
     "osd": "node ../../scripts/osd",
-    "build": "yarn plugin_helpers build",
+    "build": "yarn plugin-helpers build",
     "test": "../../node_modules/.bin/jest --config ./test/jest.config.js",
     "cypress:run": "TZ=America/Los_Angeles cypress run",
     "cypress:open": "TZ=America/Los_Angeles cypress open",
-    "plugin_helpers": "node ../../scripts/plugin_helpers"
+    "plugin-helpers": "node ../../scripts/plugin_helpers"
   },
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Make srdash compatible with default build script

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/2649

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
