### PR TITLE
Resolve to newer versions of dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,5 +16,10 @@
     "@types/enzyme-adapter-react-16": "^1.0.6",
     "cypress": "9.5.4",
     "eslint": "^6.8.0"
+  },
+  "resolutions": {
+    "ansi-regex": "^5.0.1",
+    "glob-parent": "^6.0.1",
+    "qs": "~6.5.3"
   }
 }


### PR DESCRIPTION
This addresses the following CVEs:

```
CVE-2021-3807  - Inefficient Regular Expression Complexity in
                 chalk/ansi-regex
CVE-2022-24999 - Improperly Controlled Modification of Object
                 Prototype Attributes ('Prototype Pollution'),
                 qs vulnerable to Prototype Pollution
GMS-2022-3113  - glob-parent before 6.0.1 and 5.1.2 vulnerable to
                 Regular Expression Denial of Service (ReDoS)
```

Signed-off-by: Michael Froh <froh@amazon.com>

### Description
_Describe what this change achieves._

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
