### PR TITLE
[Backport 2.x]Unit Test Coverage Threshold (#101)

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -3,5 +3,6 @@ coverage:
   status:
     project:
       default:
-        # https://docs.codecov.com/docs/commit-status#target
-        target: auto  # coverage must be equal or above the previous commit
+        target: 80%%
+        threshold: 2%
+

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -3,6 +3,7 @@ name: Pull Request Stats
 on:
   pull_request:
     types: [opened]
+  workflow_dispatch:
 
 jobs:
   stats:


### PR DESCRIPTION
Backport '052c593' from  [101](https://github.com/opensearch-project/dashboards-search-relevance/pull/101)

* Setting unit test coverage target to 80% with a 2% threshold. Builds will fail if coverage hits 78%.
* Adding pull request stats action to test.

Signed-off-by: Mark Cohen <markcoh@amazon.com>
Co-authored-by: Mark Cohen <macohen@users.noreply.github.com>
Signed-off-by: Mingshi Liu <mingshl@amazon.com>

 
