### PR TITLE
[Backport 2.x] adding Mingshi Liu as a maintainer so she can be release manager (#112)

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -8,3 +8,4 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | ------------ | ------------------------------------- | ----------- |
 | Mark Cohen   | [macohen](https://github.com/macohen) | Amazon      |
 | Michael Froh | [msfroh](https://github.com/msfroh)   | Amazon      |
+| Mingshi Liu  | [mingshl](https://github.com/mingshl) | Amazon      |


### PR DESCRIPTION
 Backport 'efaaeff' from [112](https://github.com/opensearch-project/dashboards-search-relevance/pull/112)