### PR TITLE
Instrument metrics on server-side

### DIFF
--- a/common/index.ts
+++ b/common/index.ts
@@ -9,4 +9,5 @@ export const PLUGIN_NAME = 'Search Relevance';
 export enum ServiceEndpoints {
   GetIndexes = '/api/relevancy/search/indexes',
   GetSearchResults = '/api/relevancy/search',
+  GetStats = '/api/relevancy/stats',
 }

--- a/config.ts
+++ b/config.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { schema, TypeOf } from '@osd/config-schema';
+
+const METRICS_REFRESH_TIME: number = 60000;
+
+export const configSchema = schema.object({
+  metrics: schema.object({
+    refreshTime: schema.number({ defaultValue: METRICS_REFRESH_TIME }),
+  }),
+});
+
+export type SearchRelevancePluginConfigType = TypeOf<typeof configSchema>;

--- a/config.ts
+++ b/config.ts
@@ -5,11 +5,12 @@
 
 import { schema, TypeOf } from '@osd/config-schema';
 
-const METRICS_REFRESH_TIME: number = 60000;
+import { METRIC_INTERVAL, DEFAULT_WINDOW_SIZE } from './server/metrics';
 
 export const configSchema = schema.object({
   metrics: schema.object({
-    refreshTime: schema.number({ defaultValue: METRICS_REFRESH_TIME }),
+    metricInterval: schema.number({ defaultValue: METRIC_INTERVAL.ONE_MINUTE }),
+    windowSize: schema.number({ min: 2, max: 10, defaultValue: DEFAULT_WINDOW_SIZE }),
   }),
 });
 

--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -4,7 +4,5 @@
   "opensearchDashboardsVersion": "3.0.0",
   "server": true,
   "ui": true,
-  "requiredPlugins": [
-    "navigation"
-  ]
+  "requiredPlugins": ["navigation"]
 }

--- a/server/index.ts
+++ b/server/index.ts
@@ -3,11 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { PluginInitializerContext } from '../../../src/core/server';
+import { PluginConfigDescriptor, PluginInitializerContext } from '../../../src/core/server';
 import { SearchRelevancePlugin } from './plugin';
+import { configSchema, SearchRelevancePluginConfigType } from '../config';
 
-// This exports static code and TypeScript types,
-// as well as, OpenSearch Dashboards Platform `plugin()` initializer.
+export const config: PluginConfigDescriptor<SearchRelevancePluginConfigType> = {
+  schema: configSchema,
+};
 
 export function plugin(initializerContext: PluginInitializerContext) {
   return new SearchRelevancePlugin(initializerContext);

--- a/server/metrics/index.ts
+++ b/server/metrics/index.ts
@@ -6,7 +6,7 @@
 export { MetricsServiceSetup, MetricsService } from './metrics_service';
 
 export enum METRIC_NAME {
-  RELEVANT_SEARCH = 'relevant_search',
+  RELEVANT_SEARCH = 'search_relevance',
 }
 
 export enum METRIC_ACTION {

--- a/server/metrics/index.ts
+++ b/server/metrics/index.ts
@@ -5,6 +5,13 @@
 
 export { MetricsServiceSetup, MetricsService } from './metrics_service';
 
+export enum METRIC_INTERVAL {
+  ONE_SECOND = 1000,
+  ONE_MINUTE = 60000,
+}
+
+export const DEFAULT_WINDOW_SIZE = 3;
+
 export enum METRIC_NAME {
   RELEVANT_SEARCH = 'search_relevance',
 }

--- a/server/metrics/index.ts
+++ b/server/metrics/index.ts
@@ -1,0 +1,16 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { MetricsServiceSetup, MetricsService } from './metrics_service';
+
+export enum METRIC_NAME {
+  RELEVANT_SEARCH = 'relevant_search',
+}
+
+export enum METRIC_ACTION {
+  COMPARE_SEARCH = 'compare_search',
+  SINGLE_SEARCH = 'single_search',
+  FETCH_INDEX = 'fetch_index',
+}

--- a/server/metrics/metrics_service.test.ts
+++ b/server/metrics/metrics_service.test.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { MetricsService, MetricsServiceSetup } from '.';
+
+describe('MetricsService', () => {
+  let metricsService: MetricsService;
+  let setup: MetricsServiceSetup;
+
+  beforeEach(() => {
+    metricsService = new MetricsService();
+    setup = metricsService.setup(1000);
+  });
+
+  afterEach(() => {
+    metricsService.stop();
+  });
+
+  describe('addMetric', () => {
+    it('should track metric data', () => {
+      setup.addMetric('component1', 'action1', 200, 100);
+      setup.addMetric('component1', 'action1', 200, 200);
+      setup.addMetric('component1', 'action2', 200, 300);
+
+      const stats = setup.getStats();
+      expect(stats.data).toEqual({
+        component1: {
+          action1: {
+            200: { sum: 300, count: 2 },
+          },
+          action2: {
+            200: { sum: 300, count: 1 },
+          },
+        },
+      });
+    });
+
+    it('should track overall metric data', () => {
+      setup.addMetric('component1', 'action1', 200, 100);
+      setup.addMetric('component1', 'action1', 200, 200);
+      setup.addMetric('component1', 'action2', 200, 300);
+
+      const stats = setup.getStats();
+      expect(stats.overall).toEqual({
+        response_time_avg: 200,
+        requests_per_second: 3,
+      });
+    });
+
+    it('should track component counts', () => {
+      setup.addMetric('component1', 'action1', 200, 100);
+      setup.addMetric('component2', 'action1', 200, 200);
+      setup.addMetric('component2', 'action2', 200, 300);
+
+      const stats = setup.getStats();
+      expect(stats.component_counts).toEqual({
+        component1: 1,
+        component2: 2,
+      });
+    });
+
+    it('should track status code counts', () => {
+      setup.addMetric('component1', 'action1', 200, 100);
+      setup.addMetric('component2', 'action1', 200, 200);
+      setup.addMetric('component2', 'action2', 400, 300);
+
+      const stats = setup.getStats();
+      expect(stats.status_code_counts).toEqual({
+        200: 2,
+        400: 1,
+      });
+    });
+  });
+
+  describe('resetMetrics', () => {
+    it('should reset all metrics data', () => {
+      setup.addMetric('component1', 'action1', 200, 100);
+      setup.addMetric('component2', 'action1', 200, 200);
+      metricsService.resetMetrics();
+      const stats = setup.getStats();
+      expect(stats).toEqual({
+        data: {},
+        overall: { response_time_avg: NaN, requests_per_second: 0 },
+        component_counts: {},
+        status_code_counts: {},
+      });
+    });
+  });
+});

--- a/server/metrics/metrics_service.ts
+++ b/server/metrics/metrics_service.ts
@@ -1,0 +1,121 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { Logger } from '../../../../src/core/server';
+
+interface MetricValue {
+  sum: number;
+  count: number;
+}
+
+interface MetricOutPut {
+  response_time_avg: number;
+  requests_per_second: number;
+}
+
+interface MetricsData {
+  [componentName: string]: {
+    [action: string]: {
+      [statusCode: number]: MetricValue;
+    };
+  };
+}
+
+export interface Stats {
+  readonly data: MetricsData;
+  readonly overall: MetricOutPut;
+  readonly component_counts: Record<string, number>;
+  readonly status_code_counts: Record<string, number>;
+}
+
+export interface MetricsServiceSetup {
+  addMetric: (componentName: string, action: string, statusCode: number, value: number) => void;
+  getStats: () => Stats;
+}
+
+export class MetricsService {
+  private data: MetricsData = {};
+  private overall: MetricValue = { sum: 0, count: 0 };
+  private componentCounts: Record<string, number> = {};
+  private statusCodeCounts: Record<string, number> = {};
+
+  private resetIntervalMs?: number;
+
+  constructor(private logger?: Logger) {}
+
+  setup(resetIntervalMs: number): MetricsServiceSetup {
+    this.resetIntervalMs = resetIntervalMs;
+
+    setInterval(() => {
+      this.resetMetrics();
+    }, resetIntervalMs);
+
+    const addMetric = (
+      componentName: string,
+      action: string,
+      statusCode: number,
+      value: number
+    ): void => {
+      if (!this.data[componentName]) {
+        this.data[componentName] = {};
+      }
+      if (!this.data[componentName][action]) {
+        this.data[componentName][action] = {};
+      }
+      if (!this.data[componentName][action][statusCode]) {
+        this.data[componentName][action][statusCode] = { sum: 0, count: 0 };
+      }
+
+      const { sum, count } = this.data[componentName][action][statusCode];
+      this.data[componentName][action][statusCode] = {
+        sum: sum + value,
+        count: count + 1,
+      };
+
+      this.overall.sum += value;
+      this.overall.count++;
+
+      if (!this.componentCounts[componentName]) {
+        this.componentCounts[componentName] = 0;
+      }
+      this.componentCounts[componentName]++;
+
+      if (!this.statusCodeCounts[statusCode]) {
+        this.statusCodeCounts[statusCode] = 0;
+      }
+      this.statusCodeCounts[statusCode]++;
+    };
+
+    const getStats = (): Stats => {
+      const requestsPerSecond = this.overall.count / (this.resetIntervalMs! / 1000);
+
+      return {
+        data: { ...this.data },
+        overall: {
+          response_time_avg: this.overall.sum / this.overall.count,
+          requests_per_second: requestsPerSecond,
+        },
+        component_counts: { ...this.componentCounts },
+        status_code_counts: { ...this.statusCodeCounts },
+      };
+    };
+
+    return { addMetric, getStats };
+  }
+
+  start() {}
+
+  stop() {
+    this.resetMetrics();
+  }
+
+  resetMetrics(): void {
+    this.data = {};
+    this.overall.sum = 0;
+    this.overall.count = 0;
+    this.componentCounts = {};
+    this.statusCodeCounts = {};
+  }
+}

--- a/server/metrics/metrics_service.ts
+++ b/server/metrics/metrics_service.ts
@@ -4,6 +4,7 @@
  */
 
 import { Logger } from '../../../../src/core/server';
+import { METRIC_INTERVAL, DEFAULT_WINDOW_SIZE } from '.';
 
 interface MetricValue {
   sum: number;
@@ -36,8 +37,8 @@ export interface MetricsServiceSetup {
 }
 
 export class MetricsService {
-  private interval: number = 60000;
-  private windowSize: number = 10;
+  private interval: number = METRIC_INTERVAL.ONE_MINUTE;
+  private windowSize: number = DEFAULT_WINDOW_SIZE;
 
   private data: Record<number, MetricsData> = {};
   private componentCounts: Record<number, Record<string, number>> = {};
@@ -46,8 +47,10 @@ export class MetricsService {
 
   constructor(private logger?: Logger) {}
 
-  setup(logger: Logger, interval: number, windowSize: number): MetricsServiceSetup {
-    this.logger = logger;
+  setup(
+    interval: number = METRIC_INTERVAL.ONE_MINUTE,
+    windowSize: number = DEFAULT_WINDOW_SIZE
+  ): MetricsServiceSetup {
     this.interval = interval;
     this.windowSize = windowSize;
 

--- a/server/plugin.ts
+++ b/server/plugin.ts
@@ -41,7 +41,8 @@ export class SearchRelevancePlugin
     const config: SearchRelevancePluginConfigType = await this.config$.pipe(first()).toPromise();
 
     const metricsService: MetricsServiceSetup = this.metricsService.setup(
-      config.metrics.refreshTime
+      config.metrics.metricInterval,
+      config.metrics.windowSize
     );
 
     const router = core.http.createRouter();

--- a/server/plugin.ts
+++ b/server/plugin.ts
@@ -3,43 +3,63 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { Observable } from 'rxjs';
+import { first } from 'rxjs/operators';
+
 import {
   PluginInitializerContext,
   CoreSetup,
   CoreStart,
+  IContextProvider,
   Logger,
   Plugin,
   ILegacyClusterClient,
+  RequestHandler,
 } from '../../../src/core/server';
 import { defineRoutes } from './routes';
 
+import { MetricsService, MetricsServiceSetup } from './metrics/metrics_service';
+import { SearchRelevancePluginConfigType } from '../config';
 import { SearchRelevancePluginSetup, SearchRelevancePluginStart } from './types';
 
 export class SearchRelevancePlugin
-  implements Plugin<SearchRelevancePluginSetup, SearchRelevancePluginStart> {
+  implements Plugin<SearchRelevancePluginSetup, SearchRelevancePluginStart>
+{
+  private readonly config$: Observable<SearchRelevancePluginConfigType>;
   private readonly logger: Logger;
-  constructor(initializerContext: PluginInitializerContext) {
-    this.logger = initializerContext.logger.get();
+  private metricsService: MetricsService;
+
+  constructor(private initializerContext: PluginInitializerContext) {
+    this.config$ = this.initializerContext.config.create<SearchRelevancePluginConfigType>();
+    this.logger = this.initializerContext.logger.get();
+    this.metricsService = new MetricsService(this.logger.get('metrics-service'));
   }
 
-  public setup(core: CoreSetup) {
+  public async setup(core: CoreSetup) {
     this.logger.debug('SearchRelevance: Setup');
-    const router = core.http.createRouter();
 
-    const opensearchSearchRelevanceClient: ILegacyClusterClient = core.opensearch.legacy.createClient(
-      'opensearch_search_relevance'
+    const config: SearchRelevancePluginConfigType = await this.config$.pipe(first()).toPromise();
+
+    const metricsService: MetricsServiceSetup = this.metricsService.setup(
+      config.metrics.refreshTime
     );
 
+    const router = core.http.createRouter();
+
+    const opensearchSearchRelevanceClient: ILegacyClusterClient =
+      core.opensearch.legacy.createClient('opensearch_search_relevance');
+
     // @ts-ignore
-    core.http.registerRouteHandlerContext('search_relevance_plugin', (context, request) => {
+    core.http.registerRouteHandlerContext('searchRelevance', (context, request) => {
       return {
         logger: this.logger,
         relevancyWorkbenchClient: opensearchSearchRelevanceClient,
+        metricsService: metricsService,
       };
     });
 
     // Register server side APIs
-    defineRoutes({ router });
+    defineRoutes(router);
 
     return {};
   }

--- a/server/routes/dsl_route.ts
+++ b/server/routes/dsl_route.ts
@@ -7,40 +7,118 @@ import { schema } from '@osd/config-schema';
 import { RequestParams } from '@opensearch-project/opensearch';
 
 import { IRouter } from '../../../../src/core/server';
+import { METRIC_NAME, METRIC_ACTION } from '../metrics';
 import { ServiceEndpoints } from '../../common';
 
-export function registerDslRoute({ router }: { router: IRouter }) {
+interface SearchResultsResponse {
+  result1?: Object;
+  result2?: Object;
+  errorMessage1?: Object;
+  errorMessage2?: Object;
+}
+
+const performance = require('perf_hooks').performance;
+
+export function registerDslRoute(router: IRouter) {
   router.post(
     {
       path: ServiceEndpoints.GetSearchResults,
       validate: { body: schema.any() },
     },
     async (context, request, response) => {
-      const { index, size, ...rest } = request.body;
-      const params: RequestParams.Search = {
-        index,
-        size,
-        body: rest,
-      };
-      try {
-        const resp = await context.core.opensearch.legacy.client.callAsCurrentUser(
-          'search',
-          params
-        );
-        return response.ok({
-          body: resp,
-        });
-      } catch (error) {
-        if (error.statusCode !== 404) console.error(error);
+      const { query1, query2 } = request.body;
+      const actionName =
+        query1 && query2 ? METRIC_ACTION.COMPARE_SEARCH : METRIC_ACTION.SINGLE_SEARCH;
+      let resBody: SearchResultsResponse = {};
 
-        // Template: Error: {{Error.type}} – {{Error.reason}}
-        const errorMessage = `Error: ${error.body?.error?.type} - ${error.body?.error?.reason}`;
+      if (query1) {
+        const { index, size, ...rest } = query1;
+        const params: RequestParams.Search = {
+          index,
+          size,
+          body: rest,
+        };
 
-        return response.custom({
-          statusCode: error.statusCode || 500,
-          body: errorMessage,
-        });
+        const start = performance.now();
+        try {
+          const resp = await context.core.opensearch.legacy.client.callAsCurrentUser(
+            'search',
+            params
+          );
+          const end = performance.now();
+          context.searchRelevance.metricsService.addMetric(
+            METRIC_NAME.RELEVANT_SEARCH,
+            actionName,
+            200,
+            end - start
+          );
+          resBody.result1 = resp;
+        } catch (error) {
+          const end = performance.now();
+          context.searchRelevance.metricsService.addMetric(
+            METRIC_NAME.RELEVANT_SEARCH,
+            actionName,
+            error.statusCode,
+            end - start
+          );
+
+          if (error.statusCode !== 404) console.error(error);
+
+          // Template: Error: {{Error.type}} – {{Error.reason}}
+          const errorMessage = `Error: ${error.body?.error?.type} - ${error.body?.error?.reason}`;
+
+          resBody.errorMessage1 = {
+            statusCode: error.statusCode || 500,
+            body: errorMessage,
+          };
+        }
       }
+
+      if (query2) {
+        const { index, size, ...rest } = query2;
+        const params: RequestParams.Search = {
+          index,
+          size,
+          body: rest,
+        };
+
+        const start = performance.now();
+        try {
+          const resp = await context.core.opensearch.legacy.client.callAsCurrentUser(
+            'search',
+            params
+          );
+          const end = performance.now();
+          context.searchRelevance.metricsService.addMetric(
+            METRIC_NAME.RELEVANT_SEARCH,
+            actionName,
+            200,
+            end - start
+          );
+          resBody.result2 = resp;
+        } catch (error) {
+          const end = performance.now();
+          if (error.statusCode !== 404) console.error(error);
+          context.searchRelevance.metricsService.addMetric(
+            METRIC_NAME.RELEVANT_SEARCH,
+            actionName,
+            error.statusCode,
+            end - start
+          );
+
+          // Template: Error: {{Error.type}} – {{Error.reason}}
+          const errorMessage = `Error: ${error.body?.error?.type} - ${error.body?.error?.reason}`;
+
+          resBody.errorMessage2 = {
+            statusCode: error.statusCode || 500,
+            body: errorMessage,
+          };
+        }
+      }
+
+      return response.ok({
+        body: resBody,
+      });
     }
   );
 
@@ -53,15 +131,30 @@ export function registerDslRoute({ router }: { router: IRouter }) {
       const params = {
         format: 'json',
       };
+      const start = performance.now();
       try {
         const resp = await context.core.opensearch.legacy.client.callAsCurrentUser(
           'cat.indices',
           params
         );
+        const end = performance.now();
+        context.searchRelevance.metricsService.addMetric(
+          METRIC_NAME.RELEVANT_SEARCH,
+          METRIC_ACTION.FETCH_INDEX,
+          200,
+          end - start
+        );
         return response.ok({
           body: resp,
         });
       } catch (error) {
+        const end = performance.now();
+        context.searchRelevance.metricsService.addMetric(
+          METRIC_NAME.RELEVANT_SEARCH,
+          METRIC_ACTION.FETCH_INDEX,
+          error.statusCode,
+          end - start
+        );
         if (error.statusCode !== 404) console.error(error);
         return response.custom({
           statusCode: error.statusCode || 500,

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -5,7 +5,9 @@
 
 import { ILegacyClusterClient, IRouter } from '../../../../src/core/server';
 import { registerDslRoute } from './dsl_route';
+import { registerMetricsRoute } from './metrics_route';
 
-export function defineRoutes({ router }: { router: IRouter }) {
-  registerDslRoute({ router });
+export function defineRoutes(router: IRouter) {
+  registerDslRoute(router);
+  registerMetricsRoute(router);
 }

--- a/server/routes/metrics_route.ts
+++ b/server/routes/metrics_route.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { IRouter } from '../../../../src/core/server';
+import { ServiceEndpoints } from '../../common';
+
+export function registerMetricsRoute(router: IRouter) {
+  router.get(
+    {
+      path: ServiceEndpoints.GetStats,
+      validate: false,
+    },
+    async (context, _, response) => {
+      try {
+        const metrics = context.searchRelevance.metricsService.getStats();
+        return response.ok({
+          body: JSON.stringify(metrics, null, 2),
+        });
+      } catch (error) {
+        console.error(error);
+        return response.custom({
+          statusCode: error.statusCode || 500,
+          body: error.message,
+        });
+      }
+    }
+  );
+}

--- a/server/types.ts
+++ b/server/types.ts
@@ -3,6 +3,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { MetricsServiceSetup } from './metrics/metrics_service';
+
+export interface SearchRelevancePluginRequestContext {
+  metricsService: MetricsServiceSetup;
+}
+
+declare module '../../../src/core/server' {
+  interface RequestHandlerContext {
+    searchRelevance: SearchRelevancePluginRequestContext;
+  }
+}
+
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface SearchRelevancePluginSetup {}
 // eslint-disable-next-line @typescript-eslint/no-empty-interface


### PR DESCRIPTION
### Description
Instrument metrics on server-side

Example output

```
% curl -XGET http://localhost:5603/hgn/api/relevancy/stats
{
  "data": {
    "relevant_search": {
      "fetch_index": {
        "200": {
          "sum": 12.02572301030159,
          "count": 1
        }
      },
      "single_search": {
        "200": {
          "sum": 4.898337006568909,
          "count": 1
        }
      }
    }
  },
  "overall": {
    "response_time_avg": 8.46203000843525,
    "requests_per_second": 0.03333333333333333
  },
  "component_counts": {
    "relevant_search": 2
  },
  "status_code_counts": {
    "200": 2
  }
}%   
```

### Issues Resolved
https://github.com/opensearch-project/dashboards-search-relevance/issues/160

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
