### PR TITLE
Bump next version to 2.6.1

### DIFF
--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -5,7 +5,7 @@ on: [pull_request, push]
 env:
   PLUGIN_NAME: dashboards-search-relevance
   OPENSEARCH_VERSION: '2.x'
-  OPENSEARCH_PLUGIN_VERSION: 2.6.0.0
+  OPENSEARCH_PLUGIN_VERSION: 2.6.1.0
 
 jobs:
   build:

--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -1,7 +1,7 @@
 {
   "id": "searchRelevanceDashboards",
-  "version": "2.6.0.0",
-  "opensearchDashboardsVersion": "2.6.0",
+  "version": "2.6.1.0",
+  "opensearchDashboardsVersion": "2.6.1",
   "server": true,
   "ui": true,
   "requiredPlugins": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "searchRelevanceDashboards",
-  "version": "2.6.0.0",
+  "version": "2.6.1.0",
   "main": "./public/index.ts",
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
### Description
Now that 2.6.0 is released, our 2.6 branch should be tracking toward a future 2.6.1 release (if needed).

### Issues Resolved
https://github.com/opensearch-project/dashboards-search-relevance/issues/157

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
