### PR TITLE
backporting maintainer changes added noCharger and sejli

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
-# This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
-*   @opensearch-project/search-relevance-dashboards-team
+# This should match the list of maintainers in https://github.com/opensearch-project/dashboards-search-relevance/blob/main/MAINTAINERS.md
+*   @macohen @mingshl @msfroh @noCharger @sejli
+

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -9,3 +9,5 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Mark Cohen   | [macohen](https://github.com/macohen) | Amazon      |
 | Michael Froh | [msfroh](https://github.com/msfroh)   | Amazon      |
 | Mingshi Liu  | [mingshl](https://github.com/mingshl) | Amazon      |
+| Louis Chu    | [noCharger](https://github.com/noCharger) | Amazon  |
+| Sean Li      | [sejli](https://github.com/sejli)     | Amazon |


### PR DESCRIPTION
### Description
adds noCharger and sejli as maintainers

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
