### PR TITLE
[Bug] Bugfix on right-hand-side single search

### DIFF
--- a/public/components/query_compare/search_result/index.tsx
+++ b/public/components/query_compare/search_result/index.tsx
@@ -104,10 +104,15 @@ export const SearchResult = ({ http }: SearchResultProps) => {
           body: JSON.stringify(requestBody),
         })
         .then((res) => {
-          setQueryResult1(res.result1);
-          updateComparedResult1(res.result1);
-          setQueryResult2(res.result2);
-          updateComparedResult2(res.result2);
+          if (res.result1) {
+            setQueryResult1(res.result1);
+            updateComparedResult1(res.result1);
+          }
+
+          if (res.result2) {
+            setQueryResult2(res.result2);
+            updateComparedResult2(res.result2);
+          }
 
           if (res.errorMessage1) {
             setQueryError1({


### PR DESCRIPTION
### Description
When doing single search on the right-hand side, the left-hand search should not be updated.

<img width="1785" alt="Screen Shot 2023-04-19 at 8 31 24 AM" src="https://user-images.githubusercontent.com/44716267/233127801-c7bf5e74-e00e-44c9-9547-71b8f882e1c7.png">

After fix:

<img width="1787" alt="Screen Shot 2023-04-19 at 8 29 44 AM" src="https://user-images.githubusercontent.com/44716267/233127851-46b4d7bc-4b19-43cb-8200-c66096df4238.png">


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
