### PR TITLE
bumping the version from 2.7 to 2.8

### DIFF
--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -1,7 +1,7 @@
 {
   "id": "searchRelevanceDashboards",
-  "version": "2.7.0.0",
-  "opensearchDashboardsVersion": "2.7.0",
+  "version": "2.8.0.0",
+  "opensearchDashboardsVersion": "2.8.0",
   "server": true,
   "ui": true,
   "requiredPlugins": ["navigation"]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "searchRelevanceDashboards",
-  "version": "2.7.0.0",
+  "version": "2.8.0.0",
   "main": "./public/index.ts",
   "license": "Apache-2.0",
   "scripts": {


### PR DESCRIPTION
### Description
version bump from 2.7 to 2.8

### Issues Resolved
partially resolves [Release version 2.7.0#170](https://github.com/opensearch-project/dashboards-search-relevance/issues/170)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
