### PR TITLE
[Manual Backport 2.x] Backport 143 and 177 to 2.x

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-# This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
-*   @opensearch-project/search-relevance-dashboards-team
+# This should match the list of maintainers in https://github.com/opensearch-project/dashboards-search-relevance/blob/main/MAINTAINERS.md
+*   @macohen @mingshl @msfroh @noCharger @sejli

--- a/.github/workflows/remote-integ-tests-workflow.yml
+++ b/.github/workflows/remote-integ-tests-workflow.yml
@@ -9,11 +9,6 @@ on:
   pull_request:
     branches:
       - "*"
-env:
-  OPENSEARCH_DASHBOARDS_VERSION: 'main'
-  OPENSEARCH_VERSION: '3.0.0-SNAPSHOT'
-  OPENSEARCH_DASHBOARDS_FTREPO_VERSION: 'main'
-  ANOMALY_DETECTION_PLUGIN_VERSION: 'main'
 jobs:
   test-without-security:
     name: Run integ tests without security
@@ -34,6 +29,28 @@ jobs:
           distribution: 'corretto'
           java-version: '11'
 
+      - uses: actions/checkout@v2
+      - name: Fetch Version Information
+        id: fetch version
+        run: |
+          if [[ "${{ github.event_name }}" == "push" ]]; then
+            echo "Base branch name is $(basename "${{ github.ref }}")"
+            BRANCH_NAME=$(basename "${{ github.ref }}")
+          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "Base branch name is "${{ github.event.pull_request.base.ref }}""
+            BRANCH_NAME="${{ github.event.pull_request.base.ref }}"
+          fi
+          CURRENT_VERSION=$(node -p "require('./package.json').version")
+          MAJOR_VERSION=$(echo $CURRENT_VERSION | cut -d. -f1)
+          MINOR_VERSION=$(echo $CURRENT_VERSION | cut -d. -f2)
+          PATCH_VERSION=$(echo $CURRENT_VERSION | cut -d. -f3)
+          OPENSEARCH_VERSION="$MAJOR_VERSION.$MINOR_VERSION.$PATCH_VERSION"
+          echo "OPENSEARCH_VERSION: $OPENSEARCH_VERSION"
+          echo "OPENSEARCH_VERSION=$OPENSEARCH_VERSION" >> $GITHUB_ENV
+          echo "OPENSEARCH_DASHBOARDS_VERSION=$BRANCH_NAME" >> $GITHUB_ENV
+          echo "OPENSEARCH_DASHBOARDS_FTREPO_VERSION=$BRANCH_NAME" >> $GITHUB_ENV
+          echo "SEARCH_PROCESSOR_PLUGIN_VERSION=$BRANCH_NAME" >> $GITHUB_ENV
+
       - name: Enable longer filenames
         if: ${{ matrix.os == 'windows-latest' }}
         run: git config --system core.longpaths true
@@ -41,16 +58,16 @@ jobs:
       # It doesn't matter what plugin we use, but by launching OpenSearch
       # from a plugin repo, we don't need to checkout and build 
       # OpenSearch itself.
-      - name: Checkout Anomaly-Detection
+      - name: Checkout Search-Processor
         uses: actions/checkout@v2
         with:
-          path: anomaly-detection
-          repository: opensearch-project/anomaly-detection
-          ref: ${{ env.ANOMALY_DETECTION_PLUGIN_VERSION }}
+          path: search-processor
+          repository: opensearch-project/search-processor
+          ref: ${{ env.SEARCH_PROCESSOR_PLUGIN_VERSION }}
 
       - name: Run OpenSearch with plugin
         run: |
-          cd anomaly-detection
+          cd search-processor
           ./gradlew run -Dopensearch.version=${{ env.OPENSEARCH_VERSION }} &
           t=0
           while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:9200)" != "200" ]]; do 
@@ -105,7 +122,7 @@ jobs:
 
       # Windows and Mac OS take a while to start, so we need a long sleep
       - name: Sleep until OSD server starts
-        run: sleep 900 
+        run: sleep 900
         shell: bash
 
       - name: Checkout opensearch-dashboards-functional-test

--- a/.github/workflows/remote-integ-tests-workflow.yml
+++ b/.github/workflows/remote-integ-tests-workflow.yml
@@ -1,0 +1,141 @@
+# Running search relevance integ tests stored in https://github.com/opensearch-project/opensearch-dashboards-functional-test
+# In the future we should pull dependencies from bundled build snapshots. Because that is not available
+# yet we build the cluster from source (besides core Opensearch, which is a pulled min artifact).
+name: Remote integ tests workflow
+on:
+  push:
+    branches:
+      - "*"
+  pull_request:
+    branches:
+      - "*"
+env:
+  OPENSEARCH_DASHBOARDS_VERSION: 'main'
+  OPENSEARCH_VERSION: '3.0.0-SNAPSHOT'
+  OPENSEARCH_DASHBOARDS_FTREPO_VERSION: 'main'
+  ANOMALY_DETECTION_PLUGIN_VERSION: 'main'
+jobs:
+  test-without-security:
+    name: Run integ tests without security
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        java: [11]
+        include:
+          - os: windows-latest
+            cypress_cache_folder: ~/AppData/Local/Cypress/Cache
+          - os: ubuntu-latest
+            cypress_cache_folder: ~/.cache/Cypress
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Set up Java 11
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'corretto'
+          java-version: '11'
+
+      - name: Enable longer filenames
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: git config --system core.longpaths true
+
+      # It doesn't matter what plugin we use, but by launching OpenSearch
+      # from a plugin repo, we don't need to checkout and build 
+      # OpenSearch itself.
+      - name: Checkout Anomaly-Detection
+        uses: actions/checkout@v2
+        with:
+          path: anomaly-detection
+          repository: opensearch-project/anomaly-detection
+          ref: ${{ env.ANOMALY_DETECTION_PLUGIN_VERSION }}
+
+      - name: Run OpenSearch with plugin
+        run: |
+          cd anomaly-detection
+          ./gradlew run -Dopensearch.version=${{ env.OPENSEARCH_VERSION }} &
+          t=0
+          while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' localhost:9200)" != "200" ]]; do 
+            sleep 5
+            let t=$t+5
+            if [[ $t -gt 300 ]]; then 
+              exit 1 
+            fi
+          done
+        shell: bash
+
+      - name: Checkout OpenSearch Dashboards
+        uses: actions/checkout@v2
+        with:
+          repository: opensearch-project/OpenSearch-Dashboards
+          ref: ${{ env.OPENSEARCH_DASHBOARDS_VERSION }}
+          path: OpenSearch-Dashboards
+
+      - name: Checkout Search Relevance OpenSearch Dashboards plugin
+        uses: actions/checkout@v2
+        with:
+          path: OpenSearch-Dashboards/plugins/dashboards-search-relevance
+
+      - name: Get node and yarn versions
+        id: versions_step
+        run: |
+          echo "::set-output name=node_version::$(node -p "(require('./OpenSearch-Dashboards/package.json').engines.node).match(/[.0-9]+/)[0]")"
+          echo "::set-output name=yarn_version::$(node -p "(require('./OpenSearch-Dashboards/package.json').engines.yarn).match(/[.0-9]+/)[0]")"
+
+      - name: Setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ steps.versions_step.outputs.node_version }}
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install correct yarn version for OpenSearch Dashboards
+        run: |
+          npm uninstall -g yarn
+          echo "Installing yarn ${{ steps.versions_step.outputs.yarn_version }}"
+          npm i -g yarn@${{ steps.versions_step.outputs.yarn_version }}
+
+      - name: Bootstrap the plugin
+        run: |
+          cd OpenSearch-Dashboards/plugins/dashboards-search-relevance
+          yarn osd bootstrap
+
+      - name: Run OpenSearch Dashboards server
+        run: |
+          cd OpenSearch-Dashboards
+          yarn start --no-base-path --no-watch &
+        shell: bash
+
+      # Windows and Mac OS take a while to start, so we need a long sleep
+      - name: Sleep until OSD server starts
+        run: sleep 900 
+        shell: bash
+
+      - name: Checkout opensearch-dashboards-functional-test
+        uses: actions/checkout@v2
+        with:
+          path: opensearch-dashboards-functional-test
+          repository: opensearch-project/opensearch-dashboards-functional-test
+          ref: ${{ env.OPENSEARCH_DASHBOARDS_FTREPO_VERSION }}
+
+      - name: Get Cypress version
+        id: cypress_version
+        run: |
+          echo "::set-output name=cypress_version::$(cat ./opensearch-dashboards-functional-test/package.json | jq '.devDependencies.cypress' | tr -d '"')"
+
+      - name: Cache Cypress
+        id: cache-cypress
+        uses: actions/cache@v1
+        with:
+          path: ${{ matrix.cypress_cache_folder }}
+          key: cypress-cache-v2-${{ runner.os }}-${{ hashFiles('**/package.json') }}
+        env:
+          CYPRESS_INSTALL_BINARY: ${{ steps.cypress_version.outputs.cypress_version }}
+      - run: npx cypress cache list
+      - run: npx cypress cache path
+
+      - name: Run search-relevance cypress tests
+        uses: cypress-io/github-action@v2
+        with:
+          working-directory: opensearch-dashboards-functional-test
+          command: yarn run cypress run --env SECURITY_ENABLED=false --browser chrome --spec cypress/integration/plugins/search-relevance-dashboards/*.js
+        env:
+          CYPRESS_CACHE_FOLDER: ${{ matrix.cypress_cache_folder }}
+

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -2,6 +2,9 @@ name: Test and Build Dashboards Search Relevance Plugin
 
 on: [pull_request, push]
 
+env:
+  PLUGIN_NAME: dashboards-search-relevance
+  
 jobs:
   build:
     strategy:

--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -4,8 +4,11 @@ on: [pull_request, push]
 
 env:
   PLUGIN_NAME: dashboards-search-relevance
+<<<<<<< HEAD
   OPENSEARCH_VERSION: '2.x'
   OPENSEARCH_PLUGIN_VERSION: 2.5.0.0
+=======
+>>>>>>> dc5b53c (Make Workflows Fetch Version Automatically (#177))
 
 jobs:
   build:
@@ -15,6 +18,21 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - uses: actions/checkout@v2
+      - name: Fetch Version Information
+        shell: bash
+        run: |
+          OPENSEARCH_PLUGIN_VERSION=$(node -p "require('./package.json').version")
+          if [[ "${{ github.event_name }}" == "push" ]]; then
+            echo "Base branch name is $(basename "${{ github.ref }}")"
+            BRANCH_NAME=$(basename "${{ github.ref }}")
+          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "Base branch name is "${{ github.event.pull_request.base.ref }}""
+            BRANCH_NAME="${{ github.event.pull_request.base.ref }}"
+          fi
+          echo "OPENSEARCH_PLUGIN_VERSION=$OPENSEARCH_PLUGIN_VERSION" >> $GITHUB_ENV
+          echo "OPENSEARCH_VERSION=$BRANCH_NAME" >> $GITHUB_ENV
+
       - name: Enable core.longpaths on Windows
         if: ${{ matrix.os == 'windows-latest' }}
         run: git config --global core.longpaths true


### PR DESCRIPTION
### Description
This is the first commit:

```
Run the Cypress integration tests as a GitHub action on every build, to better catch regressions.

Signed-off-by: Michael Froh [froh@amazon.com](mailto:froh@amazon.com)
(cherry picked from commit 2ef265d54536089c9749bea42e499fafc5a03804)
```

This is the second commit:

```
Make Workflows Fetch Version Automatically

Signed-off-by: Mingshi Liu <mingshl@amazon.com>
Signed-off-by: Mingshi Liu <113382730+mingshl@users.noreply.github.com>
(cherry picked from commit dc5b53c37229675a1ab45b184897bacbb9e74ed1)
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
