### PR TITLE
Resolve tough-cookie to 4.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "resolutions": {
     "ansi-regex": "^5.0.1",
     "glob-parent": "^6.0.1",
-    "qs": "~6.5.3"
+    "qs": "~6.5.3",
+    "tough-cookie": "^4.1.3"
   }
 }


### PR DESCRIPTION
Based on recommendation by @AMoo-Miki on
https://github.com/opensearch-project/opensearch-build/issues/3856

### Description
Regenerating our yarn.lock file, as done by the automation to bump version numbers with each release, downgrades our tough-cookie dependency from 4.1.3 to 2.5, because the version of Cypress that we use depends on 2.5.

To avoid the downgrade, we should update our package.json to reflect the version that we intend to use.

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
