### PR TITLE
Fix (styles): Make ace editor theme consistent for Search Relevance plugin

### DIFF
--- a/public/components/query_compare/search_result/search_components/__tests__/__snapshots__/search_configs.test.tsx.snap
+++ b/public/components/query_compare/search_result/search_components/__tests__/__snapshots__/search_configs.test.tsx.snap
@@ -333,7 +333,7 @@ exports[`Flyout component Renders flyout component 1`] = `
                           }
                           showPrintMargin={false}
                           tabSize={2}
-                          theme="sql_console"
+                          theme="textmate"
                           value="{}"
                           width="100%"
                         >
@@ -434,7 +434,7 @@ exports[`Flyout component Renders flyout component 1`] = `
                               showPrintMargin={false}
                               style={Object {}}
                               tabSize={2}
-                              theme="sql_console"
+                              theme="textmate"
                               value="{}"
                               width="100%"
                               wrapEnabled={false}
@@ -775,7 +775,7 @@ exports[`Flyout component Renders flyout component 1`] = `
                           }
                           showPrintMargin={false}
                           tabSize={2}
-                          theme="sql_console"
+                          theme="textmate"
                           value="{}"
                           width="100%"
                         >
@@ -876,7 +876,7 @@ exports[`Flyout component Renders flyout component 1`] = `
                               showPrintMargin={false}
                               style={Object {}}
                               tabSize={2}
-                              theme="sql_console"
+                              theme="textmate"
                               value="{}"
                               width="100%"
                               wrapEnabled={false}

--- a/public/components/query_compare/search_result/search_components/search_configs/search_config.tsx
+++ b/public/components/query_compare/search_result/search_components/search_configs/search_config.tsx
@@ -118,7 +118,7 @@ export const SearchConfig: FunctionComponent<SearchConfigProps> = ({
       >
         <EuiCodeEditor
           mode="json"
-          theme="sql_console"
+          theme="textmate"
           width="100%"
           height="10rem"
           value={queryString}


### PR DESCRIPTION
### Description
_Fixes inconsistent editor theming in dark mode for Search Relevance plugin by using "textmate" theme rather than "sql_console". Builds off solution discussed in https://github.com/opensearch-project/OpenSearch-Dashboards/pull/4609._

### Issues Resolved
_Closes #307_ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).


# Screenshots

### Before

Editor is still in light mode while site is in dark mode:

![Editor is inconsistent with dark theme.](https://github.com/opensearch-project/dashboards-search-relevance/assets/37952714/81aa44bc-adbe-4bc7-95f6-21505af49c01 "Editor is inconsistent with dark theme")


### After

Editor and site are now both in dark mode:

![Editor is consistent with dark theme.](https://github.com/opensearch-project/dashboards-search-relevance/assets/37952714/493ab0ee-21c4-41c1-8ddd-17ad4c7763be "Editor is consistent with dark theme")