### PR TITLE
Fix (styles): Update border color of Search Relevance to be compliant with Dark Mode

### DIFF
--- a/public/components/common/__test__/__snapshots__/header.test.tsx.snap
+++ b/public/components/common/__test__/__snapshots__/header.test.tsx.snap
@@ -4,22 +4,13 @@ exports[`Header component Renders header component 1`] = `
 <Header>
   <EuiPanel
     borderRadius="none"
+    color="transparent"
     grow={false}
     hasBorder={false}
     hasShadow={false}
-    style={
-      Object {
-        "borderBottom": "1px solid #D3DAE6",
-      }
-    }
   >
     <div
-      className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusNone euiPanel--plain euiPanel--noShadow euiPanel--noBorder euiPanel--flexGrowZero"
-      style={
-        Object {
-          "borderBottom": "1px solid #D3DAE6",
-        }
-      }
+      className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusNone euiPanel--transparent euiPanel--noShadow euiPanel--noBorder euiPanel--flexGrowZero"
     >
       <EuiTitle>
         <h1

--- a/public/components/common/header.tsx
+++ b/public/components/common/header.tsx
@@ -15,9 +15,9 @@ export const Header = ({ children }: HeaderProps) => {
     <EuiPanel
       hasBorder={false}
       hasShadow={false}
+      color="transparent"
       grow={false}
       borderRadius="none"
-      style={{ borderBottom: '1px solid #D3DAE6' }}
     >
       <EuiTitle>
         <h1>Compare search results</h1>

--- a/public/components/query_compare/__test__/__snapshots__/create_index.test.tsx.snap
+++ b/public/components/query_compare/__test__/__snapshots__/create_index.test.tsx.snap
@@ -5,22 +5,13 @@ exports[`Create index component Renders create index component 1`] = `
   <Header>
     <EuiPanel
       borderRadius="none"
+      color="transparent"
       grow={false}
       hasBorder={false}
       hasShadow={false}
-      style={
-        Object {
-          "borderBottom": "1px solid #D3DAE6",
-        }
-      }
     >
       <div
-        className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusNone euiPanel--plain euiPanel--noShadow euiPanel--noBorder euiPanel--flexGrowZero"
-        style={
-          Object {
-            "borderBottom": "1px solid #D3DAE6",
-          }
-        }
+        className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusNone euiPanel--transparent euiPanel--noShadow euiPanel--noBorder euiPanel--flexGrowZero"
       >
         <EuiTitle>
           <h1

--- a/public/components/query_compare/search_result/result_components/result_components.scss
+++ b/public/components/query_compare/search_result/result_components/result_components.scss
@@ -7,7 +7,7 @@
   min-height: 500px;
 
   &:nth-child(1) {
-    border-right: 1px solid #D3DAE6;
+    border-right: 1px solid $euiBorderColor;
   }
 }
   

--- a/public/components/query_compare/search_result/search_components/__tests__/__snapshots__/search_config.test.tsx.snap
+++ b/public/components/query_compare/search_result/search_components/__tests__/__snapshots__/search_config.test.tsx.snap
@@ -314,7 +314,7 @@ exports[`Flyout component Renders flyout component 1`] = `
             }
             showPrintMargin={false}
             tabSize={2}
-            theme="sql_console"
+            theme="textmate"
             value="{}"
             width="100%"
           >
@@ -416,7 +416,7 @@ exports[`Flyout component Renders flyout component 1`] = `
                 showPrintMargin={false}
                 style={Object {}}
                 tabSize={2}
-                theme="sql_console"
+                theme="textmate"
                 value="{}"
                 width="100%"
                 wrapEnabled={false}

--- a/public/components/query_compare/search_result/search_components/__tests__/__snapshots__/search_configs.test.tsx.snap
+++ b/public/components/query_compare/search_result/search_components/__tests__/__snapshots__/search_configs.test.tsx.snap
@@ -32,13 +32,13 @@ exports[`Flyout component Renders flyout component 1`] = `
   >
     <EuiPanel
       borderRadius="none"
-      className="right-border left-border"
+      className="left-right-borders"
       color="transparent"
       grow={false}
       hasShadow={false}
     >
       <div
-        className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusNone euiPanel--transparent euiPanel--noShadow euiPanel--flexGrowZero right-border left-border"
+        className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusNone euiPanel--transparent euiPanel--noShadow euiPanel--flexGrowZero left-right-borders"
       >
         <EuiFlexGroup>
           <div

--- a/public/components/query_compare/search_result/search_components/__tests__/__snapshots__/search_configs.test.tsx.snap
+++ b/public/components/query_compare/search_result/search_components/__tests__/__snapshots__/search_configs.test.tsx.snap
@@ -32,23 +32,13 @@ exports[`Flyout component Renders flyout component 1`] = `
   >
     <EuiPanel
       borderRadius="none"
+      className="right-border left-border"
       color="transparent"
       grow={false}
-      hasBorder={false}
       hasShadow={false}
-      style={
-        Object {
-          "borderBottom": "1px solid #D3DAE6",
-        }
-      }
     >
       <div
-        className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusNone euiPanel--transparent euiPanel--noShadow euiPanel--noBorder euiPanel--flexGrowZero"
-        style={
-          Object {
-            "borderBottom": "1px solid #D3DAE6",
-          }
-        }
+        className="euiPanel euiPanel--paddingMedium euiPanel--borderRadiusNone euiPanel--transparent euiPanel--noShadow euiPanel--flexGrowZero right-border left-border"
       >
         <EuiFlexGroup>
           <div

--- a/public/components/query_compare/search_result/search_components/search_configs/search_configs.scss
+++ b/public/components/query_compare/search_result/search_components/search_configs/search_configs.scss
@@ -9,10 +9,7 @@
   border-right: 1px solid $euiBorderColor;
 }
 
-.right-border {
-  border-right: 0;
-}
-
-.left-border {
+.left-right-borders {
   border-left: 0;
+  border-right: 0;
 }

--- a/public/components/query_compare/search_result/search_components/search_configs/search_configs.scss
+++ b/public/components/query_compare/search_result/search_components/search_configs/search_configs.scss
@@ -6,6 +6,13 @@
 .search-relevance-config:nth-child(1) {
   margin: 0;
   padding: 12px;
-  border-right: 1px solid #D3DAE6;
+  border-right: 1px solid $euiBorderColor;
 }
-  
+
+.right-border {
+  border-right: 0;
+}
+
+.left-border {
+  border-left: 0;
+}

--- a/public/components/query_compare/search_result/search_components/search_configs/search_configs.tsx
+++ b/public/components/query_compare/search_result/search_components/search_configs/search_configs.tsx
@@ -44,11 +44,10 @@ export const SearchConfigsPanel = ({
   return (
     <EuiPanel
       hasShadow={false}
-      hasBorder={false}
       color="transparent"
       grow={false}
       borderRadius="none"
-      style={{ borderBottom: '1px solid #D3DAE6' }}
+      className="right-border left-border"
     >
       <EuiFlexGroup>
         <EuiFlexItem className="search-relevance-config">

--- a/public/components/query_compare/search_result/search_components/search_configs/search_configs.tsx
+++ b/public/components/query_compare/search_result/search_components/search_configs/search_configs.tsx
@@ -47,7 +47,7 @@ export const SearchConfigsPanel = ({
       color="transparent"
       grow={false}
       borderRadius="none"
-      className="right-border left-border"
+      className="left-right-borders"
     >
       <EuiFlexGroup>
         <EuiFlexItem className="search-relevance-config">


### PR DESCRIPTION
### Description
_Fixes hard-coded horizontal and vertical rules that previously made borders bright white in dark mode. Panels had `hasBorder` property set to `false` so that was adjusted, and `$ouiBorderColor` was used to color the borders instead._

### Issues Resolved
_Closes #306_ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

# Screenshots

### Before

Bright white borders while site is in dark mode:

![Bright white borders while site is in dark mode.](https://github.com/opensearch-project/dashboards-search-relevance/assets/37952714/283301ab-140e-4f03-952e-3bc2a4999a48)


### After

Subtle borders with `$ouiBorderColor` in dark mode:

![Subtle borders with $ouiBorderColor in dark mode.](https://github.com/opensearch-project/dashboards-search-relevance/assets/37952714/da23c1fe-83b5-403e-a9ce-a2a7f41afd30)