### PR TITLE
Utilize EuiEmptyPrompt to represent empty state

### DIFF
--- a/public/components/query_compare/search_result/result_components/result_components.tsx
+++ b/public/components/query_compare/search_result/result_components/result_components.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useEffect, useState } from 'react';
-import { EuiSplitPanel, EuiTitle, EuiFlexGroup, EuiPanel } from '@elastic/eui';
+import { EuiSplitPanel, EuiEmptyPrompt, EuiButton, EuiPanel } from '@elastic/eui';
 
 import { QueryError, SearchResults } from '../../../../types/index';
 import { ResultPanel } from './result_panel';
@@ -26,11 +26,20 @@ const InitialState = () => {
       grow={true}
       style={{ display: 'flex', justifyContent: 'center', alignItems: 'center' }}
     >
-      <EuiFlexGroup justifyContent="center">
-        <EuiTitle>
-          <h2>Add queries to compare search results.</h2>
-        </EuiTitle>
-      </EuiFlexGroup>
+      <EuiEmptyPrompt
+        iconType="database"
+        title={<h2>No data available</h2>}
+        body={
+          <>
+            <p>Add queries to compare search results.</p>
+          </>
+        }
+        actions={
+          <EuiButton color="primary" fill href="home#/tutorial_directory">
+            Connect to a data source
+          </EuiButton>
+        }
+      />
     </EuiPanel>
   );
 };


### PR DESCRIPTION
### Description
_Implements `EuiEmptyPrompt` component to represent empty state in the result panel of Search Relevance. "Connect to data source" button links to the `tutorial_directory` endpoint so users can add sample data if they wish._

### Issues Resolved
_Closes #308_ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

# Screenshots

### Before

Dark Mode

![Screenshot 2023-10-07 115045](https://github.com/opensearch-project/dashboards-search-relevance/assets/37952714/f23be7a1-ebdd-4de9-aa0f-36385442a4cc)

Light Mode

![Screenshot 2023-10-07 115023](https://github.com/opensearch-project/dashboards-search-relevance/assets/37952714/668c3617-beba-4b04-88b6-9d7addfd1a71)

### After

Dark Mode

![Screenshot 2023-10-07 114624](https://github.com/opensearch-project/dashboards-search-relevance/assets/37952714/f6da3405-3f4b-4d70-b051-2cb0ac94817b)

Light Mode

![Screenshot 2023-10-07 114807](https://github.com/opensearch-project/dashboards-search-relevance/assets/37952714/146fb03f-8eff-4528-9138-12d32010e8ec)


### Navigation to "Add Sample Data" page:

Dark Mode

![euiEmptyPrompt-darkMode](https://github.com/opensearch-project/dashboards-search-relevance/assets/37952714/c49af993-413e-4e44-adbe-ec4f4a9af701)

Light Mode

![euiEmptyPrompt-lightMode](https://github.com/opensearch-project/dashboards-search-relevance/assets/37952714/b65c28a5-7254-47fd-81f3-c6e35cbb844e)