### PR TITLE
[Backport 2.11] Fix (styles): Make ace editor theme consistent for Search Relevance plugin

### DIFF
--- a/public/components/query_compare/search_result/search_components/__tests__/__snapshots__/search_configs.test.tsx.snap
+++ b/public/components/query_compare/search_result/search_components/__tests__/__snapshots__/search_configs.test.tsx.snap
@@ -372,7 +372,7 @@ exports[`Flyout component Renders flyout component 1`] = `
                           }
                           showPrintMargin={false}
                           tabSize={2}
-                          theme="sql_console"
+                          theme="textmate"
                           value="{}"
                           width="100%"
                         >
@@ -474,7 +474,7 @@ exports[`Flyout component Renders flyout component 1`] = `
                               showPrintMargin={false}
                               style={Object {}}
                               tabSize={2}
-                              theme="sql_console"
+                              theme="textmate"
                               value="{}"
                               width="100%"
                               wrapEnabled={false}
@@ -836,7 +836,7 @@ exports[`Flyout component Renders flyout component 1`] = `
                           }
                           showPrintMargin={false}
                           tabSize={2}
-                          theme="sql_console"
+                          theme="textmate"
                           value="{}"
                           width="100%"
                         >
@@ -938,7 +938,7 @@ exports[`Flyout component Renders flyout component 1`] = `
                               showPrintMargin={false}
                               style={Object {}}
                               tabSize={2}
-                              theme="sql_console"
+                              theme="textmate"
                               value="{}"
                               width="100%"
                               wrapEnabled={false}

--- a/public/components/query_compare/search_result/search_components/search_configs/search_config.tsx
+++ b/public/components/query_compare/search_result/search_components/search_configs/search_config.tsx
@@ -128,7 +128,7 @@ export const SearchConfig: FunctionComponent<SearchConfigProps> = ({
       >
         <EuiCodeEditor
           mode="json"
-          theme="sql_console"
+          theme="textmate"
           width="100%"
           height="10rem"
           value={queryString}


### PR DESCRIPTION
Backport of (#300)

* Update code editor theme to textmate

Signed-off-by: Nicholas Ung <37952714+nung22@users.noreply.github.com>
Signed-off-by: Nicholas Ung <nicholasung22@gmail.com>

* Update theme in testing file

Signed-off-by: Nicholas Ung <nicholasung22@gmail.com>

---------

Signed-off-by: Nicholas Ung <37952714+nung22@users.noreply.github.com>
Signed-off-by: Nicholas Ung <nicholasung22@gmail.com>
(cherry picked from commit 0b5d9f3b67961d0473497f062a6874eb0d39ee6b)

### Description
_Describe what this change achieves._

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
