### PR TITLE
Remove babel-proposal plugins

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -11,8 +11,6 @@
   ],
   "plugins": [
     "@babel/plugin-transform-modules-commonjs",
-    ["@babel/plugin-transform-runtime", { "regenerator": true }],
-    "@babel/plugin-proposal-class-properties",
-    "@babel/plugin-proposal-object-rest-spread"
+    ["@babel/plugin-transform-runtime", { "regenerator": true }]
   ]
 }

--- a/.github/workflows/remote-integ-tests-workflow.yml
+++ b/.github/workflows/remote-integ-tests-workflow.yml
@@ -127,7 +127,7 @@ jobs:
 
       # Windows and Mac OS take a while to start, so we need a long sleep
       - name: Sleep until OSD server starts
-        run: while [[ "$(curl -s localhost:5601/api/status | jq -r '.status.overall.state')" != "green" ]]; do sleep 5; done
+        run: sleep 1000
         shell: bash
 
       - name: Checkout opensearch-dashboards-functional-test

--- a/.github/workflows/remote-integ-tests-workflow.yml
+++ b/.github/workflows/remote-integ-tests-workflow.yml
@@ -127,7 +127,7 @@ jobs:
 
       # Windows and Mac OS take a while to start, so we need a long sleep
       - name: Sleep until OSD server starts
-        run: sleep 900
+        run: while [[ "$(curl -s localhost:5601/api/status | jq -r '.status.overall.state')" != "green" ]]; do sleep 5; done
         shell: bash
 
       - name: Checkout opensearch-dashboards-functional-test

--- a/.github/workflows/remote-integ-tests-workflow.yml
+++ b/.github/workflows/remote-integ-tests-workflow.yml
@@ -101,23 +101,18 @@ jobs:
         with:
           path: OpenSearch-Dashboards/plugins/dashboards-search-relevance
 
-      - name: Get node and yarn versions
-        id: versions_step
-        run: |
-          echo "::set-output name=node_version::$(node -p "(require('./OpenSearch-Dashboards/package.json').engines.node).match(/[.0-9]+/)[0]")"
-          echo "::set-output name=yarn_version::$(node -p "(require('./OpenSearch-Dashboards/package.json').engines.yarn).match(/[.0-9]+/)[0]")"
-
-      - name: Setup node
-        uses: actions/setup-node@v1
+      - name: Setup Node
+        uses: actions/setup-node@v3
         with:
-          node-version: ${{ steps.versions_step.outputs.node_version }}
+          node-version-file: './OpenSearch-Dashboards/.nvmrc'
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Install correct yarn version for OpenSearch Dashboards
+      - name: Install Yarn
+        shell: bash
         run: |
-          npm uninstall -g yarn
-          echo "Installing yarn ${{ steps.versions_step.outputs.yarn_version }}"
-          npm i -g yarn@${{ steps.versions_step.outputs.yarn_version }}
+          YARN_VERSION=$(node -p "require('./OpenSearch-Dashboards/package.json').engines.yarn")
+          echo "Installing yarn@$YARN_VERSION"
+          npm i -g yarn@$YARN_VERSION
 
       - name: Bootstrap the plugin
         run: |

--- a/.github/workflows/remote-integ-tests-workflow.yml
+++ b/.github/workflows/remote-integ-tests-workflow.yml
@@ -122,12 +122,12 @@ jobs:
       - name: Run OpenSearch Dashboards server
         run: |
           cd OpenSearch-Dashboards
-          yarn start --no-base-path --no-watch --server.host="0.0.0.0" &
+          yarn start --no-base-path --no-watch --server.host="0.0.0.0" --opensearch.requestTimeout=120000 &
         shell: bash
 
       # Windows and Mac OS take a while to start, so we need a long sleep
       - name: Sleep until OSD server starts
-        run: sleep 1000
+        run: sleep 900
         shell: bash
 
       - name: Checkout opensearch-dashboards-functional-test


### PR DESCRIPTION
### Description
The OSD team updated the `proposal` plugins to their `transform` equivalents in [this PR](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5428), which broke our builds. Removing `proposal` plugins, as they are not needed.

### Issues Resolved

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
