### PR TITLE
Updating Jest snapshot for 2.12 Release

### DIFF
--- a/public/components/common/__test__/__snapshots__/flyout.test.tsx.snap
+++ b/public/components/common/__test__/__snapshots__/flyout.test.tsx.snap
@@ -53,7 +53,11 @@ exports[`Flyout component Renders flyout component 1`] = `
                       viewBox="0 0 16 16"
                       width="16"
                       xmlns="http://www.w3.org/2000/svg"
-                    />
+                    >
+                      <path
+                        d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                      />
+                    </svg>
                   </button>
                   <div
                     class="euiFlyoutHeader euiFlyoutHeader--hasBorder"
@@ -101,7 +105,11 @@ exports[`Flyout component Renders flyout component 1`] = `
                                 viewBox="0 0 16 16"
                                 width="16"
                                 xmlns="http://www.w3.org/2000/svg"
-                              />
+                              >
+                                <path
+                                  d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                />
+                              </svg>
                               <span
                                 class="euiScreenReaderOnly"
                               >
@@ -405,7 +413,11 @@ exports[`Flyout component Renders flyout component 1`] = `
                                       viewBox="0 0 16 16"
                                       width="16"
                                       xmlns="http://www.w3.org/2000/svg"
-                                    />
+                                    >
+                                      <path
+                                        d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                      />
+                                    </svg>
                                   </button>
                                 </span>
                               </div>
@@ -643,7 +655,11 @@ exports[`Flyout component Renders flyout component 1`] = `
                                       viewBox="0 0 16 16"
                                       width="16"
                                       xmlns="http://www.w3.org/2000/svg"
-                                    />
+                                    >
+                                      <path
+                                        d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                      />
+                                    </svg>
                                   </button>
                                 </span>
                               </div>
@@ -669,7 +685,11 @@ exports[`Flyout component Renders flyout component 1`] = `
                                 viewBox="0 0 16 16"
                                 width="16"
                                 xmlns="http://www.w3.org/2000/svg"
-                              />
+                              >
+                                <path
+                                  d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                />
+                              </svg>
                               <span
                                 class="euiScreenReaderOnly"
                               >
@@ -811,7 +831,11 @@ exports[`Flyout component Renders flyout component 1`] = `
                               viewBox="0 0 16 16"
                               width="16"
                               xmlns="http://www.w3.org/2000/svg"
-                            />
+                            >
+                              <path
+                                d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                              />
+                            </svg>
                           </button>
                           <div
                             class="euiFlyoutHeader euiFlyoutHeader--hasBorder"
@@ -859,7 +883,11 @@ exports[`Flyout component Renders flyout component 1`] = `
                                         viewBox="0 0 16 16"
                                         width="16"
                                         xmlns="http://www.w3.org/2000/svg"
-                                      />
+                                      >
+                                        <path
+                                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                        />
+                                      </svg>
                                       <span
                                         class="euiScreenReaderOnly"
                                       >
@@ -1163,7 +1191,11 @@ exports[`Flyout component Renders flyout component 1`] = `
                                               viewBox="0 0 16 16"
                                               width="16"
                                               xmlns="http://www.w3.org/2000/svg"
-                                            />
+                                            >
+                                              <path
+                                                d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                              />
+                                            </svg>
                                           </button>
                                         </span>
                                       </div>
@@ -1401,7 +1433,11 @@ exports[`Flyout component Renders flyout component 1`] = `
                                               viewBox="0 0 16 16"
                                               width="16"
                                               xmlns="http://www.w3.org/2000/svg"
-                                            />
+                                            >
+                                              <path
+                                                d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                              />
+                                            </svg>
                                           </button>
                                         </span>
                                       </div>
@@ -1427,7 +1463,11 @@ exports[`Flyout component Renders flyout component 1`] = `
                                         viewBox="0 0 16 16"
                                         width="16"
                                         xmlns="http://www.w3.org/2000/svg"
-                                      />
+                                      >
+                                        <path
+                                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                        />
+                                      </svg>
                                       <span
                                         class="euiScreenReaderOnly"
                                       >
@@ -1501,7 +1541,11 @@ exports[`Flyout component Renders flyout component 1`] = `
                                 viewBox="0 0 16 16"
                                 width="16"
                                 xmlns="http://www.w3.org/2000/svg"
-                              />
+                              >
+                                <path
+                                  d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                />
+                              </svg>
                             </button>
                             <div
                               class="euiFlyoutHeader euiFlyoutHeader--hasBorder"
@@ -1549,7 +1593,11 @@ exports[`Flyout component Renders flyout component 1`] = `
                                           viewBox="0 0 16 16"
                                           width="16"
                                           xmlns="http://www.w3.org/2000/svg"
-                                        />
+                                        >
+                                          <path
+                                            d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                          />
+                                        </svg>
                                         <span
                                           class="euiScreenReaderOnly"
                                         >
@@ -1853,7 +1901,11 @@ exports[`Flyout component Renders flyout component 1`] = `
                                                 viewBox="0 0 16 16"
                                                 width="16"
                                                 xmlns="http://www.w3.org/2000/svg"
-                                              />
+                                              >
+                                                <path
+                                                  d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                />
+                                              </svg>
                                             </button>
                                           </span>
                                         </div>
@@ -2091,7 +2143,11 @@ exports[`Flyout component Renders flyout component 1`] = `
                                                 viewBox="0 0 16 16"
                                                 width="16"
                                                 xmlns="http://www.w3.org/2000/svg"
-                                              />
+                                              >
+                                                <path
+                                                  d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                />
+                                              </svg>
                                             </button>
                                           </span>
                                         </div>
@@ -2117,7 +2173,11 @@ exports[`Flyout component Renders flyout component 1`] = `
                                           viewBox="0 0 16 16"
                                           width="16"
                                           xmlns="http://www.w3.org/2000/svg"
-                                        />
+                                        >
+                                          <path
+                                            d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                          />
+                                        </svg>
                                         <span
                                           class="euiScreenReaderOnly"
                                         >
@@ -2191,7 +2251,11 @@ exports[`Flyout component Renders flyout component 1`] = `
                                   viewBox="0 0 16 16"
                                   width="16"
                                   xmlns="http://www.w3.org/2000/svg"
-                                />
+                                >
+                                  <path
+                                    d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                  />
+                                </svg>
                               </button>
                               <div
                                 class="euiFlyoutHeader euiFlyoutHeader--hasBorder"
@@ -2239,7 +2303,11 @@ exports[`Flyout component Renders flyout component 1`] = `
                                             viewBox="0 0 16 16"
                                             width="16"
                                             xmlns="http://www.w3.org/2000/svg"
-                                          />
+                                          >
+                                            <path
+                                              d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                            />
+                                          </svg>
                                           <span
                                             class="euiScreenReaderOnly"
                                           >
@@ -2543,7 +2611,11 @@ exports[`Flyout component Renders flyout component 1`] = `
                                                   viewBox="0 0 16 16"
                                                   width="16"
                                                   xmlns="http://www.w3.org/2000/svg"
-                                                />
+                                                >
+                                                  <path
+                                                    d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                  />
+                                                </svg>
                                               </button>
                                             </span>
                                           </div>
@@ -2781,7 +2853,11 @@ exports[`Flyout component Renders flyout component 1`] = `
                                                   viewBox="0 0 16 16"
                                                   width="16"
                                                   xmlns="http://www.w3.org/2000/svg"
-                                                />
+                                                >
+                                                  <path
+                                                    d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                  />
+                                                </svg>
                                               </button>
                                             </span>
                                           </div>
@@ -2807,7 +2883,11 @@ exports[`Flyout component Renders flyout component 1`] = `
                                             viewBox="0 0 16 16"
                                             width="16"
                                             xmlns="http://www.w3.org/2000/svg"
-                                          />
+                                          >
+                                            <path
+                                              d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                            />
+                                          </svg>
                                           <span
                                             class="euiScreenReaderOnly"
                                           >
@@ -2869,7 +2949,11 @@ exports[`Flyout component Renders flyout component 1`] = `
                                     viewBox="0 0 16 16"
                                     width="16"
                                     xmlns="http://www.w3.org/2000/svg"
-                                  />
+                                  >
+                                    <path
+                                      d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                    />
+                                  </svg>
                                 </button>
                                 <div
                                   class="euiFlyoutHeader euiFlyoutHeader--hasBorder"
@@ -2917,7 +3001,11 @@ exports[`Flyout component Renders flyout component 1`] = `
                                               viewBox="0 0 16 16"
                                               width="16"
                                               xmlns="http://www.w3.org/2000/svg"
-                                            />
+                                            >
+                                              <path
+                                                d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                              />
+                                            </svg>
                                             <span
                                               class="euiScreenReaderOnly"
                                             >
@@ -3221,7 +3309,11 @@ exports[`Flyout component Renders flyout component 1`] = `
                                                     viewBox="0 0 16 16"
                                                     width="16"
                                                     xmlns="http://www.w3.org/2000/svg"
-                                                  />
+                                                  >
+                                                    <path
+                                                      d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                    />
+                                                  </svg>
                                                 </button>
                                               </span>
                                             </div>
@@ -3459,7 +3551,11 @@ exports[`Flyout component Renders flyout component 1`] = `
                                                     viewBox="0 0 16 16"
                                                     width="16"
                                                     xmlns="http://www.w3.org/2000/svg"
-                                                  />
+                                                  >
+                                                    <path
+                                                      d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                    />
+                                                  </svg>
                                                 </button>
                                               </span>
                                             </div>
@@ -3485,7 +3581,11 @@ exports[`Flyout component Renders flyout component 1`] = `
                                               viewBox="0 0 16 16"
                                               width="16"
                                               xmlns="http://www.w3.org/2000/svg"
-                                            />
+                                            >
+                                              <path
+                                                d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                              />
+                                            </svg>
                                             <span
                                               class="euiScreenReaderOnly"
                                             >
@@ -3583,7 +3683,7 @@ exports[`Flyout component Renders flyout component 1`] = `
                                   size="m"
                                   type="cross"
                                 >
-                                  <EuiIconEmpty
+                                  <EuiIconBeaker
                                     aria-hidden={true}
                                     className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
                                     focusable="false"
@@ -3600,8 +3700,12 @@ exports[`Flyout component Renders flyout component 1`] = `
                                       viewBox="0 0 16 16"
                                       width={16}
                                       xmlns="http://www.w3.org/2000/svg"
-                                    />
-                                  </EuiIconEmpty>
+                                    >
+                                      <path
+                                        d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                      />
+                                    </svg>
+                                  </EuiIconBeaker>
                                 </EuiIcon>
                               </button>
                             </EuiButtonIcon>
@@ -3662,7 +3766,7 @@ exports[`Flyout component Renders flyout component 1`] = `
                                               size="s"
                                               type="popout"
                                             >
-                                              <EuiIconEmpty
+                                              <EuiIconBeaker
                                                 aria-hidden={true}
                                                 aria-label="External link"
                                                 className="euiIcon euiIcon--small euiIcon-isLoading euiLink__externalIcon"
@@ -3681,8 +3785,12 @@ exports[`Flyout component Renders flyout component 1`] = `
                                                   viewBox="0 0 16 16"
                                                   width={16}
                                                   xmlns="http://www.w3.org/2000/svg"
-                                                />
-                                              </EuiIconEmpty>
+                                                >
+                                                  <path
+                                                    d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                  />
+                                                </svg>
+                                              </EuiIconBeaker>
                                             </EuiIcon>
                                             <EuiScreenReaderOnly>
                                               <span
@@ -4110,7 +4218,7 @@ exports[`Flyout component Renders flyout component 1`] = `
                                                               size="m"
                                                               type="copy"
                                                             >
-                                                              <EuiIconEmpty
+                                                              <EuiIconBeaker
                                                                 aria-hidden={true}
                                                                 className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
                                                                 focusable="false"
@@ -4127,8 +4235,12 @@ exports[`Flyout component Renders flyout component 1`] = `
                                                                   viewBox="0 0 16 16"
                                                                   width={16}
                                                                   xmlns="http://www.w3.org/2000/svg"
-                                                                />
-                                                              </EuiIconEmpty>
+                                                                >
+                                                                  <path
+                                                                    d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                                  />
+                                                                </svg>
+                                                              </EuiIconBeaker>
                                                             </EuiIcon>
                                                           </button>
                                                         </EuiButtonIcon>
@@ -4453,7 +4565,7 @@ exports[`Flyout component Renders flyout component 1`] = `
                                                               size="m"
                                                               type="copy"
                                                             >
-                                                              <EuiIconEmpty
+                                                              <EuiIconBeaker
                                                                 aria-hidden={true}
                                                                 className="euiIcon euiIcon--medium euiIcon--inherit euiIcon-isLoading euiButtonIcon__icon"
                                                                 focusable="false"
@@ -4470,8 +4582,12 @@ exports[`Flyout component Renders flyout component 1`] = `
                                                                   viewBox="0 0 16 16"
                                                                   width={16}
                                                                   xmlns="http://www.w3.org/2000/svg"
-                                                                />
-                                                              </EuiIconEmpty>
+                                                                >
+                                                                  <path
+                                                                    d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                                  />
+                                                                </svg>
+                                                              </EuiIconBeaker>
                                                             </EuiIcon>
                                                           </button>
                                                         </EuiButtonIcon>
@@ -4504,7 +4620,7 @@ exports[`Flyout component Renders flyout component 1`] = `
                                               size="s"
                                               type="popout"
                                             >
-                                              <EuiIconEmpty
+                                              <EuiIconBeaker
                                                 aria-hidden={true}
                                                 aria-label="External link"
                                                 className="euiIcon euiIcon--small euiIcon-isLoading euiLink__externalIcon"
@@ -4523,8 +4639,12 @@ exports[`Flyout component Renders flyout component 1`] = `
                                                   viewBox="0 0 16 16"
                                                   width={16}
                                                   xmlns="http://www.w3.org/2000/svg"
-                                                />
-                                              </EuiIconEmpty>
+                                                >
+                                                  <path
+                                                    d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                  />
+                                                </svg>
+                                              </EuiIconBeaker>
                                             </EuiIcon>
                                             <EuiScreenReaderOnly>
                                               <span

--- a/public/components/common/__test__/__snapshots__/header.test.tsx.snap
+++ b/public/components/common/__test__/__snapshots__/header.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`Header component Renders header component 1`] = `
                   size="s"
                   type="popout"
                 >
-                  <EuiIconEmpty
+                  <EuiIconBeaker
                     aria-hidden={true}
                     aria-label="External link"
                     className="euiIcon euiIcon--small euiIcon-isLoading euiLink__externalIcon"
@@ -62,8 +62,12 @@ exports[`Header component Renders header component 1`] = `
                       viewBox="0 0 16 16"
                       width={16}
                       xmlns="http://www.w3.org/2000/svg"
-                    />
-                  </EuiIconEmpty>
+                    >
+                      <path
+                        d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                      />
+                    </svg>
+                  </EuiIconBeaker>
                 </EuiIcon>
                 <EuiScreenReaderOnly>
                   <span

--- a/public/components/query_compare/__test__/__snapshots__/create_index.test.tsx.snap
+++ b/public/components/query_compare/__test__/__snapshots__/create_index.test.tsx.snap
@@ -44,7 +44,7 @@ exports[`Create index component Renders create index component 1`] = `
                     size="s"
                     type="popout"
                   >
-                    <EuiIconEmpty
+                    <EuiIconBeaker
                       aria-hidden={true}
                       aria-label="External link"
                       className="euiIcon euiIcon--small euiIcon-isLoading euiLink__externalIcon"
@@ -63,8 +63,12 @@ exports[`Create index component Renders create index component 1`] = `
                         viewBox="0 0 16 16"
                         width={16}
                         xmlns="http://www.w3.org/2000/svg"
-                      />
-                    </EuiIconEmpty>
+                      >
+                        <path
+                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                        />
+                      </svg>
+                    </EuiIconBeaker>
                   </EuiIcon>
                   <EuiScreenReaderOnly>
                     <span
@@ -165,7 +169,7 @@ exports[`Create index component Renders create index component 1`] = `
                           size="s"
                           type="popout"
                         >
-                          <EuiIconEmpty
+                          <EuiIconBeaker
                             aria-hidden={true}
                             aria-label="External link"
                             className="euiIcon euiIcon--small euiIcon-isLoading euiLink__externalIcon"
@@ -184,8 +188,12 @@ exports[`Create index component Renders create index component 1`] = `
                               viewBox="0 0 16 16"
                               width={16}
                               xmlns="http://www.w3.org/2000/svg"
-                            />
-                          </EuiIconEmpty>
+                            >
+                              <path
+                                d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                              />
+                            </svg>
+                          </EuiIconBeaker>
                         </EuiIcon>
                         <EuiScreenReaderOnly>
                           <span

--- a/public/components/query_compare/search_result/result_components/__test__/__snapshots__/result_component.test.tsx.snap
+++ b/public/components/query_compare/search_result/result_components/__test__/__snapshots__/result_component.test.tsx.snap
@@ -1406,7 +1406,7 @@ exports[`Result component Renders result component 1`] = `
                                                     tabIndex={0}
                                                     type="questionInCircle"
                                                   >
-                                                    <EuiIconEmpty
+                                                    <EuiIconBeaker
                                                       aria-hidden={true}
                                                       aria-label="IconTip"
                                                       className="euiIcon euiIcon--medium euiIcon--customColor euiIcon-isLoading"
@@ -1439,8 +1439,12 @@ exports[`Result component Renders result component 1`] = `
                                                         viewBox="0 0 16 16"
                                                         width={16}
                                                         xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
+                                                      >
+                                                        <path
+                                                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                        />
+                                                      </svg>
+                                                    </EuiIconBeaker>
                                                   </EuiIcon>
                                                 </span>
                                               </EuiToolTip>
@@ -1695,7 +1699,7 @@ exports[`Result component Renders result component 1`] = `
                                                     tabIndex={0}
                                                     type="questionInCircle"
                                                   >
-                                                    <EuiIconEmpty
+                                                    <EuiIconBeaker
                                                       aria-hidden={true}
                                                       aria-label="IconTip"
                                                       className="euiIcon euiIcon--medium euiIcon--customColor euiIcon-isLoading"
@@ -1728,8 +1732,12 @@ exports[`Result component Renders result component 1`] = `
                                                         viewBox="0 0 16 16"
                                                         width={16}
                                                         xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
+                                                      >
+                                                        <path
+                                                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                        />
+                                                      </svg>
+                                                    </EuiIconBeaker>
                                                   </EuiIcon>
                                                 </span>
                                               </EuiToolTip>
@@ -1997,7 +2005,7 @@ exports[`Result component Renders result component 1`] = `
                                                     tabIndex={0}
                                                     type="questionInCircle"
                                                   >
-                                                    <EuiIconEmpty
+                                                    <EuiIconBeaker
                                                       aria-hidden={true}
                                                       aria-label="IconTip"
                                                       className="euiIcon euiIcon--medium euiIcon--customColor euiIcon-isLoading"
@@ -2030,8 +2038,12 @@ exports[`Result component Renders result component 1`] = `
                                                         viewBox="0 0 16 16"
                                                         width={16}
                                                         xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
+                                                      >
+                                                        <path
+                                                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                        />
+                                                      </svg>
+                                                    </EuiIconBeaker>
                                                   </EuiIcon>
                                                 </span>
                                               </EuiToolTip>
@@ -2286,7 +2298,7 @@ exports[`Result component Renders result component 1`] = `
                                                     tabIndex={0}
                                                     type="questionInCircle"
                                                   >
-                                                    <EuiIconEmpty
+                                                    <EuiIconBeaker
                                                       aria-hidden={true}
                                                       aria-label="IconTip"
                                                       className="euiIcon euiIcon--medium euiIcon--customColor euiIcon-isLoading"
@@ -2319,8 +2331,12 @@ exports[`Result component Renders result component 1`] = `
                                                         viewBox="0 0 16 16"
                                                         width={16}
                                                         xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
+                                                      >
+                                                        <path
+                                                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                        />
+                                                      </svg>
+                                                    </EuiIconBeaker>
                                                   </EuiIcon>
                                                 </span>
                                               </EuiToolTip>
@@ -2562,7 +2578,7 @@ exports[`Result component Renders result component 1`] = `
                                                     tabIndex={0}
                                                     type="questionInCircle"
                                                   >
-                                                    <EuiIconEmpty
+                                                    <EuiIconBeaker
                                                       aria-hidden={true}
                                                       aria-label="IconTip"
                                                       className="euiIcon euiIcon--medium euiIcon--customColor euiIcon-isLoading"
@@ -2595,8 +2611,12 @@ exports[`Result component Renders result component 1`] = `
                                                         viewBox="0 0 16 16"
                                                         width={16}
                                                         xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
+                                                      >
+                                                        <path
+                                                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                        />
+                                                      </svg>
+                                                    </EuiIconBeaker>
                                                   </EuiIcon>
                                                 </span>
                                               </EuiToolTip>
@@ -2838,7 +2858,7 @@ exports[`Result component Renders result component 1`] = `
                                                     tabIndex={0}
                                                     type="questionInCircle"
                                                   >
-                                                    <EuiIconEmpty
+                                                    <EuiIconBeaker
                                                       aria-hidden={true}
                                                       aria-label="IconTip"
                                                       className="euiIcon euiIcon--medium euiIcon--customColor euiIcon-isLoading"
@@ -2871,8 +2891,12 @@ exports[`Result component Renders result component 1`] = `
                                                         viewBox="0 0 16 16"
                                                         width={16}
                                                         xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
+                                                      >
+                                                        <path
+                                                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                        />
+                                                      </svg>
+                                                    </EuiIconBeaker>
                                                   </EuiIcon>
                                                 </span>
                                               </EuiToolTip>
@@ -3114,7 +3138,7 @@ exports[`Result component Renders result component 1`] = `
                                                     tabIndex={0}
                                                     type="questionInCircle"
                                                   >
-                                                    <EuiIconEmpty
+                                                    <EuiIconBeaker
                                                       aria-hidden={true}
                                                       aria-label="IconTip"
                                                       className="euiIcon euiIcon--medium euiIcon--customColor euiIcon-isLoading"
@@ -3147,8 +3171,12 @@ exports[`Result component Renders result component 1`] = `
                                                         viewBox="0 0 16 16"
                                                         width={16}
                                                         xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
+                                                      >
+                                                        <path
+                                                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                        />
+                                                      </svg>
+                                                    </EuiIconBeaker>
                                                   </EuiIcon>
                                                 </span>
                                               </EuiToolTip>
@@ -3403,7 +3431,7 @@ exports[`Result component Renders result component 1`] = `
                                                     tabIndex={0}
                                                     type="questionInCircle"
                                                   >
-                                                    <EuiIconEmpty
+                                                    <EuiIconBeaker
                                                       aria-hidden={true}
                                                       aria-label="IconTip"
                                                       className="euiIcon euiIcon--medium euiIcon--customColor euiIcon-isLoading"
@@ -3436,8 +3464,12 @@ exports[`Result component Renders result component 1`] = `
                                                         viewBox="0 0 16 16"
                                                         width={16}
                                                         xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
+                                                      >
+                                                        <path
+                                                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                        />
+                                                      </svg>
+                                                    </EuiIconBeaker>
                                                   </EuiIcon>
                                                 </span>
                                               </EuiToolTip>
@@ -3679,7 +3711,7 @@ exports[`Result component Renders result component 1`] = `
                                                     tabIndex={0}
                                                     type="questionInCircle"
                                                   >
-                                                    <EuiIconEmpty
+                                                    <EuiIconBeaker
                                                       aria-hidden={true}
                                                       aria-label="IconTip"
                                                       className="euiIcon euiIcon--medium euiIcon--customColor euiIcon-isLoading"
@@ -3712,8 +3744,12 @@ exports[`Result component Renders result component 1`] = `
                                                         viewBox="0 0 16 16"
                                                         width={16}
                                                         xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
+                                                      >
+                                                        <path
+                                                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                        />
+                                                      </svg>
+                                                    </EuiIconBeaker>
                                                   </EuiIcon>
                                                 </span>
                                               </EuiToolTip>
@@ -3968,7 +4004,7 @@ exports[`Result component Renders result component 1`] = `
                                                     tabIndex={0}
                                                     type="questionInCircle"
                                                   >
-                                                    <EuiIconEmpty
+                                                    <EuiIconBeaker
                                                       aria-hidden={true}
                                                       aria-label="IconTip"
                                                       className="euiIcon euiIcon--medium euiIcon--customColor euiIcon-isLoading"
@@ -4001,8 +4037,12 @@ exports[`Result component Renders result component 1`] = `
                                                         viewBox="0 0 16 16"
                                                         width={16}
                                                         xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
+                                                      >
+                                                        <path
+                                                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                        />
+                                                      </svg>
+                                                    </EuiIconBeaker>
                                                   </EuiIcon>
                                                 </span>
                                               </EuiToolTip>
@@ -4727,7 +4767,7 @@ exports[`Result component Renders result component 1`] = `
                                                     tabIndex={0}
                                                     type="questionInCircle"
                                                   >
-                                                    <EuiIconEmpty
+                                                    <EuiIconBeaker
                                                       aria-hidden={true}
                                                       aria-label="IconTip"
                                                       className="euiIcon euiIcon--medium euiIcon--customColor euiIcon-isLoading"
@@ -4760,8 +4800,12 @@ exports[`Result component Renders result component 1`] = `
                                                         viewBox="0 0 16 16"
                                                         width={16}
                                                         xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
+                                                      >
+                                                        <path
+                                                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                        />
+                                                      </svg>
+                                                    </EuiIconBeaker>
                                                   </EuiIcon>
                                                 </span>
                                               </EuiToolTip>
@@ -5016,7 +5060,7 @@ exports[`Result component Renders result component 1`] = `
                                                     tabIndex={0}
                                                     type="questionInCircle"
                                                   >
-                                                    <EuiIconEmpty
+                                                    <EuiIconBeaker
                                                       aria-hidden={true}
                                                       aria-label="IconTip"
                                                       className="euiIcon euiIcon--medium euiIcon--customColor euiIcon-isLoading"
@@ -5049,8 +5093,12 @@ exports[`Result component Renders result component 1`] = `
                                                         viewBox="0 0 16 16"
                                                         width={16}
                                                         xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
+                                                      >
+                                                        <path
+                                                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                        />
+                                                      </svg>
+                                                    </EuiIconBeaker>
                                                   </EuiIcon>
                                                 </span>
                                               </EuiToolTip>
@@ -5318,7 +5366,7 @@ exports[`Result component Renders result component 1`] = `
                                                     tabIndex={0}
                                                     type="questionInCircle"
                                                   >
-                                                    <EuiIconEmpty
+                                                    <EuiIconBeaker
                                                       aria-hidden={true}
                                                       aria-label="IconTip"
                                                       className="euiIcon euiIcon--medium euiIcon--customColor euiIcon-isLoading"
@@ -5351,8 +5399,12 @@ exports[`Result component Renders result component 1`] = `
                                                         viewBox="0 0 16 16"
                                                         width={16}
                                                         xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
+                                                      >
+                                                        <path
+                                                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                        />
+                                                      </svg>
+                                                    </EuiIconBeaker>
                                                   </EuiIcon>
                                                 </span>
                                               </EuiToolTip>
@@ -5607,7 +5659,7 @@ exports[`Result component Renders result component 1`] = `
                                                     tabIndex={0}
                                                     type="questionInCircle"
                                                   >
-                                                    <EuiIconEmpty
+                                                    <EuiIconBeaker
                                                       aria-hidden={true}
                                                       aria-label="IconTip"
                                                       className="euiIcon euiIcon--medium euiIcon--customColor euiIcon-isLoading"
@@ -5640,8 +5692,12 @@ exports[`Result component Renders result component 1`] = `
                                                         viewBox="0 0 16 16"
                                                         width={16}
                                                         xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
+                                                      >
+                                                        <path
+                                                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                        />
+                                                      </svg>
+                                                    </EuiIconBeaker>
                                                   </EuiIcon>
                                                 </span>
                                               </EuiToolTip>
@@ -5883,7 +5939,7 @@ exports[`Result component Renders result component 1`] = `
                                                     tabIndex={0}
                                                     type="questionInCircle"
                                                   >
-                                                    <EuiIconEmpty
+                                                    <EuiIconBeaker
                                                       aria-hidden={true}
                                                       aria-label="IconTip"
                                                       className="euiIcon euiIcon--medium euiIcon--customColor euiIcon-isLoading"
@@ -5916,8 +5972,12 @@ exports[`Result component Renders result component 1`] = `
                                                         viewBox="0 0 16 16"
                                                         width={16}
                                                         xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
+                                                      >
+                                                        <path
+                                                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                        />
+                                                      </svg>
+                                                    </EuiIconBeaker>
                                                   </EuiIcon>
                                                 </span>
                                               </EuiToolTip>
@@ -6159,7 +6219,7 @@ exports[`Result component Renders result component 1`] = `
                                                     tabIndex={0}
                                                     type="questionInCircle"
                                                   >
-                                                    <EuiIconEmpty
+                                                    <EuiIconBeaker
                                                       aria-hidden={true}
                                                       aria-label="IconTip"
                                                       className="euiIcon euiIcon--medium euiIcon--customColor euiIcon-isLoading"
@@ -6192,8 +6252,12 @@ exports[`Result component Renders result component 1`] = `
                                                         viewBox="0 0 16 16"
                                                         width={16}
                                                         xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
+                                                      >
+                                                        <path
+                                                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                        />
+                                                      </svg>
+                                                    </EuiIconBeaker>
                                                   </EuiIcon>
                                                 </span>
                                               </EuiToolTip>
@@ -6435,7 +6499,7 @@ exports[`Result component Renders result component 1`] = `
                                                     tabIndex={0}
                                                     type="questionInCircle"
                                                   >
-                                                    <EuiIconEmpty
+                                                    <EuiIconBeaker
                                                       aria-hidden={true}
                                                       aria-label="IconTip"
                                                       className="euiIcon euiIcon--medium euiIcon--customColor euiIcon-isLoading"
@@ -6468,8 +6532,12 @@ exports[`Result component Renders result component 1`] = `
                                                         viewBox="0 0 16 16"
                                                         width={16}
                                                         xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
+                                                      >
+                                                        <path
+                                                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                        />
+                                                      </svg>
+                                                    </EuiIconBeaker>
                                                   </EuiIcon>
                                                 </span>
                                               </EuiToolTip>
@@ -6724,7 +6792,7 @@ exports[`Result component Renders result component 1`] = `
                                                     tabIndex={0}
                                                     type="questionInCircle"
                                                   >
-                                                    <EuiIconEmpty
+                                                    <EuiIconBeaker
                                                       aria-hidden={true}
                                                       aria-label="IconTip"
                                                       className="euiIcon euiIcon--medium euiIcon--customColor euiIcon-isLoading"
@@ -6757,8 +6825,12 @@ exports[`Result component Renders result component 1`] = `
                                                         viewBox="0 0 16 16"
                                                         width={16}
                                                         xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
+                                                      >
+                                                        <path
+                                                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                        />
+                                                      </svg>
+                                                    </EuiIconBeaker>
                                                   </EuiIcon>
                                                 </span>
                                               </EuiToolTip>
@@ -7000,7 +7072,7 @@ exports[`Result component Renders result component 1`] = `
                                                     tabIndex={0}
                                                     type="questionInCircle"
                                                   >
-                                                    <EuiIconEmpty
+                                                    <EuiIconBeaker
                                                       aria-hidden={true}
                                                       aria-label="IconTip"
                                                       className="euiIcon euiIcon--medium euiIcon--customColor euiIcon-isLoading"
@@ -7033,8 +7105,12 @@ exports[`Result component Renders result component 1`] = `
                                                         viewBox="0 0 16 16"
                                                         width={16}
                                                         xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
+                                                      >
+                                                        <path
+                                                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                        />
+                                                      </svg>
+                                                    </EuiIconBeaker>
                                                   </EuiIcon>
                                                 </span>
                                               </EuiToolTip>
@@ -7289,7 +7365,7 @@ exports[`Result component Renders result component 1`] = `
                                                     tabIndex={0}
                                                     type="questionInCircle"
                                                   >
-                                                    <EuiIconEmpty
+                                                    <EuiIconBeaker
                                                       aria-hidden={true}
                                                       aria-label="IconTip"
                                                       className="euiIcon euiIcon--medium euiIcon--customColor euiIcon-isLoading"
@@ -7322,8 +7398,12 @@ exports[`Result component Renders result component 1`] = `
                                                         viewBox="0 0 16 16"
                                                         width={16}
                                                         xmlns="http://www.w3.org/2000/svg"
-                                                      />
-                                                    </EuiIconEmpty>
+                                                      >
+                                                        <path
+                                                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                        />
+                                                      </svg>
+                                                    </EuiIconBeaker>
                                                   </EuiIcon>
                                                 </span>
                                               </EuiToolTip>

--- a/public/components/query_compare/search_result/result_components/__test__/__snapshots__/result_grid.test.tsx.snap
+++ b/public/components/query_compare/search_result/result_components/__test__/__snapshots__/result_grid.test.tsx.snap
@@ -276,7 +276,7 @@ exports[`Result grid component Renders result grid component 1`] = `
                             <EuiIcon
                               type="sortUp"
                             >
-                              <EuiIconEmpty
+                              <EuiIconBeaker
                                 aria-hidden={true}
                                 className="euiIcon euiIcon--medium euiIcon-isLoading"
                                 focusable="false"
@@ -293,8 +293,12 @@ exports[`Result grid component Renders result grid component 1`] = `
                                   viewBox="0 0 16 16"
                                   width={16}
                                   xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </EuiIconEmpty>
+                                >
+                                  <path
+                                    d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                  />
+                                </svg>
+                              </EuiIconBeaker>
                             </EuiIcon>
                              Up 
                             1
@@ -504,7 +508,7 @@ exports[`Result grid component Renders result grid component 1`] = `
                             <EuiIcon
                               type="sortDown"
                             >
-                              <EuiIconEmpty
+                              <EuiIconBeaker
                                 aria-hidden={true}
                                 className="euiIcon euiIcon--medium euiIcon-isLoading"
                                 focusable="false"
@@ -521,8 +525,12 @@ exports[`Result grid component Renders result grid component 1`] = `
                                   viewBox="0 0 16 16"
                                   width={16}
                                   xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </EuiIconEmpty>
+                                >
+                                  <path
+                                    d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                  />
+                                </svg>
+                              </EuiIconBeaker>
                             </EuiIcon>
                              Down 
                             1
@@ -745,7 +753,7 @@ exports[`Result grid component Renders result grid component 1`] = `
                             <EuiIcon
                               type="sortUp"
                             >
-                              <EuiIconEmpty
+                              <EuiIconBeaker
                                 aria-hidden={true}
                                 className="euiIcon euiIcon--medium euiIcon-isLoading"
                                 focusable="false"
@@ -762,8 +770,12 @@ exports[`Result grid component Renders result grid component 1`] = `
                                   viewBox="0 0 16 16"
                                   width={16}
                                   xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </EuiIconEmpty>
+                                >
+                                  <path
+                                    d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                  />
+                                </svg>
+                              </EuiIconBeaker>
                             </EuiIcon>
                              Up 
                             7
@@ -973,7 +985,7 @@ exports[`Result grid component Renders result grid component 1`] = `
                             <EuiIcon
                               type="sortUp"
                             >
-                              <EuiIconEmpty
+                              <EuiIconBeaker
                                 aria-hidden={true}
                                 className="euiIcon euiIcon--medium euiIcon-isLoading"
                                 focusable="false"
@@ -990,8 +1002,12 @@ exports[`Result grid component Renders result grid component 1`] = `
                                   viewBox="0 0 16 16"
                                   width={16}
                                   xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </EuiIconEmpty>
+                                >
+                                  <path
+                                    d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                  />
+                                </svg>
+                              </EuiIconBeaker>
                             </EuiIcon>
                              Up 
                             96
@@ -1233,7 +1249,7 @@ exports[`Result grid component Renders result grid component 1`] = `
                                   tabIndex={0}
                                   type="questionInCircle"
                                 >
-                                  <EuiIconEmpty
+                                  <EuiIconBeaker
                                     aria-hidden={true}
                                     aria-label="IconTip"
                                     className="euiIcon euiIcon--medium euiIcon--customColor euiIcon-isLoading"
@@ -1266,8 +1282,12 @@ exports[`Result grid component Renders result grid component 1`] = `
                                       viewBox="0 0 16 16"
                                       width={16}
                                       xmlns="http://www.w3.org/2000/svg"
-                                    />
-                                  </EuiIconEmpty>
+                                    >
+                                      <path
+                                        d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                      />
+                                    </svg>
+                                  </EuiIconBeaker>
                                 </EuiIcon>
                               </span>
                             </EuiToolTip>
@@ -1509,7 +1529,7 @@ exports[`Result grid component Renders result grid component 1`] = `
                                   tabIndex={0}
                                   type="questionInCircle"
                                 >
-                                  <EuiIconEmpty
+                                  <EuiIconBeaker
                                     aria-hidden={true}
                                     aria-label="IconTip"
                                     className="euiIcon euiIcon--medium euiIcon--customColor euiIcon-isLoading"
@@ -1542,8 +1562,12 @@ exports[`Result grid component Renders result grid component 1`] = `
                                       viewBox="0 0 16 16"
                                       width={16}
                                       xmlns="http://www.w3.org/2000/svg"
-                                    />
-                                  </EuiIconEmpty>
+                                    >
+                                      <path
+                                        d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                      />
+                                    </svg>
+                                  </EuiIconBeaker>
                                 </EuiIcon>
                               </span>
                             </EuiToolTip>
@@ -1785,7 +1809,7 @@ exports[`Result grid component Renders result grid component 1`] = `
                                   tabIndex={0}
                                   type="questionInCircle"
                                 >
-                                  <EuiIconEmpty
+                                  <EuiIconBeaker
                                     aria-hidden={true}
                                     aria-label="IconTip"
                                     className="euiIcon euiIcon--medium euiIcon--customColor euiIcon-isLoading"
@@ -1818,8 +1842,12 @@ exports[`Result grid component Renders result grid component 1`] = `
                                       viewBox="0 0 16 16"
                                       width={16}
                                       xmlns="http://www.w3.org/2000/svg"
-                                    />
-                                  </EuiIconEmpty>
+                                    >
+                                      <path
+                                        d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                      />
+                                    </svg>
+                                  </EuiIconBeaker>
                                 </EuiIcon>
                               </span>
                             </EuiToolTip>
@@ -2074,7 +2102,7 @@ exports[`Result grid component Renders result grid component 1`] = `
                                   tabIndex={0}
                                   type="questionInCircle"
                                 >
-                                  <EuiIconEmpty
+                                  <EuiIconBeaker
                                     aria-hidden={true}
                                     aria-label="IconTip"
                                     className="euiIcon euiIcon--medium euiIcon--customColor euiIcon-isLoading"
@@ -2107,8 +2135,12 @@ exports[`Result grid component Renders result grid component 1`] = `
                                       viewBox="0 0 16 16"
                                       width={16}
                                       xmlns="http://www.w3.org/2000/svg"
-                                    />
-                                  </EuiIconEmpty>
+                                    >
+                                      <path
+                                        d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                      />
+                                    </svg>
+                                  </EuiIconBeaker>
                                 </EuiIcon>
                               </span>
                             </EuiToolTip>
@@ -2350,7 +2382,7 @@ exports[`Result grid component Renders result grid component 1`] = `
                                   tabIndex={0}
                                   type="questionInCircle"
                                 >
-                                  <EuiIconEmpty
+                                  <EuiIconBeaker
                                     aria-hidden={true}
                                     aria-label="IconTip"
                                     className="euiIcon euiIcon--medium euiIcon--customColor euiIcon-isLoading"
@@ -2383,8 +2415,12 @@ exports[`Result grid component Renders result grid component 1`] = `
                                       viewBox="0 0 16 16"
                                       width={16}
                                       xmlns="http://www.w3.org/2000/svg"
-                                    />
-                                  </EuiIconEmpty>
+                                    >
+                                      <path
+                                        d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                      />
+                                    </svg>
+                                  </EuiIconBeaker>
                                 </EuiIcon>
                               </span>
                             </EuiToolTip>
@@ -2639,7 +2675,7 @@ exports[`Result grid component Renders result grid component 1`] = `
                                   tabIndex={0}
                                   type="questionInCircle"
                                 >
-                                  <EuiIconEmpty
+                                  <EuiIconBeaker
                                     aria-hidden={true}
                                     aria-label="IconTip"
                                     className="euiIcon euiIcon--medium euiIcon--customColor euiIcon-isLoading"
@@ -2672,8 +2708,12 @@ exports[`Result grid component Renders result grid component 1`] = `
                                       viewBox="0 0 16 16"
                                       width={16}
                                       xmlns="http://www.w3.org/2000/svg"
-                                    />
-                                  </EuiIconEmpty>
+                                    >
+                                      <path
+                                        d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                      />
+                                    </svg>
+                                  </EuiIconBeaker>
                                 </EuiIcon>
                               </span>
                             </EuiToolTip>

--- a/public/components/query_compare/search_result/search_components/__tests__/__snapshots__/search_bar.test.tsx.snap
+++ b/public/components/query_compare/search_result/search_components/__tests__/__snapshots__/search_bar.test.tsx.snap
@@ -91,7 +91,7 @@ exports[`Search bar component Renders search bar component 1`] = `
                             size="m"
                             type="search"
                           >
-                            <EuiIconEmpty
+                            <EuiIconBeaker
                               aria-hidden={true}
                               className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
                               focusable="false"
@@ -108,8 +108,12 @@ exports[`Search bar component Renders search bar component 1`] = `
                                 viewBox="0 0 16 16"
                                 width={16}
                                 xmlns="http://www.w3.org/2000/svg"
-                              />
-                            </EuiIconEmpty>
+                              >
+                                <path
+                                  d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                />
+                              </svg>
+                            </EuiIconBeaker>
                           </EuiIcon>
                         </span>
                       </EuiFormControlLayoutCustomIcon>
@@ -135,7 +139,7 @@ exports[`Search bar component Renders search bar component 1`] = `
                               className="euiFormControlLayoutClearButton__icon"
                               type="cross"
                             >
-                              <EuiIconEmpty
+                              <EuiIconBeaker
                                 aria-hidden={true}
                                 className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutClearButton__icon"
                                 focusable="false"
@@ -152,8 +156,12 @@ exports[`Search bar component Renders search bar component 1`] = `
                                   viewBox="0 0 16 16"
                                   width={16}
                                   xmlns="http://www.w3.org/2000/svg"
-                                />
-                              </EuiIconEmpty>
+                                >
+                                  <path
+                                    d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                  />
+                                </svg>
+                              </EuiIconBeaker>
                             </EuiIcon>
                           </button>
                         </EuiI18n>

--- a/public/components/query_compare/search_result/search_components/__tests__/__snapshots__/search_config.test.tsx.snap
+++ b/public/components/query_compare/search_result/search_components/__tests__/__snapshots__/search_config.test.tsx.snap
@@ -170,7 +170,7 @@ exports[`Flyout component Renders flyout component 1`] = `
                                     size="m"
                                     type="arrowDown"
                                   >
-                                    <EuiIconEmpty
+                                    <EuiIconBeaker
                                       aria-hidden={true}
                                       className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
                                       focusable="false"
@@ -187,8 +187,12 @@ exports[`Flyout component Renders flyout component 1`] = `
                                         viewBox="0 0 16 16"
                                         width={16}
                                         xmlns="http://www.w3.org/2000/svg"
-                                      />
-                                    </EuiIconEmpty>
+                                      >
+                                        <path
+                                          d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                        />
+                                      </svg>
+                                    </EuiIconBeaker>
                                   </EuiIcon>
                                 </span>
                               </EuiFormControlLayoutCustomIcon>
@@ -429,7 +433,7 @@ exports[`Flyout component Renders flyout component 1`] = `
                                         size="m"
                                         type="arrowDown"
                                       >
-                                        <EuiIconEmpty
+                                        <EuiIconBeaker
                                           aria-hidden={true}
                                           className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
                                           focusable="false"
@@ -446,8 +450,12 @@ exports[`Flyout component Renders flyout component 1`] = `
                                             viewBox="0 0 16 16"
                                             width={16}
                                             xmlns="http://www.w3.org/2000/svg"
-                                          />
-                                        </EuiIconEmpty>
+                                          >
+                                            <path
+                                              d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                            />
+                                          </svg>
+                                        </EuiIconBeaker>
                                       </EuiIcon>
                                     </button>
                                   </EuiFormControlLayoutCustomIcon>

--- a/public/components/query_compare/search_result/search_components/__tests__/__snapshots__/search_configs.test.tsx.snap
+++ b/public/components/query_compare/search_result/search_components/__tests__/__snapshots__/search_configs.test.tsx.snap
@@ -218,7 +218,7 @@ exports[`Flyout component Renders flyout component 1`] = `
                                                   size="m"
                                                   type="arrowDown"
                                                 >
-                                                  <EuiIconEmpty
+                                                  <EuiIconBeaker
                                                     aria-hidden={true}
                                                     className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
                                                     focusable="false"
@@ -235,8 +235,12 @@ exports[`Flyout component Renders flyout component 1`] = `
                                                       viewBox="0 0 16 16"
                                                       width={16}
                                                       xmlns="http://www.w3.org/2000/svg"
-                                                    />
-                                                  </EuiIconEmpty>
+                                                    >
+                                                      <path
+                                                        d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                      />
+                                                    </svg>
+                                                  </EuiIconBeaker>
                                                 </EuiIcon>
                                               </span>
                                             </EuiFormControlLayoutCustomIcon>
@@ -477,7 +481,7 @@ exports[`Flyout component Renders flyout component 1`] = `
                                                       size="m"
                                                       type="arrowDown"
                                                     >
-                                                      <EuiIconEmpty
+                                                      <EuiIconBeaker
                                                         aria-hidden={true}
                                                         className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
                                                         focusable="false"
@@ -494,8 +498,12 @@ exports[`Flyout component Renders flyout component 1`] = `
                                                           viewBox="0 0 16 16"
                                                           width={16}
                                                           xmlns="http://www.w3.org/2000/svg"
-                                                        />
-                                                      </EuiIconEmpty>
+                                                        >
+                                                          <path
+                                                            d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                          />
+                                                        </svg>
+                                                      </EuiIconBeaker>
                                                     </EuiIcon>
                                                   </button>
                                                 </EuiFormControlLayoutCustomIcon>
@@ -969,7 +977,7 @@ exports[`Flyout component Renders flyout component 1`] = `
                                                   size="m"
                                                   type="arrowDown"
                                                 >
-                                                  <EuiIconEmpty
+                                                  <EuiIconBeaker
                                                     aria-hidden={true}
                                                     className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
                                                     focusable="false"
@@ -986,8 +994,12 @@ exports[`Flyout component Renders flyout component 1`] = `
                                                       viewBox="0 0 16 16"
                                                       width={16}
                                                       xmlns="http://www.w3.org/2000/svg"
-                                                    />
-                                                  </EuiIconEmpty>
+                                                    >
+                                                      <path
+                                                        d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                      />
+                                                    </svg>
+                                                  </EuiIconBeaker>
                                                 </EuiIcon>
                                               </span>
                                             </EuiFormControlLayoutCustomIcon>
@@ -1228,7 +1240,7 @@ exports[`Flyout component Renders flyout component 1`] = `
                                                       size="m"
                                                       type="arrowDown"
                                                     >
-                                                      <EuiIconEmpty
+                                                      <EuiIconBeaker
                                                         aria-hidden={true}
                                                         className="euiIcon euiIcon--medium euiIcon-isLoading euiFormControlLayoutCustomIcon__icon"
                                                         focusable="false"
@@ -1245,8 +1257,12 @@ exports[`Flyout component Renders flyout component 1`] = `
                                                           viewBox="0 0 16 16"
                                                           width={16}
                                                           xmlns="http://www.w3.org/2000/svg"
-                                                        />
-                                                      </EuiIconEmpty>
+                                                        >
+                                                          <path
+                                                            d="M5.277 10.088c.02.014.04.03.057.047.582.55 1.134.812 1.666.812.586 0 1.84-.293 3.713-.88L9 6.212V2H7v4.212l-1.723 3.876Zm-.438.987L3.539 14h8.922l-1.32-2.969C9.096 11.677 7.733 12 7 12c-.74 0-1.463-.315-2.161-.925ZM6 2H5V1h6v1h-1v4l3.375 7.594A1 1 0 0 1 12.461 15H3.54a1 1 0 0 1-.914-1.406L6 6V2Z"
+                                                          />
+                                                        </svg>
+                                                      </EuiIconBeaker>
                                                     </EuiIcon>
                                                   </button>
                                                 </EuiFormControlLayoutCustomIcon>


### PR DESCRIPTION
### Description
Updates Jest snapshots using `yarn test -u` to fix build. [This change](https://github.com/opensearch-project/oui/pull/1137) to OUI set `Beaker` to the default icon type, which requires an update to our snapshots.

### Issues Resolved
N/A 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
