### PR TITLE
Adding 2.12 release notes

### DIFF
--- a/release-notes/opensearch-dashboards-search-relevance.release-notes-2.12.0.0.md
+++ b/release-notes/opensearch-dashboards-search-relevance.release-notes-2.12.0.0.md
@@ -1,0 +1,25 @@
+## Version 2.12.0.0 Release Notes
+
+Compatible with OpenSearch 2.12.0
+
+### Features
+* Add Ability to Select a Search Pipeline in Comparison Tool ([#352](https://github.com/opensearch-project/dashboards-search-relevance/pull/352)) ([#362](https://github.com/opensearch-project/dashboards-search-relevance/pull/362))
+
+### Enhancements
+* Utilize EuiEmptyPrompt to represent empty state ([#320](https://github.com/opensearch-project/dashboards-search-relevance/pull/320)) ([#333](https://github.com/opensearch-project/dashboards-search-relevance/pull/333))
+* Update results to display non-source fields in search comparison tool ([#340](https://github.com/opensearch-project/dashboards-search-relevance/pull/340) )([#354](https://github.com/opensearch-project/dashboards-search-relevance/pull/354))
+
+### Bug Fixes
+* Updating snapshots ([#363](https://github.com/opensearch-project/dashboards-search-relevance/pull/363)) ([#364](https://github.com/opensearch-project/dashboards-search-relevance/pull/364))
+
+### Infrastructure
+* Onboard jenkins prod docker images to github actions ([#345](https://github.com/opensearch-project/dashboards-search-relevance/pull/345)) ([#346](https://github.com/opensearch-project/dashboards-search-relevance/pull/346))
+* Remove babel-proposal plugins ([#355](https://github.com/opensearch-project/dashboards-search-relevance/pull/355)) ([#357](https://github.com/opensearch-project/dashboards-search-relevance/pull/357))
+
+### Documentation
+* Updating CONTRIBUTING.md by adding DCO section ([#337](https://github.com/opensearch-project/dashboards-search-relevance/pull/337)) ([#341](https://github.com/opensearch-project/dashboards-search-relevance/pull/341))
+* Update CONTRIBUTING.md by adding command for running tests to PR directions ([#335](https://github.com/opensearch-project/dashboards-search-relevance/pull/335)) ([#347](https://github.com/opensearch-project/dashboards-search-relevance/pull/347))
+* Add DCO section ([#337](https://github.com/opensearch-project/dashboards-search-relevance/commit/8c0c9d95b7ae92776a241a8b7c480bed2504d058) )([#341](https://github.com/opensearch-project/dashboards-search-relevance/pull/341))
+
+### Refactoring
+* Add id attribute to search bar ([#338](https://github.com/opensearch-project/dashboards-search-relevance/pull/338)) ([#353](https://github.com/opensearch-project/dashboards-search-relevance/pull/353))

--- a/release-notes/opensearch-dashboards-search-relevance.release-notes-2.12.0.0.md
+++ b/release-notes/opensearch-dashboards-search-relevance.release-notes-2.12.0.0.md
@@ -19,7 +19,9 @@ Compatible with OpenSearch 2.12.0
 ### Documentation
 * Updating CONTRIBUTING.md by adding DCO section ([#337](https://github.com/opensearch-project/dashboards-search-relevance/pull/337)) ([#341](https://github.com/opensearch-project/dashboards-search-relevance/pull/341))
 * Update CONTRIBUTING.md by adding command for running tests to PR directions ([#335](https://github.com/opensearch-project/dashboards-search-relevance/pull/335)) ([#347](https://github.com/opensearch-project/dashboards-search-relevance/pull/347))
-* Add DCO section ([#337](https://github.com/opensearch-project/dashboards-search-relevance/commit/8c0c9d95b7ae92776a241a8b7c480bed2504d058) )([#341](https://github.com/opensearch-project/dashboards-search-relevance/pull/341))
 
 ### Refactoring
 * Add id attribute to search bar ([#338](https://github.com/opensearch-project/dashboards-search-relevance/pull/338)) ([#353](https://github.com/opensearch-project/dashboards-search-relevance/pull/353))
+
+## New Contributors
+* @nung22 made their first contribution in [#300](https://github.com/opensearch-project/dashboards-search-relevance/pull/300)


### PR DESCRIPTION
### Description
Adds release notes for 2.12. Needs to be backported to `2.x` and `2.12`.

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
