### PR TITLE
Fix Broken Search Comparison Tool

### DIFF
--- a/public/components/query_compare/home.tsx
+++ b/public/components/query_compare/home.tsx
@@ -139,7 +139,7 @@ export const Home = ({
       }
   }
 
-  const DataSourceMenu = dataSourceManagement.ui.getDataSourceMenu<DataSourceAggregatedViewConfig>();
+  const DataSourceMenu = dataSourceManagement?.ui?.getDataSourceMenu<DataSourceAggregatedViewConfig>() ?? undefined;
   // Get Indexes and Pipelines
   useEffect(() => {
 


### PR DESCRIPTION
### Description
#383 added support for multi-datasource support, but the home page fails to load if `data_source.enabled: true` is not set in the OpenSearch Dashboards config file. This change sets it to undefined so it doesn't break.

### Issues Resolved
#386 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
