### PR TITLE
[Navigation] Register all plugins to NavGroups

### DIFF
--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -13,6 +13,7 @@ import {
   SearchRelevancePluginSetup,
   SearchRelevancePluginStart,
 } from './types';
+import { registerAllPluginNavGroups } from './plugin_nav';
 
 export interface SearchRelevancePluginSetupDependencies {
   dataSource: DataSourcePluginSetup;
@@ -44,7 +45,7 @@ export class SearchRelevancePlugin
         return renderApp(coreStart, depsStart as AppPluginStartDependencies, params, dataSourceManagement);
       },
     });
-
+    registerAllPluginNavGroups(core);
     // Return methods that should be available to other plugins
     return {
       getGreeting() {

--- a/public/plugin_nav.tsx
+++ b/public/plugin_nav.tsx
@@ -1,0 +1,29 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { CoreSetup } from '../../../src/core/public';
+import { SearchRelevancePluginSetup } from './types';
+import { PLUGIN_ID } from '../common';
+import { DEFAULT_NAV_GROUPS, DEFAULT_APP_CATEGORIES, AppCategory } from '../../../src/core/public';
+import { i18n } from "@osd/i18n";
+
+const searchRelevance_category: Record<string, AppCategory & { group?: AppCategory }> = {
+  evaluateSearch: {
+    id: "evaluateSearch",
+    label: i18n.translate("core.ui.indexesNavList.label", {
+      defaultMessage: "Evaluate search",
+    }),
+    order: 3000,
+  },
+};
+
+export function registerAllPluginNavGroups(core: CoreSetup<SearchRelevancePluginSetup>) {
+  core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.search, [
+    {
+      id: PLUGIN_ID,
+      category: searchRelevance_category.evaluateSearch,//change to Evaluate Search
+    },
+  ]);
+}


### PR DESCRIPTION
### Description
This change adds a function that registers all the plugins to their corresponding NavGroups and NavCategories:
<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:////Users/tackadam/Library/Group%20Containers/UBF8T346G9.Office/TemporaryItems/msohtmlclip/clip.htm">
<link rel=File-List
href="file:////Users/tackadam/Library/Group%20Containers/UBF8T346G9.Office/TemporaryItems/msohtmlclip/clip_filelist.xml">
<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:12.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:Calibri, sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl63
	{font-weight:700;}
-->
</head>

<body link="#0563C1" vlink="#954F72">


Plug-in | Group | Category
-- | -- | --
Search Relevance | Search | Evaluate search



</body>

</html>
<img width="710" alt="Screenshot 2024-07-02 at 1 12 14 PM" src="https://github.com/opensearch-project/dashboards-search-relevance/assets/105462877/57d4d57f-2396-43f9-8fa9-326a1a83ffc3">

### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/7029

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
