### PR TITLE
New page header for search relevance

### DIFF
--- a/common/index.ts
+++ b/common/index.ts
@@ -5,6 +5,7 @@
 
 export const PLUGIN_ID = 'searchRelevance';
 export const PLUGIN_NAME = 'Search Relevance';
+export const COMPARE_SEARCH_RESULTS_TITLE = 'Compare Search Results';
 
 export enum ServiceEndpoints {
   GetIndexes = '/api/relevancy/search/indexes',

--- a/public/application.tsx
+++ b/public/application.tsx
@@ -11,7 +11,7 @@ import { SearchRelevanceApp } from './components/app';
 import { AppPluginStartDependencies } from './types';
 
 export const renderApp = (
-  { notifications, http, chrome, savedObjects }: CoreStart,
+  { notifications, http, chrome, savedObjects, application }: CoreStart,
   { navigation, dataSource }: AppPluginStartDependencies,
   { element, setHeaderActionMenu }: AppMountParameters,
   dataSourceManagement: DataSourceManagementPluginSetup
@@ -26,6 +26,7 @@ export const renderApp = (
       dataSourceEnabled={!!dataSource}
       setActionMenu={setHeaderActionMenu}
       dataSourceManagement={dataSourceManagement}
+      application={application}
     />,
     element
   );

--- a/public/components/app.tsx
+++ b/public/components/app.tsx
@@ -23,6 +23,7 @@ interface SearchRelevanceAppDeps {
   dataSourceEnabled: boolean;
   dataSourceManagement: DataSourceManagementPluginSetup;
   setActionMenu: (menuMount: MountPoint | undefined) => void;
+  application: CoreStart['application'];
 }
 
 export const SearchRelevanceApp = ({
@@ -34,6 +35,7 @@ export const SearchRelevanceApp = ({
   dataSourceEnabled,
   setActionMenu,
   dataSourceManagement,
+  application,
 }: SearchRelevanceAppDeps) => {
   const [toasts, setToasts] = useState<Toast[]>([]);
   const [toastRightSide, setToastRightSide] = useState<boolean>(true);
@@ -65,6 +67,7 @@ export const SearchRelevanceApp = ({
                 render={(props) => {
                   return (
                     <QueryCompareHome
+                      application={application}
                       parentBreadCrumbs={parentBreadCrumbs}
                       notifications={notifications}
                       http={http}

--- a/public/components/app.tsx
+++ b/public/components/app.tsx
@@ -10,7 +10,7 @@ import { HashRouter, Route, Switch } from 'react-router-dom';
 import { CoreStart, MountPoint, Toast } from '../../../../src/core/public';
 import { DataSourceManagementPluginSetup } from '../../../../src/plugins/data_source_management/public';
 import { NavigationPublicPluginStart } from '../../../../src/plugins/navigation/public';
-import { PLUGIN_NAME } from '../../common';
+import { PLUGIN_NAME, COMPARE_SEARCH_RESULTS_TITLE } from '../../common';
 import { SearchRelevanceContextProvider } from '../contexts';
 import { Home as QueryCompareHome } from './query_compare/home';
 
@@ -42,7 +42,13 @@ export const SearchRelevanceApp = ({
 
   // Render the application DOM.
   // Note that `navigation.ui.TopNavMenu` is a stateful component exported on the `navigation` plugin's start contract.
-  const parentBreadCrumbs = [{ text: PLUGIN_NAME, href: '#' }];
+
+  const getNavGroupEnabled = chrome.navGroup.getNavGroupEnabled();
+
+  const parentBreadCrumbs = getNavGroupEnabled 
+    ? [{ text: COMPARE_SEARCH_RESULTS_TITLE, href: '#' }]
+    : [{ text: PLUGIN_NAME, href: '#' }];
+
   const setToast = (title: string, color = 'success', text?: ReactChild, side?: string) => {
     if (!text) text = '';
     setToastRightSide(!side ? true : false);

--- a/public/components/common/header.tsx
+++ b/public/components/common/header.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import { EuiText, EuiLink, EuiPanel, EuiTitle, EuiSpacer } from '@elastic/eui';
+import { EuiText, EuiLink, EuiPanel, EuiTitle } from '@elastic/eui';
 
 interface HeaderProps {
   children?: React.ReactNode;

--- a/public/components/common/header.tsx
+++ b/public/components/common/header.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import { EuiText, EuiLink, EuiPanel, EuiTitle } from '@elastic/eui';
+import { EuiText, EuiLink, EuiPanel, EuiTitle, EuiSpacer } from '@elastic/eui';
 
 interface HeaderProps {
   children?: React.ReactNode;

--- a/public/components/query_compare/home.tsx
+++ b/public/components/query_compare/home.tsx
@@ -33,6 +33,7 @@ interface QueryExplorerProps {
   dataSourceEnabled: boolean
   dataSourceManagement: DataSourceManagementPluginSetup;
   setActionMenu: (menuMount: MountPoint | undefined) => void;
+  application: CoreStart['application'];
 }
 export const Home = ({
   parentBreadCrumbs,
@@ -46,6 +47,7 @@ export const Home = ({
   dataSourceEnabled,
   dataSourceManagement,
   setActionMenu,
+  application,
 }: QueryExplorerProps) => {
   const {
     showFlyout,
@@ -182,7 +184,7 @@ export const Home = ({
     <>
       {dataSourceEnabled && dataSourceMenuComponent}
       <div className="osdOverviewWrapper">
-        {documentsIndexes1.length || documentsIndexes2.length ? <SearchResult http={http} savedObjects={savedObjects} dataSourceEnabled={dataSourceEnabled} dataSourceManagement={dataSourceManagement} navigation={navigation} setActionMenu={setActionMenu} dataSourceOptions={dataSourceOptions} notifications={notifications}/> : <CreateIndex />}
+        {documentsIndexes1.length || documentsIndexes2.length ? <SearchResult application={application} chrome={chrome} http={http} savedObjects={savedObjects} dataSourceEnabled={dataSourceEnabled} dataSourceManagement={dataSourceManagement} navigation={navigation} setActionMenu={setActionMenu} dataSourceOptions={dataSourceOptions} notifications={notifications}/> : <CreateIndex />}
       </div>
       {showFlyout && <Flyout />}
     </>

--- a/public/components/query_compare/home.tsx
+++ b/public/components/query_compare/home.tsx
@@ -165,21 +165,6 @@ export const Home = ({
     
   }, [http, setDocumentsIndexes1, setDocumentsIndexes2, setFetchedPipelines1, setFetchedPipelines2, datasource1, datasource2]);
 
-  // const dataSourceMenuComponent = useMemo(() => {
-  //   return (
-  //     <DataSourceMenu
-  //       setMenuMountPoint={setActionMenu}
-  //       componentType={'DataSourceAggregatedView'}
-  //       componentConfig={{
-  //         savedObjects: savedObjects.client,
-  //         notifications: notifications,
-  //         fullWidth: true,
-  //         displayAllCompatibleDataSources: true,
-  //         dataSourceFilterFn: dataSourceFilterFn
-  //       }} 
-  //     />
-  //   );
-  // }, [setActionMenu, savedObjects.client, notifications, datasource1, datasource2]);
   return (
     <>
       {dataSourceEnabled}

--- a/public/components/query_compare/home.tsx
+++ b/public/components/query_compare/home.tsx
@@ -165,24 +165,24 @@ export const Home = ({
     
   }, [http, setDocumentsIndexes1, setDocumentsIndexes2, setFetchedPipelines1, setFetchedPipelines2, datasource1, datasource2]);
 
-  const dataSourceMenuComponent = useMemo(() => {
-    return (
-      <DataSourceMenu
-        setMenuMountPoint={setActionMenu}
-        componentType={'DataSourceAggregatedView'}
-        componentConfig={{
-          savedObjects: savedObjects.client,
-          notifications: notifications,
-          fullWidth: true,
-          displayAllCompatibleDataSources: true,
-          dataSourceFilterFn: dataSourceFilterFn
-        }} 
-      />
-    );
-  }, [setActionMenu, savedObjects.client, notifications, datasource1, datasource2]);
+  // const dataSourceMenuComponent = useMemo(() => {
+  //   return (
+  //     <DataSourceMenu
+  //       setMenuMountPoint={setActionMenu}
+  //       componentType={'DataSourceAggregatedView'}
+  //       componentConfig={{
+  //         savedObjects: savedObjects.client,
+  //         notifications: notifications,
+  //         fullWidth: true,
+  //         displayAllCompatibleDataSources: true,
+  //         dataSourceFilterFn: dataSourceFilterFn
+  //       }} 
+  //     />
+  //   );
+  // }, [setActionMenu, savedObjects.client, notifications, datasource1, datasource2]);
   return (
     <>
-      {dataSourceEnabled && dataSourceMenuComponent}
+      {dataSourceEnabled}
       <div className="osdOverviewWrapper">
         {documentsIndexes1.length || documentsIndexes2.length ? <SearchResult application={application} chrome={chrome} http={http} savedObjects={savedObjects} dataSourceEnabled={dataSourceEnabled} dataSourceManagement={dataSourceManagement} navigation={navigation} setActionMenu={setActionMenu} dataSourceOptions={dataSourceOptions} notifications={notifications}/> : <CreateIndex />}
       </div>

--- a/public/components/query_compare/search_result/index.tsx
+++ b/public/components/query_compare/search_result/index.tsx
@@ -208,19 +208,10 @@ export const SearchResult = ({ application, chrome, http, savedObjects, dataSour
 
   return (
     <>
-      {!getNavGroupEnabled && (
-        <Header>
-          <SearchInputBar
-            searchBarValue={searchBarValue}
-            setSearchBarValue={setSearchBarValue}
-            onClickSearch={onClickSearch}
-          />
-        </Header>
-      )}
-      {getNavGroupEnabled && (
+      {getNavGroupEnabled ? (
         <>
           <HeaderControlledPopoverWrapper>
-            <EuiText size='s'>
+            <EuiText size="s">
               <p>
                 Compare results using the same search text with different queries.{' '}
                 <EuiLink
@@ -232,13 +223,21 @@ export const SearchResult = ({ application, chrome, http, savedObjects, dataSour
               </p>
             </EuiText>
           </HeaderControlledPopoverWrapper>
-          <EuiSpacer size="m" />
           <SearchInputBar
             searchBarValue={searchBarValue}
             setSearchBarValue={setSearchBarValue}
             onClickSearch={onClickSearch} 
           />
-        </>      
+          <EuiSpacer size="m" />
+        </>
+      ) : (
+        <Header>
+          <SearchInputBar
+            searchBarValue={searchBarValue}
+            setSearchBarValue={setSearchBarValue}
+            onClickSearch={onClickSearch}
+          />
+        </Header>
       )}
       <EuiPageContentBody className="search-relevance-flex">
         <SearchConfigsPanel

--- a/public/components/query_compare/search_result/index.tsx
+++ b/public/components/query_compare/search_result/index.tsx
@@ -35,9 +35,11 @@ interface SearchResultProps {
   dataSourceManagement: DataSourceManagementPluginSetup;
   dataSourceOptions: DataSourceOption[]
   notifications: NotificationsStart
+  chrome: CoreStart['chrome'];
+  application: CoreStart['application'];
 }
 
-export const SearchResult = ({ http, savedObjects, dataSourceEnabled, dataSourceManagement, setActionMenu, navigation, dataSourceOptions, notifications}: SearchResultProps) => {
+export const SearchResult = ({ application, chrome, http, savedObjects, dataSourceEnabled, dataSourceManagement, setActionMenu, navigation, dataSourceOptions, notifications}: SearchResultProps) => {
   const [queryString1, setQueryString1] = useState(DEFAULT_QUERY);
   const [queryString2, setQueryString2] = useState(DEFAULT_QUERY);
   const [queryResult1, setQueryResult1] = useState<SearchResults>({} as any);
@@ -55,6 +57,22 @@ export const SearchResult = ({ http, savedObjects, dataSourceEnabled, dataSource
     datasource1,
     datasource2
   } = useSearchRelevanceContext();
+
+  const HeaderControlledPopoverWrapper = ({ children }: { children: React.ReactElement }) => {
+    const HeaderControl = navigation.ui.HeaderControl;
+    const getNavGroupEnabled = chrome.navGroup.getNavGroupEnabled();
+  
+    if (getNavGroupEnabled && HeaderControl) {
+      return (
+        <HeaderControl
+          setMountPoint={application.setAppDescriptionControls}
+          controls={[{ renderComponent: children }]}
+        />
+      );
+    }
+  
+    return <>{children}</>;
+  };
 
   const onClickSearch = () => {
     const queryErrors = [
@@ -188,13 +206,15 @@ export const SearchResult = ({ http, savedObjects, dataSourceEnabled, dataSource
 
   return (
     <>
-      <Header>
-        <SearchInputBar
-          searchBarValue={searchBarValue}
-          setSearchBarValue={setSearchBarValue}
-          onClickSearch={onClickSearch}
-        />
-      </Header>
+      <HeaderControlledPopoverWrapper>
+        <Header>
+          {/* <SearchInputBar
+            searchBarValue={searchBarValue}
+            setSearchBarValue={setSearchBarValue}
+            onClickSearch={onClickSearch}
+          /> */}
+        </Header>
+      </HeaderControlledPopoverWrapper>
       <EuiPageContentBody className="search-relevance-flex">
         <SearchConfigsPanel
           queryString1={queryString1}

--- a/public/components/query_compare/search_result/index.tsx
+++ b/public/components/query_compare/search_result/index.tsx
@@ -74,6 +74,8 @@ export const SearchResult = ({ application, chrome, http, savedObjects, dataSour
     return <>{children}</>;
   };
 
+  const getNavGroupEnabled = chrome.navGroup.getNavGroupEnabled();
+
   const onClickSearch = () => {
     const queryErrors = [
       { ...initialQueryErrorState, errorResponse: { ...initialQueryErrorState.errorResponse } },
@@ -206,15 +208,22 @@ export const SearchResult = ({ application, chrome, http, savedObjects, dataSour
 
   return (
     <>
-      <HeaderControlledPopoverWrapper>
+      {!getNavGroupEnabled && (
         <Header>
-          {/* <SearchInputBar
+          <SearchInputBar
             searchBarValue={searchBarValue}
             setSearchBarValue={setSearchBarValue}
             onClickSearch={onClickSearch}
-          /> */}
+          />
         </Header>
-      </HeaderControlledPopoverWrapper>
+      )}
+      {getNavGroupEnabled && (
+        <SearchInputBar
+          searchBarValue={searchBarValue}
+          setSearchBarValue={setSearchBarValue}
+          onClickSearch={onClickSearch}
+        />      
+      )}
       <EuiPageContentBody className="search-relevance-flex">
         <SearchConfigsPanel
           queryString1={queryString1}

--- a/public/components/query_compare/search_result/index.tsx
+++ b/public/components/query_compare/search_result/index.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiLink, EuiPageContentBody, EuiText, EuiSpacer} from '@elastic/eui';
+import { EuiLink, EuiPageContentBody, EuiText, EuiSpacer, EuiPanel} from '@elastic/eui';
 import React, { useState } from 'react';
 
 import { CoreStart, MountPoint } from '../../../../../../src/core/public';
@@ -220,15 +220,24 @@ export const SearchResult = ({ application, chrome, http, savedObjects, dataSour
                 >
                   Learn more
                 </EuiLink>
+                <EuiSpacer size="m" />
               </p>
             </EuiText>
           </HeaderControlledPopoverWrapper>
-          <SearchInputBar
-            searchBarValue={searchBarValue}
-            setSearchBarValue={setSearchBarValue}
-            onClickSearch={onClickSearch} 
-          />
-          <EuiSpacer size="m" />
+          <EuiPanel
+            hasBorder={false}
+            hasShadow={false}
+            color="transparent"
+            grow={false}
+            borderRadius="none"
+          >
+            <SearchInputBar
+              searchBarValue={searchBarValue}
+              setSearchBarValue={setSearchBarValue}
+              onClickSearch={onClickSearch}
+              getNavGroupEnabled={getNavGroupEnabled}
+            />
+          </EuiPanel>
         </>
       ) : (
         <Header>
@@ -236,6 +245,7 @@ export const SearchResult = ({ application, chrome, http, savedObjects, dataSour
             searchBarValue={searchBarValue}
             setSearchBarValue={setSearchBarValue}
             onClickSearch={onClickSearch}
+            getNavGroupEnabled={getNavGroupEnabled}
           />
         </Header>
       )}

--- a/public/components/query_compare/search_result/index.tsx
+++ b/public/components/query_compare/search_result/index.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiPageContentBody } from '@elastic/eui';
+import { EuiLink, EuiPageContentBody, EuiText, EuiSpacer} from '@elastic/eui';
 import React, { useState } from 'react';
 
 import { CoreStart, MountPoint } from '../../../../../../src/core/public';
@@ -218,11 +218,27 @@ export const SearchResult = ({ application, chrome, http, savedObjects, dataSour
         </Header>
       )}
       {getNavGroupEnabled && (
-        <SearchInputBar
-          searchBarValue={searchBarValue}
-          setSearchBarValue={setSearchBarValue}
-          onClickSearch={onClickSearch}
-        />      
+        <>
+          <HeaderControlledPopoverWrapper>
+            <EuiText size='s'>
+              <p>
+                Compare results using the same search text with different queries.{' '}
+                <EuiLink
+                  href="https://opensearch.org/docs/latest/search-plugins/search-relevance"
+                  target="_blank"
+                >
+                  Learn more
+                </EuiLink>
+              </p>
+            </EuiText>
+          </HeaderControlledPopoverWrapper>
+          <EuiSpacer size="m" />
+          <SearchInputBar
+            searchBarValue={searchBarValue}
+            setSearchBarValue={setSearchBarValue}
+            onClickSearch={onClickSearch} 
+          />
+        </>      
       )}
       <EuiPageContentBody className="search-relevance-flex">
         <SearchConfigsPanel

--- a/public/components/query_compare/search_result/search_components/__tests__/__snapshots__/search_bar.test.tsx.snap
+++ b/public/components/query_compare/search_result/search_components/__tests__/__snapshots__/search_bar.test.tsx.snap
@@ -216,6 +216,7 @@ exports[`Search bar component Renders search bar component 1`] = `
                 >
                   <EuiButtonContent
                     className="euiButton__content"
+                    iconGap="m"
                     iconSide="left"
                     textProps={
                       Object {

--- a/public/components/query_compare/search_result/search_components/__tests__/__snapshots__/search_config.test.tsx.snap
+++ b/public/components/query_compare/search_result/search_components/__tests__/__snapshots__/search_config.test.tsx.snap
@@ -259,8 +259,7 @@ exports[`Flyout component Renders flyout component 1`] = `
               fullWidth={true}
               hasChildLabel={true}
               hasEmptyLabelSpace={false}
-              helpText="Optional"
-              label="Pipeline"
+              label="Pipeline-optional"
               labelType="label"
             >
               <div
@@ -280,7 +279,7 @@ exports[`Flyout component Renders flyout component 1`] = `
                       className="euiFormLabel euiFormRow__label"
                       htmlFor="random_html_id"
                     >
-                      Pipeline
+                      Pipeline-optional
                     </label>
                   </EuiFormLabel>
                 </div>
@@ -288,7 +287,6 @@ exports[`Flyout component Renders flyout component 1`] = `
                   className="euiFormRow__fieldWrapper"
                 >
                   <EuiCompressedComboBox
-                    aria-describedby="random_html_id-help-0"
                     async={false}
                     compressed={true}
                     fullWidth={false}
@@ -314,7 +312,6 @@ exports[`Flyout component Renders flyout component 1`] = `
                     sortMatchesBy="none"
                   >
                     <div
-                      aria-describedby="random_html_id-help-0"
                       aria-expanded={false}
                       aria-haspopup="listbox"
                       className="euiComboBox euiComboBox--compressed"
@@ -510,18 +507,6 @@ exports[`Flyout component Renders flyout component 1`] = `
                       </EuiComboBoxInput>
                     </div>
                   </EuiCompressedComboBox>
-                  <EuiFormHelpText
-                    className="euiFormRow__text"
-                    id="random_html_id-help-0"
-                    key="Optional"
-                  >
-                    <div
-                      className="euiFormHelpText euiFormRow__text"
-                      id="random_html_id-help-0"
-                    >
-                      Optional
-                    </div>
-                  </EuiFormHelpText>
                 </div>
               </div>
             </EuiCompressedFormRow>
@@ -1064,8 +1049,7 @@ exports[`Flyout component Renders flyout component when multi-datasource is enab
               fullWidth={true}
               hasChildLabel={true}
               hasEmptyLabelSpace={false}
-              helpText="Optional"
-              label="Pipeline"
+              label="Pipeline-optional"
               labelType="label"
             >
               <div
@@ -1085,7 +1069,7 @@ exports[`Flyout component Renders flyout component when multi-datasource is enab
                       className="euiFormLabel euiFormRow__label"
                       htmlFor="random_html_id"
                     >
-                      Pipeline
+                      Pipeline-optional
                     </label>
                   </EuiFormLabel>
                 </div>
@@ -1093,7 +1077,6 @@ exports[`Flyout component Renders flyout component when multi-datasource is enab
                   className="euiFormRow__fieldWrapper"
                 >
                   <EuiCompressedComboBox
-                    aria-describedby="random_html_id-help-0"
                     async={false}
                     compressed={true}
                     fullWidth={false}
@@ -1119,7 +1102,6 @@ exports[`Flyout component Renders flyout component when multi-datasource is enab
                     sortMatchesBy="none"
                   >
                     <div
-                      aria-describedby="random_html_id-help-0"
                       aria-expanded={false}
                       aria-haspopup="listbox"
                       className="euiComboBox euiComboBox--compressed"
@@ -1314,18 +1296,6 @@ exports[`Flyout component Renders flyout component when multi-datasource is enab
                       </EuiComboBoxInput>
                     </div>
                   </EuiCompressedComboBox>
-                  <EuiFormHelpText
-                    className="euiFormRow__text"
-                    id="random_html_id-help-0"
-                    key="Optional"
-                  >
-                    <div
-                      className="euiFormHelpText euiFormRow__text"
-                      id="random_html_id-help-0"
-                    >
-                      Optional
-                    </div>
-                  </EuiFormHelpText>
                 </div>
               </div>
             </EuiCompressedFormRow>

--- a/public/components/query_compare/search_result/search_components/__tests__/__snapshots__/search_config.test.tsx.snap
+++ b/public/components/query_compare/search_result/search_components/__tests__/__snapshots__/search_config.test.tsx.snap
@@ -608,6 +608,7 @@ exports[`Flyout component Renders flyout component 1`] = `
                 >
                   <EuiButtonContent
                     className="euiButtonEmpty__content"
+                    iconGap="m"
                     iconSide="left"
                     iconSize="s"
                     textProps={
@@ -1411,6 +1412,7 @@ exports[`Flyout component Renders flyout component when multi-datasource is enab
                 >
                   <EuiButtonContent
                     className="euiButtonEmpty__content"
+                    iconGap="m"
                     iconSide="left"
                     iconSize="s"
                     textProps={

--- a/public/components/query_compare/search_result/search_components/__tests__/__snapshots__/search_configs.test.tsx.snap
+++ b/public/components/query_compare/search_result/search_components/__tests__/__snapshots__/search_configs.test.tsx.snap
@@ -292,8 +292,7 @@ exports[`Flyout component Renders flyout component 1`] = `
                             fullWidth={true}
                             hasChildLabel={true}
                             hasEmptyLabelSpace={false}
-                            helpText="Optional"
-                            label="Pipeline"
+                            label="Pipeline-optional"
                             labelType="label"
                           >
                             <div
@@ -313,7 +312,7 @@ exports[`Flyout component Renders flyout component 1`] = `
                                     className="euiFormLabel euiFormRow__label"
                                     htmlFor="random_html_id"
                                   >
-                                    Pipeline
+                                    Pipeline-optional
                                   </label>
                                 </EuiFormLabel>
                               </div>
@@ -321,7 +320,6 @@ exports[`Flyout component Renders flyout component 1`] = `
                                 className="euiFormRow__fieldWrapper"
                               >
                                 <EuiCompressedComboBox
-                                  aria-describedby="random_html_id-help-0"
                                   async={false}
                                   compressed={true}
                                   fullWidth={false}
@@ -347,7 +345,6 @@ exports[`Flyout component Renders flyout component 1`] = `
                                   sortMatchesBy="none"
                                 >
                                   <div
-                                    aria-describedby="random_html_id-help-0"
                                     aria-expanded={false}
                                     aria-haspopup="listbox"
                                     className="euiComboBox euiComboBox--compressed"
@@ -542,18 +539,6 @@ exports[`Flyout component Renders flyout component 1`] = `
                                     </EuiComboBoxInput>
                                   </div>
                                 </EuiCompressedComboBox>
-                                <EuiFormHelpText
-                                  className="euiFormRow__text"
-                                  id="random_html_id-help-0"
-                                  key="Optional"
-                                >
-                                  <div
-                                    className="euiFormHelpText euiFormRow__text"
-                                    id="random_html_id-help-0"
-                                  >
-                                    Optional
-                                  </div>
-                                </EuiFormHelpText>
                               </div>
                             </div>
                           </EuiCompressedFormRow>
@@ -1072,8 +1057,7 @@ exports[`Flyout component Renders flyout component 1`] = `
                             fullWidth={true}
                             hasChildLabel={true}
                             hasEmptyLabelSpace={false}
-                            helpText="Optional"
-                            label="Pipeline"
+                            label="Pipeline-optional"
                             labelType="label"
                           >
                             <div
@@ -1093,7 +1077,7 @@ exports[`Flyout component Renders flyout component 1`] = `
                                     className="euiFormLabel euiFormRow__label"
                                     htmlFor="random_html_id"
                                   >
-                                    Pipeline
+                                    Pipeline-optional
                                   </label>
                                 </EuiFormLabel>
                               </div>
@@ -1101,7 +1085,6 @@ exports[`Flyout component Renders flyout component 1`] = `
                                 className="euiFormRow__fieldWrapper"
                               >
                                 <EuiCompressedComboBox
-                                  aria-describedby="random_html_id-help-0"
                                   async={false}
                                   compressed={true}
                                   fullWidth={false}
@@ -1127,7 +1110,6 @@ exports[`Flyout component Renders flyout component 1`] = `
                                   sortMatchesBy="none"
                                 >
                                   <div
-                                    aria-describedby="random_html_id-help-0"
                                     aria-expanded={false}
                                     aria-haspopup="listbox"
                                     className="euiComboBox euiComboBox--compressed"
@@ -1322,18 +1304,6 @@ exports[`Flyout component Renders flyout component 1`] = `
                                     </EuiComboBoxInput>
                                   </div>
                                 </EuiCompressedComboBox>
-                                <EuiFormHelpText
-                                  className="euiFormRow__text"
-                                  id="random_html_id-help-0"
-                                  key="Optional"
-                                >
-                                  <div
-                                    className="euiFormHelpText euiFormRow__text"
-                                    id="random_html_id-help-0"
-                                  >
-                                    Optional
-                                  </div>
-                                </EuiFormHelpText>
                               </div>
                             </div>
                           </EuiCompressedFormRow>
@@ -1900,8 +1870,7 @@ exports[`Flyout component Renders flyout component when multi dataSource enabled
                             fullWidth={true}
                             hasChildLabel={true}
                             hasEmptyLabelSpace={false}
-                            helpText="Optional"
-                            label="Pipeline"
+                            label="Pipeline-optional"
                             labelType="label"
                           >
                             <div
@@ -1921,7 +1890,7 @@ exports[`Flyout component Renders flyout component when multi dataSource enabled
                                     className="euiFormLabel euiFormRow__label"
                                     htmlFor="random_html_id"
                                   >
-                                    Pipeline
+                                    Pipeline-optional
                                   </label>
                                 </EuiFormLabel>
                               </div>
@@ -1929,7 +1898,6 @@ exports[`Flyout component Renders flyout component when multi dataSource enabled
                                 className="euiFormRow__fieldWrapper"
                               >
                                 <EuiCompressedComboBox
-                                  aria-describedby="random_html_id-help-0"
                                   async={false}
                                   compressed={true}
                                   fullWidth={false}
@@ -1955,7 +1923,6 @@ exports[`Flyout component Renders flyout component when multi dataSource enabled
                                   sortMatchesBy="none"
                                 >
                                   <div
-                                    aria-describedby="random_html_id-help-0"
                                     aria-expanded={false}
                                     aria-haspopup="listbox"
                                     className="euiComboBox euiComboBox--compressed"
@@ -2151,18 +2118,6 @@ exports[`Flyout component Renders flyout component when multi dataSource enabled
                                     </EuiComboBoxInput>
                                   </div>
                                 </EuiCompressedComboBox>
-                                <EuiFormHelpText
-                                  className="euiFormRow__text"
-                                  id="random_html_id-help-0"
-                                  key="Optional"
-                                >
-                                  <div
-                                    className="euiFormHelpText euiFormRow__text"
-                                    id="random_html_id-help-0"
-                                  >
-                                    Optional
-                                  </div>
-                                </EuiFormHelpText>
                               </div>
                             </div>
                           </EuiCompressedFormRow>
@@ -2676,8 +2631,7 @@ exports[`Flyout component Renders flyout component when multi dataSource enabled
                             fullWidth={true}
                             hasChildLabel={true}
                             hasEmptyLabelSpace={false}
-                            helpText="Optional"
-                            label="Pipeline"
+                            label="Pipeline-optional"
                             labelType="label"
                           >
                             <div
@@ -2697,7 +2651,7 @@ exports[`Flyout component Renders flyout component when multi dataSource enabled
                                     className="euiFormLabel euiFormRow__label"
                                     htmlFor="random_html_id"
                                   >
-                                    Pipeline
+                                    Pipeline-optional
                                   </label>
                                 </EuiFormLabel>
                               </div>
@@ -2705,7 +2659,6 @@ exports[`Flyout component Renders flyout component when multi dataSource enabled
                                 className="euiFormRow__fieldWrapper"
                               >
                                 <EuiCompressedComboBox
-                                  aria-describedby="random_html_id-help-0"
                                   async={false}
                                   compressed={true}
                                   fullWidth={false}
@@ -2731,7 +2684,6 @@ exports[`Flyout component Renders flyout component when multi dataSource enabled
                                   sortMatchesBy="none"
                                 >
                                   <div
-                                    aria-describedby="random_html_id-help-0"
                                     aria-expanded={false}
                                     aria-haspopup="listbox"
                                     className="euiComboBox euiComboBox--compressed"
@@ -2927,18 +2879,6 @@ exports[`Flyout component Renders flyout component when multi dataSource enabled
                                     </EuiComboBoxInput>
                                   </div>
                                 </EuiCompressedComboBox>
-                                <EuiFormHelpText
-                                  className="euiFormRow__text"
-                                  id="random_html_id-help-0"
-                                  key="Optional"
-                                >
-                                  <div
-                                    className="euiFormHelpText euiFormRow__text"
-                                    id="random_html_id-help-0"
-                                  >
-                                    Optional
-                                  </div>
-                                </EuiFormHelpText>
                               </div>
                             </div>
                           </EuiCompressedFormRow>

--- a/public/components/query_compare/search_result/search_components/__tests__/__snapshots__/search_configs.test.tsx.snap
+++ b/public/components/query_compare/search_result/search_components/__tests__/__snapshots__/search_configs.test.tsx.snap
@@ -640,6 +640,7 @@ exports[`Flyout component Renders flyout component 1`] = `
                               >
                                 <EuiButtonContent
                                   className="euiButtonEmpty__content"
+                                  iconGap="m"
                                   iconSide="left"
                                   iconSize="s"
                                   textProps={
@@ -1419,6 +1420,7 @@ exports[`Flyout component Renders flyout component 1`] = `
                               >
                                 <EuiButtonContent
                                   className="euiButtonEmpty__content"
+                                  iconGap="m"
                                   iconSide="left"
                                   iconSize="s"
                                   textProps={
@@ -2247,6 +2249,7 @@ exports[`Flyout component Renders flyout component when multi dataSource enabled
                               >
                                 <EuiButtonContent
                                   className="euiButtonEmpty__content"
+                                  iconGap="m"
                                   iconSide="left"
                                   iconSize="s"
                                   textProps={
@@ -3022,6 +3025,7 @@ exports[`Flyout component Renders flyout component when multi dataSource enabled
                               >
                                 <EuiButtonContent
                                   className="euiButtonEmpty__content"
+                                  iconGap="m"
                                   iconSide="left"
                                   iconSize="s"
                                   textProps={

--- a/public/components/query_compare/search_result/search_components/search_bar.tsx
+++ b/public/components/query_compare/search_result/search_components/search_bar.tsx
@@ -19,7 +19,6 @@ export const SearchInputBar = ({
   onClickSearch,
   getNavGroupEnabled,
 }: SearchBarProps) => {
-  console.log('getNavGroupEnabled sb', getNavGroupEnabled);
   return (
     <>
       {!getNavGroupEnabled && <EuiSpacer size="m" />}

--- a/public/components/query_compare/search_result/search_components/search_bar.tsx
+++ b/public/components/query_compare/search_result/search_components/search_bar.tsx
@@ -10,16 +10,19 @@ interface SearchBarProps {
   searchBarValue: string;
   setSearchBarValue: React.Dispatch<React.SetStateAction<string>>;
   onClickSearch: () => void;
+  getNavGroupEnabled?: boolean;
 }
 
 export const SearchInputBar = ({
   searchBarValue,
   setSearchBarValue,
   onClickSearch,
+  getNavGroupEnabled,
 }: SearchBarProps) => {
+  console.log('getNavGroupEnabled sb', getNavGroupEnabled);
   return (
     <>
-      <EuiSpacer size="m" />
+      {!getNavGroupEnabled && <EuiSpacer size="m" />}
       <EuiFlexGroup>
         <EuiFlexItem grow={true}>
           <EuiCompressedFieldSearch

--- a/public/components/query_compare/search_result/search_components/search_configs/search_config.tsx
+++ b/public/components/query_compare/search_result/search_components/search_configs/search_config.tsx
@@ -180,6 +180,7 @@ export const SearchConfig: FunctionComponent<SearchConfigProps> = ({
                 defaultOption= {[]}
               />
             </EuiCompressedFormRow>
+            <EuiSpacer size="s" />
           </EuiFlexItem> )}
         <EuiFlexItem>
           <EuiCompressedFormRow

--- a/public/components/query_compare/search_result/search_components/search_configs/search_config.tsx
+++ b/public/components/query_compare/search_result/search_components/search_configs/search_config.tsx
@@ -170,6 +170,7 @@ export const SearchConfig: FunctionComponent<SearchConfigProps> = ({
               label="Data Source"
             >
               <DataSourceSelector
+                compressed={true}
                 savedObjectsClient={savedObjects.client}
                 notifications={notifications}
                 onSelectedDataSource={onSelectedDataSource}
@@ -201,7 +202,7 @@ export const SearchConfig: FunctionComponent<SearchConfigProps> = ({
           </EuiCompressedFormRow>
         </EuiFlexItem>
         <EuiFlexItem>
-          <EuiCompressedFormRow fullWidth label="Pipeline" helpText="Optional">
+          <EuiCompressedFormRow fullWidth label="Pipeline-optional">
             <EuiCompressedComboBox
               placeholder=""
               singleSelection={{ asPlainText: true }}


### PR DESCRIPTION
### Description
New page header for search relevance

### Screenshot
Nav Group Enabled:
<img width="1509" alt="Screenshot 2024-08-29 at 7 16 11 PM" src="https://github.com/user-attachments/assets/c7414c1a-9bea-42a0-b883-51c75bf78e5e">

Nav Group Disabled
<img width="1511" alt="Screenshot 2024-08-29 at 6 43 14 PM" src="https://github.com/user-attachments/assets/71b605e5-7989-4f8e-93eb-f0bda94f3507">

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
