### PR TITLE
Adding sumukhswamy as maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # This should match the list of maintainers in https://github.com/opensearch-project/dashboards-search-relevance/blob/main/MAINTAINERS.md
-*   @macohen @mingshl @msfroh @noCharger @sejli
+*   @macohen @mingshl @msfroh @noCharger @sejli @sumukhswamy

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -11,3 +11,4 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Mingshi Liu  | [mingshl](https://github.com/mingshl) | Amazon      |
 | Louis Chu    | [noCharger](https://github.com/noCharger) | Amazon  |
 | Sean Li      | [sejli](https://github.com/sejli)     | Amazon |
+| Sumukh Swamy | [sumukhswamy](https://github.com/sumukhswamy) | Amazon |


### PR DESCRIPTION
### Description
Adding @sumukhswamy as a maintainer

@opensearch-project/admin could we add Sumukh to the maintainer permissions?

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
