### PR TITLE
Bumping actions/upload-artifact@v1 to v4

### DIFF
--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -84,7 +84,7 @@ jobs:
                                whoami && yarn build && mv -v ./build/*.zip ./build/${{ env.PLUGIN_NAME }}-${{ env.OPENSEARCH_PLUGIN_VERSION }}.zip"
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: dashboards-search-relevance-${{ matrix.os }}
           path: ./OpenSearch-Dashboards/plugins/dashboards-search-relevance/build
@@ -171,7 +171,7 @@ jobs:
           mv ./build/*.zip ./build/${{ env.PLUGIN_NAME }}-${{ env.OPENSEARCH_PLUGIN_VERSION }}.zip
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: dashboards-search-relevance-${{ matrix.os }}
           path: ./OpenSearch-Dashboards/plugins/dashboards-search-relevance/build


### PR DESCRIPTION
### Description
Bumps `actions/upload-artifact` from `v1` to `v4` due to `v1` being [deprecated](https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/)

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
