### PR TITLE
Component to enable search-relevance and opensearch API calls

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,4 @@
+---
+extends:
+- "@elastic/eslint-config-kibana"
+- "plugin:@elastic/eui/recommended"

--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,0 +1,3 @@
+{
+   "*.{js,jsx,json,css,md}": ["prettier --write", "git add"]
+ }

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,8 @@
+.vscode
+build
+coverage
+node_modules
+npm-debug.log
+yarn.lock
+*.md
+*.lock

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "printWidth": 100
+}

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,16 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+module.exports = {
+  presets: [
+    require('@babel/preset-env'),
+    require('@babel/preset-react'),
+    require('@babel/preset-typescript'),
+  ],
+  plugins: [
+    ['@babel/plugin-transform-modules-commonjs', { allowTopLevelThis: true }],
+    [require('@babel/plugin-transform-runtime'), { regenerator: true }],
+  ],
+};

--- a/common/index.ts
+++ b/common/index.ts
@@ -8,15 +8,38 @@ export const PLUGIN_NAME = 'Search Relevance';
 export const COMPARE_SEARCH_RESULTS_TITLE = 'Compare Search Results';
 export const SEARCH_RELEVANCE_WORKBENCH = 'Search Relevance Workbench';
 
-export enum ServiceEndpoints {
-  GetIndexes = '/api/relevancy/search/indexes',
-  GetPipelines = '/api/relevancy/search/pipelines',
-  GetSearchResults = '/api/relevancy/search',
-  GetStats = '/api/relevancy/stats',
-}
+/**
+ * BACKEND SEARCH RELEVANCE APIs
+ */
+export const SEARCH_RELEVANCE_BASE_API = '/_plugins/search_relevance';
+export const SEARCH_RELEVANCE_QUERY_SET_API = `${SEARCH_RELEVANCE_BASE_API}/queryset`;
 
+/**
+ * OPEN SEARCH CORE APIs
+ */
 export const SEARCH_API = '/_search';
 
-//Query1 for the left search and Query2 for the right search page
+/**
+ * Node APIs
+ */
+export const BASE_NODE_API_PATH = '/api/relevancy';
+
+// OpenSearch node APIs
+export const INDEX_NODE_API_PATH = `${BASE_NODE_API_PATH}/search/indexes`;
+export const SEARCH_PIPELINE_NODE_API_PATH = `${BASE_NODE_API_PATH}/search/pipelines`;
+export const SEARCH_NODE_API_PATH = `${BASE_NODE_API_PATH}/search`;
+export const STATS_NODE_API_PATH = `${BASE_NODE_API_PATH}/stats`;
+
+// Search Relevance node APIs
+export const BASE_QUERYSET_NODE_API_PATH = `${BASE_NODE_API_PATH}/queryset`;
+
+export const DEFAULT_HEADERS = {
+  'Content-Type': 'application/json',
+  Accept: 'application/json',
+  'User-Agent': 'OpenSearch-Dashboards',
+  'osd-xsrf': true,
+};
+
+// Query1 for the left search and Query2 for the right search page
 export const QUERY_NUMBER_ONE = '1';
 export const QUERY_NUMBER_TWO = '2';

--- a/public/components/app.tsx
+++ b/public/components/app.tsx
@@ -3,7 +3,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { EuiGlobalToastList } from '@elastic/eui';
+import {
+  EuiButton,
+  EuiButtonEmpty,
+  EuiGlobalToastList,
+  EuiModal,
+  EuiModalBody,
+  EuiModalFooter,
+  EuiModalHeader,
+  EuiSwitch,
+  EuiModalHeaderTitle
+} from '@elastic/eui';
 import { I18nProvider } from '@osd/i18n/react';
 import React, { useState } from 'react';
 import { HashRouter, Route, Switch } from 'react-router-dom';
@@ -13,7 +23,7 @@ import { NavigationPublicPluginStart } from '../../../../src/plugins/navigation/
 import { PLUGIN_NAME, COMPARE_SEARCH_RESULTS_TITLE } from '../../common';
 import { SearchRelevanceContextProvider } from '../contexts';
 import { Home as QueryCompareHome } from './query_compare/home';
-import { ExperimentPage } from "./experiment/experiment_page";
+import { ExperimentPage } from './experiment';
 
 interface SearchRelevanceAppDeps {
   notifications: CoreStart['notifications'];
@@ -41,6 +51,9 @@ export const SearchRelevanceApp = ({
   const [toasts, setToasts] = useState<Toast[]>([]);
   const [toastRightSide, setToastRightSide] = useState<boolean>(true);
 
+  const [useOldVersion, setUseOldVersion] = useState(false);
+  const [isModalVisible, setIsModalVisible] = useState(true);
+
   // Render the application DOM.
   // Note that `navigation.ui.TopNavMenu` is a stateful component exported on the `navigation` plugin's start contract.
 
@@ -55,6 +68,56 @@ export const SearchRelevanceApp = ({
     setToastRightSide(!side ? true : false);
     setToasts([...toasts, { id: new Date().toISOString(), title, text, color } as Toast]);
   };
+
+  const onToggleChange = (e) => {
+    setUseOldVersion(e.target.checked);
+  };
+
+  const closeModal = () => {
+    setIsModalVisible(false);
+  };
+
+  const selectVersion = (isOld: boolean) => {
+    setUseOldVersion(isOld);
+    closeModal();
+  };
+
+  const versionModal = (
+    <>
+      {isModalVisible && (
+        <EuiModal onClose={closeModal}>
+          <EuiModalHeader>
+            <EuiModalHeaderTitle>
+              <h1>Select Version</h1>
+            </EuiModalHeaderTitle>
+          </EuiModalHeader>
+
+          <EuiModalBody>
+            <p>Please select which version you would like to use:</p>
+          </EuiModalBody>
+
+          <EuiModalFooter>
+            <EuiButtonEmpty onClick={() => selectVersion(true)}>
+              Use Old Version
+            </EuiButtonEmpty>
+            <EuiButton fill onClick={() => selectVersion(false)}>
+              Use New Version
+            </EuiButton>
+          </EuiModalFooter>
+        </EuiModal>
+      )}
+    </>
+  );
+
+  const versionToggle = (
+    <EuiSwitch
+      label="Use Old Version"
+      checked={useOldVersion}
+      onChange={onToggleChange}
+      style={{ marginBottom: '16px' }}
+    />
+  );
+
   return (
     <HashRouter>
       <I18nProvider>
@@ -69,17 +132,36 @@ export const SearchRelevanceApp = ({
               toastLifeTimeMs={6000}
             />
             <Switch>
-                <Route
-                  path={['/']}
-                  render={(props) => {
-                    return (
-                      <ExperimentPage
-                        application={application}
-                        chrome={chrome}
-                      />
-                    );
-                  }}
-                />
+              <Route
+                path={['/']}
+                render={(props) => {
+                  return (
+                    <>
+                      {versionModal}
+                      {versionToggle}
+
+                      {useOldVersion ? (
+                        <QueryCompareHome
+                          application={application}
+                          parentBreadCrumbs={parentBreadCrumbs}
+                          notifications={notifications}
+                          http={http}
+                          navigation={navigation}
+                          setBreadcrumbs={chrome.setBreadcrumbs}
+                          setToast={setToast}
+                          chrome={chrome}
+                          savedObjects={savedObjects}
+                          dataSourceEnabled={dataSourceEnabled}
+                          dataSourceManagement={dataSourceManagement}
+                          setActionMenu={setActionMenu}
+                        />
+                      ) : (
+                        <ExperimentPage application={application} chrome={chrome} />
+                      )}
+                    </>
+                  );
+                }}
+              />
             </Switch>
           </>
         </SearchRelevanceContextProvider>

--- a/public/components/query_compare/home.tsx
+++ b/public/components/query_compare/home.tsx
@@ -16,7 +16,12 @@ import {
   DataSourceManagementPluginSetup,
 } from '../../../../../src/plugins/data_source_management/public';
 import { NavigationPublicPluginStart } from '../../../../../src/plugins/navigation/public';
-import { QUERY_NUMBER_ONE, QUERY_NUMBER_TWO, ServiceEndpoints } from '../../../common';
+import {
+  INDEX_NODE_API_PATH,
+  QUERY_NUMBER_ONE,
+  QUERY_NUMBER_TWO,
+  SEARCH_PIPELINE_NODE_API_PATH,
+} from '../../../common';
 import '../../ace-themes/sql_console';
 import { useSearchRelevanceContext } from '../../contexts';
 import { DocumentsIndex } from '../../types/index';
@@ -82,9 +87,9 @@ export const Home = ({
   const [shouldShowCreateIndex, setShouldShowCreateIndex] = useState(false);
   const fetchIndexes = (dataConnectionId: string, queryNumber: string) => {
     http
-      .get(`${ServiceEndpoints.GetIndexes}/${dataConnectionId}`)
+      .get(`${INDEX_NODE_API_PATH}/${dataConnectionId}`)
       .then((res: DocumentsIndex[]) => {
-        if (queryNumber == QUERY_NUMBER_ONE) {
+        if (queryNumber === QUERY_NUMBER_ONE) {
           setDocumentsIndexes1(res);
         } else {
           setDocumentsIndexes2(res);
@@ -101,7 +106,7 @@ export const Home = ({
   };
   const fetchPipelines = (dataConnectionId: string, queryNumber: string) => {
     http
-      .get(`${ServiceEndpoints.GetPipelines}/${dataConnectionId}`)
+      .get(`${SEARCH_PIPELINE_NODE_API_PATH}/${dataConnectionId}`)
       .then((res: {}) => {
         if (queryNumber === QUERY_NUMBER_ONE) {
           setFetchedPipelines1(res);

--- a/public/components/query_compare/search_result/index.tsx
+++ b/public/components/query_compare/search_result/index.tsx
@@ -10,7 +10,6 @@ import { CoreStart, MountPoint } from '../../../../../../src/core/public';
 import { DataSourceManagementPluginSetup } from '../../../../../../src/plugins/data_source_management/public';
 import { DataSourceOption } from '../../../../../../src/plugins/data_source_management/public/components/data_source_selector/data_source_selector';
 import { NavigationPublicPluginStart } from '../../../../../../src/plugins/navigation/public';
-import { ServiceEndpoints } from '../../../../common';
 import { useSearchRelevanceContext } from '../../../contexts';
 import {
   QueryError,
@@ -23,6 +22,7 @@ import { Header } from '../../common/header';
 import { ResultComponents } from './result_components/result_components';
 import { SearchInputBar } from './search_components/search_bar';
 import { SearchConfigsPanel } from './search_components/search_configs/search_configs';
+import { SEARCH_NODE_API_PATH } from '../../../../common';
 
 const DEFAULT_QUERY = '{}';
 
@@ -61,7 +61,7 @@ export const SearchResult = ({ application, chrome, http, savedObjects, dataSour
   const HeaderControlledPopoverWrapper = ({ children }: { children: React.ReactElement }) => {
     const HeaderControl = navigation.ui.HeaderControl;
     const getNavGroupEnabled = chrome.navGroup.getNavGroupEnabled();
-  
+
     if (getNavGroupEnabled && HeaderControl) {
       return (
         <HeaderControl
@@ -70,7 +70,7 @@ export const SearchResult = ({ application, chrome, http, savedObjects, dataSour
         />
       );
     }
-  
+
     return <>{children}</>;
   };
 
@@ -158,7 +158,7 @@ export const SearchResult = ({ application, chrome, http, savedObjects, dataSour
     if (Object.keys(requestBody1).length !== 0 || Object.keys(requestBody2).length !== 0) {
         // First Query
         if (Object.keys(requestBody1).length !== 0) {
-            http.post(ServiceEndpoints.GetSearchResults, {
+            http.post(SEARCH_NODE_API_PATH, {
                 body: JSON.stringify({ query1: requestBody1, dataSourceId1: datasource1? datasource1: '' }),
             })
             .then((res) => {
@@ -182,7 +182,7 @@ export const SearchResult = ({ application, chrome, http, savedObjects, dataSour
 
         // Second Query
         if (Object.keys(requestBody2).length !== 0) {
-            http.post(ServiceEndpoints.GetSearchResults, {
+            http.post(SEARCH_NODE_API_PATH, {
                 body: JSON.stringify({ query2: requestBody2, dataSourceId2: datasource2? datasource2: '' }),
             })
             .then((res) => {

--- a/public/services.ts
+++ b/public/services.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { BASE_QUERYSET_NODE_API_PATH } from '../common';
+
+export const postQuerySet = async (id: string, http: any) => {
+  try {
+    return await http.post(`..${BASE_QUERYSET_NODE_API_PATH}`, {
+      body: JSON.stringify({
+        querySetId: id,
+      }),
+    });
+  } catch (e) {
+    return e;
+  }
+};

--- a/server/clusters/index.ts
+++ b/server/clusters/index.ts
@@ -1,0 +1,7 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export * from './search_relevance_plugin';
+export * from './search_relevance_cluster';

--- a/server/clusters/search_relevance_cluster.ts
+++ b/server/clusters/search_relevance_cluster.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { DEFAULT_HEADERS } from '../../common';
+import searchRelevancePlugin from './search_relevance_plugin';
+
+export function createSearchRelevanceCluster(core: any, globalConfig: any) {
+  const { customHeaders, ...rest } = globalConfig.opensearch;
+  return core.opensearch.legacy.createClient('searchRelevance', {
+    plugins: [searchRelevancePlugin],
+    // Currently we are overriding any headers with our own since we explicitly required User-Agent to be OpenSearch Dashboards
+    // for integration with our backend plugin.
+    customHeaders: { ...customHeaders, ...DEFAULT_HEADERS },
+    ...rest,
+  });
+}

--- a/server/clusters/search_relevance_plugin.ts
+++ b/server/clusters/search_relevance_plugin.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { SEARCH_RELEVANCE_QUERY_SET_API } from '../../common';
+
+/**
+ * Register client actions representing search relevance plugin APIs.
+ */
+// eslint-disable-next-line import/no-default-export
+export default function searchRelevancePlugin(Client: any, config: any, components: any) {
+  const ca = components.clientAction.factory;
+
+  Client.prototype.searchRelevance = components.clientAction.namespaceFactory();
+  const searchRelevance = Client.prototype.searchRelevance.prototype;
+
+  searchRelevance.createQuerySet = ca({
+    url: {
+      fmt: `${SEARCH_RELEVANCE_QUERY_SET_API}`,
+    },
+    method: 'POST',
+  });
+}

--- a/server/plugin.ts
+++ b/server/plugin.ts
@@ -9,18 +9,22 @@ import { first } from 'rxjs/operators';
 import {
   CoreSetup,
   CoreStart,
-  ILegacyClusterClient,
   Logger,
   Plugin,
   PluginInitializerContext
 } from '../../../src/core/server';
-import { defineRoutes } from './routes';
+import {
+  defineRoutes,
+  registerSearchRelevanceRoutes,
+  SearchRelevanceRoutesService
+} from './routes';
 
 import { DataSourcePluginSetup } from '../../../src/plugins/data_source/server/types';
 import { DataSourceManagementPlugin } from '../../../src/plugins/data_source_management/public/plugin';
 import { SearchRelevancePluginConfigType } from '../config';
 import { MetricsService, MetricsServiceSetup } from './metrics/metrics_service';
 import { SearchRelevancePluginSetup, SearchRelevancePluginStart } from './types';
+import { createSearchRelevanceCluster } from './clusters/search_relevance_cluster';
 
 export interface SearchRelevancePluginSetupDependencies {
   dataSourceManagement: ReturnType<DataSourceManagementPlugin['setup']>;
@@ -30,11 +34,13 @@ export interface SearchRelevancePluginSetupDependencies {
 export class SearchRelevancePlugin
   implements Plugin<SearchRelevancePluginSetup, SearchRelevancePluginStart>
 {
+  private readonly globalConfig$;
   private readonly config$: Observable<SearchRelevancePluginConfigType>;
   private readonly logger: Logger;
   private metricsService: MetricsService;
 
   constructor(private initializerContext: PluginInitializerContext) {
+    this.globalConfig$ = initializerContext.config.legacy.globalConfig$;
     this.config$ = this.initializerContext.config.create<SearchRelevancePluginConfigType>();
     this.logger = this.initializerContext.logger.get();
     this.metricsService = new MetricsService(this.logger.get('metrics-service'));
@@ -46,6 +52,7 @@ export class SearchRelevancePlugin
     this.logger.debug('SearchRelevance: Setup');
 
     const config: SearchRelevancePluginConfigType = await this.config$.pipe(first()).toPromise();
+    const globalConfig = await this.globalConfig$.pipe(first()).toPromise();
 
     const metricsService: MetricsServiceSetup = this.metricsService.setup(
       config.metrics.metricInterval,
@@ -54,22 +61,26 @@ export class SearchRelevancePlugin
 
     const router = core.http.createRouter();
 
-    let opensearchSearchRelevanceClient: ILegacyClusterClient | undefined = undefined;
-      opensearchSearchRelevanceClient = core.opensearch.legacy.createClient(
-        'opensearch_search_relevance',
-      )
+    const searchRelevanceClient = createSearchRelevanceCluster(core, globalConfig);
 
     // @ts-ignore
     core.http.registerRouteHandlerContext('searchRelevance', (context, request) => {
       return {
         logger: this.logger,
-        relevancyWorkbenchClient: opensearchSearchRelevanceClient,
-        metricsService: metricsService,
+        relevancyWorkbenchClient: searchRelevanceClient,
+        metricsService,
       };
     });
 
+    // Initialize service
+    const searchRelevanceService = new SearchRelevanceRoutesService(
+      searchRelevanceClient,
+      dataSourceEnabled
+    );
+
     // Register server side APIs
-    defineRoutes(router,core.opensearch,dataSourceEnabled);
+    defineRoutes(router, core.opensearch, dataSourceEnabled);
+    registerSearchRelevanceRoutes(router, searchRelevanceService);
 
     return {};
   }

--- a/server/routes/dsl_route.ts
+++ b/server/routes/dsl_route.ts
@@ -6,23 +6,29 @@
 import { RequestParams } from '@opensearch-project/opensearch';
 import { schema } from '@osd/config-schema';
 
-import { ILegacyScopedClusterClient, IRouter, OpenSearchServiceSetup } from '../../../../src/core/server';
-import { SEARCH_API, ServiceEndpoints } from '../../common';
+import { ILegacyScopedClusterClient, IRouter } from '../../../../src/core/server';
+import {
+  INDEX_NODE_API_PATH,
+  SEARCH_API,
+  SEARCH_NODE_API_PATH,
+  SEARCH_PIPELINE_NODE_API_PATH,
+} from '../../common';
 import { METRIC_ACTION, METRIC_NAME } from '../metrics';
 
 interface SearchResultsResponse {
-  result1?: Object;
-  result2?: Object;
-  errorMessage1?: Object;
-  errorMessage2?: Object;
+  result1?: any;
+  result2?: any;
+  errorMessage1?: any;
+  errorMessage2?: any;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 const performance = require('perf_hooks').performance;
 
-export function registerDslRoute(router: IRouter,  openSearchServiceSetup: OpenSearchServiceSetup, dataSourceEnabled: boolean) {
+export function registerDslRoute(router: IRouter, dataSourceEnabled: boolean) {
   router.post(
     {
-      path: ServiceEndpoints.GetSearchResults,
+      path: SEARCH_NODE_API_PATH,
       validate: { body: schema.any() },
     },
     async (context, request, response) => {
@@ -60,7 +66,7 @@ export function registerDslRoute(router: IRouter,  openSearchServiceSetup: OpenS
             resBody.errorMessage1 = {
               statusCode: 400,
               body: 'Invalid Pipepline',
-            }; 
+            };
           }
           if(dataSourceEnabled && dataSourceId1){
             const client = context.dataSource.opensearch.legacy.getClient(dataSourceId1);
@@ -128,7 +134,7 @@ export function registerDslRoute(router: IRouter,  openSearchServiceSetup: OpenS
             resBody.errorMessage1 = {
               statusCode: 400,
               body: 'Invalid Pipepline',
-            }; 
+            };
           }
           if(dataSourceEnabled && dataSourceId2){
             const client = context.dataSource.opensearch.legacy.getClient(dataSourceId2);
@@ -177,7 +183,7 @@ export function registerDslRoute(router: IRouter,  openSearchServiceSetup: OpenS
   // Get Indices
   router.get(
     {
-      path: `${ServiceEndpoints.GetIndexes}/{dataSourceId?}`,
+      path: `${INDEX_NODE_API_PATH}/{dataSourceId?}`,
       validate: {
         params: schema.object({
           dataSourceId: schema.maybe(schema.string({ defaultValue: '' }))
@@ -228,7 +234,7 @@ export function registerDslRoute(router: IRouter,  openSearchServiceSetup: OpenS
   // Get Pipelines
   router.get(
     {
-      path: `${ServiceEndpoints.GetPipelines}/{dataSourceId?}`,
+      path: `${SEARCH_PIPELINE_NODE_API_PATH}/{dataSourceId?}`,
       validate: {
         params: schema.object({
           dataSourceId: schema.maybe(schema.string({ defaultValue: '' }))

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -11,3 +11,5 @@ export function defineRoutes(router: IRouter, openSearchServiceSetup: OpenSearch
   registerDslRoute(router, openSearchServiceSetup, dataSourceEnabled);
   registerMetricsRoute(router);
 }
+
+export * from './search_relevance_rourte_servce';

--- a/server/routes/metrics_route.ts
+++ b/server/routes/metrics_route.ts
@@ -4,12 +4,12 @@
  */
 
 import { IRouter } from '../../../../src/core/server';
-import { ServiceEndpoints } from '../../common';
+import { STATS_NODE_API_PATH } from '../../common';
 
 export function registerMetricsRoute(router: IRouter) {
   router.get(
     {
-      path: ServiceEndpoints.GetStats,
+      path: STATS_NODE_API_PATH,
       validate: false,
     },
     async (context, _, response) => {


### PR DESCRIPTION
### Description
1. Add code formatting
2. Add switch to opt in new version of workbench or stay with old experience
3. Modify the name convention to make backend APIs and node APIs more readable
4. Refactor code to add dashboards-search-relevance plugin to communicate with services - search-relevance


<img width="1199" alt="Screenshot 2025-03-21 at 11 48 24 AM" src="https://github.com/user-attachments/assets/1a0bec28-5715-4121-b439-afdc342eced6" />

### Issues Resolved
https://github.com/o19s/search-relevance/issues/23

### Testing
jest tests should be added components by components, this is a quick example for connector tests, since we don't have any workflows/pages ready yet. 

- under the path `public/components/api`, I created two test page
- QuerySetTester in `app.tsx`
<img width="1167" alt="querySet" src="https://github.com/user-attachments/assets/27b9e334-6b98-45c9-b50c-fe29c0cf2158" />

- GetIndexTester in `app.tsx`
- this API would return a list of indexes available from os cluster, or return the status of a index if indexName is specified.
<img width="1172" alt="getIndex" src="https://github.com/user-attachments/assets/f6a183bc-23d3-4420-a12f-f80d9d86ba72" />




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
