### PR TITLE
Add get query set by id to router

### DIFF
--- a/common/index.ts
+++ b/common/index.ts
@@ -12,7 +12,10 @@ export const SEARCH_RELEVANCE_WORKBENCH = 'Search Relevance Workbench';
  * BACKEND SEARCH RELEVANCE APIs
  */
 export const SEARCH_RELEVANCE_BASE_API = '/_plugins/search_relevance';
-export const SEARCH_RELEVANCE_QUERY_SET_API = `${SEARCH_RELEVANCE_BASE_API}/queryset`;
+export const SEARCH_RELEVANCE_QUERY_SET_API = `${SEARCH_RELEVANCE_BASE_API}/query_sets`;
+export const SEARCH_RELEVANCE_EXPERIMENT_API = `${SEARCH_RELEVANCE_BASE_API}/experiments`;
+export const SEARCH_RELEVANCE_JUDGMENT_API = `${SEARCH_RELEVANCE_BASE_API}/judgments`;
+export const SEARCH_RELEVANCE_SEARCH_CONFIGURATION = `${SEARCH_RELEVANCE_BASE_API}/search_configurations`;
 
 /**
  * OPEN SEARCH CORE APIs
@@ -32,6 +35,11 @@ export const STATS_NODE_API_PATH = `${BASE_NODE_API_PATH}/stats`;
 
 // Search Relevance node APIs
 export const BASE_QUERYSET_NODE_API_PATH = `${BASE_NODE_API_PATH}/queryset`;
+export const BASE_EXPERIMENT_NODE_API_PATH = `${BASE_NODE_API_PATH}/experiment`;
+export const BASE_JUDGMENT_NODE_API_PATH = `${BASE_NODE_API_PATH}/judgment`;
+export const BASE_SEARCH_CONFIG_NODE_API_PATH = `${BASE_NODE_API_PATH}/search_configuration`;
+
+
 
 export const DEFAULT_HEADERS = {
   'Content-Type': 'application/json',

--- a/public/components/api/search_relevance_testing_page.tsx
+++ b/public/components/api/search_relevance_testing_page.tsx
@@ -15,30 +15,50 @@ import {
   EuiCallOut,
   EuiCodeBlock,
 } from '@elastic/eui';
-import { postQuerySet } from '../../services';
+import { postQuerySet, getQuerySets } from '../../services';
 import { CoreStart } from '../../../../../src/core/public';
 
 export interface TestProps {
   http: CoreStart['http'];
 }
 export const QuerySetTester = ({ http }: TestProps) => {
-  const [querySetId, setQuerySetId] = useState('');
-  const [response, setResponse] = useState(null);
-  const [isLoading, setIsLoading] = useState(false);
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [createResponse, setCreateResponse] = useState(null);
+  const [isCreateLoading, setIsCreateLoading] = useState(false);
+
+  const [id, setId] = useState('');
+  const [getResponse, setGetResponse] = useState(null);
+  const [isGetLoading, setIsGetLoading] = useState(false);
   const [error, setError] = useState(null);
 
-  const handleSubmit = async (e) => {
+  const handleCreateSubmit = async (e) => {
     e.preventDefault();
-    setIsLoading(true);
+    setIsCreateLoading(true);
     setError(null);
 
     try {
-      const result = await postQuerySet(querySetId, http);
-      setResponse(result);
+      const postResult = await postQuerySet(name, description, http);
+      setCreateResponse(postResult);
     } catch (err) {
       setError(err.message || 'An error occurred');
     } finally {
-      setIsLoading(false);
+      setIsCreateLoading(false);
+    }
+  };
+
+  const handleGetSubmit = async (e) => {
+    e.preventDefault();
+    setIsGetLoading(true);
+    setError(null);
+
+    try {
+      const listResult = await getQuerySets(id, http);
+      setGetResponse(listResult);
+    } catch (err) {
+      setError(err.message || 'An error occurred');
+    } finally {
+      setIsGetLoading(false);
     }
   };
 
@@ -48,19 +68,43 @@ export const QuerySetTester = ({ http }: TestProps) => {
         <h2>Query Set Tester</h2>
       </EuiText>
       <EuiSpacer size="m" />
-      <EuiForm component="form" onSubmit={handleSubmit}>
-        <EuiFormRow label="Query Set ID:">
+      <EuiForm component="form" onSubmit={handleCreateSubmit}>
+        <EuiFormRow label="Query Set Name:">
           <EuiFieldText
-            placeholder="Enter Query Set ID"
-            value={querySetId}
-            onChange={(e) => setQuerySetId(e.target.value)}
+            placeholder="Enter Query Set Name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            fullWidth
+          />
+        </EuiFormRow>
+        <EuiFormRow label="Query Set Description:">
+          <EuiFieldText
+            placeholder="Enter Query Set Description"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
             fullWidth
           />
         </EuiFormRow>
         <EuiSpacer size="m" />
-        <EuiButton type="submit" fill isLoading={isLoading}>
-          {isLoading ? 'Sending...' : 'Send Request'}
+        <EuiButton type="create submit" fill isCreateLoading={isCreateLoading}>
+          {isCreateLoading ? 'Sending...' : 'Send Create Request'}
         </EuiButton>
+        <EuiSpacer size="m" />
+      </EuiForm>
+      <EuiForm component="form" onSubmit={handleGetSubmit}>
+        <EuiFormRow label="Get Query ID:">
+          <EuiFieldText
+            placeholder="Enter Get Query ID"
+            value={id}
+            onChange={(e) => setId(e.target.value)}
+            fullWidth
+          />
+        </EuiFormRow>
+        <EuiSpacer size="m" />
+        <EuiButton type="get submit" fill isGetLoading={isGetLoading}>
+          {isCreateLoading ? 'Sending...' : 'Send Get Request'}
+        </EuiButton>
+        <EuiSpacer size="m" />
       </EuiForm>
       <EuiSpacer size="l" />
 
@@ -70,14 +114,26 @@ export const QuerySetTester = ({ http }: TestProps) => {
         </EuiCallOut>
       )}
 
-      {response && (
+      {createResponse && (
         <>
           <EuiText>
-            <h3>Response:</h3>
+            <h3>Create Response:</h3>
           </EuiText>
           <EuiSpacer size="s" />
           <EuiCodeBlock language="json" paddingSize="m" isCopyable>
-            {JSON.stringify(response, null, 2)}
+            {JSON.stringify(createResponse, null, 2)}
+          </EuiCodeBlock>
+        </>
+      )}
+
+      {getResponse && (
+        <>
+          <EuiText>
+            <h3>Get Response:</h3>
+          </EuiText>
+          <EuiSpacer size="s" />
+          <EuiCodeBlock language="json" paddingSize="m" isCopyable>
+            {typeof getResponse === 'string' ? getResponse : JSON.stringify(getResponse, null, 2)}
           </EuiCodeBlock>
         </>
       )}

--- a/public/components/app.tsx
+++ b/public/components/app.tsx
@@ -24,6 +24,7 @@ import { PLUGIN_NAME, COMPARE_SEARCH_RESULTS_TITLE } from '../../common';
 import { SearchRelevanceContextProvider } from '../contexts';
 import { Home as QueryCompareHome } from './query_compare/home';
 import { ExperimentPage } from './experiment';
+import QuerySetTester from "./api/search_relevance_testing_page";
 
 interface SearchRelevanceAppDeps {
   notifications: CoreStart['notifications'];
@@ -156,7 +157,7 @@ export const SearchRelevanceApp = ({
                           setActionMenu={setActionMenu}
                         />
                       ) : (
-                        <ExperimentPage application={application} chrome={chrome} />
+                        <QuerySetTester http={http} />
                       )}
                     </>
                   );

--- a/public/services.ts
+++ b/public/services.ts
@@ -5,14 +5,29 @@
 
 import { BASE_QUERYSET_NODE_API_PATH } from '../common';
 
-export const postQuerySet = async (id: string, http: any) => {
+export const postQuerySet = async (name: string, description: string, http: any) => {
   try {
     return await http.post(`..${BASE_QUERYSET_NODE_API_PATH}`, {
       body: JSON.stringify({
-        querySetId: id,
+        name,
+        description,
       }),
     });
   } catch (e) {
+    return e;
+  }
+};
+
+export const getQuerySets = async (id: string, http: any) => {
+  try {
+    const response = await http.get(`..${BASE_QUERYSET_NODE_API_PATH}/${id}`);
+    // Add logging to debug
+    // eslint-disable-next-line no-console
+    console.log('GET Response:', response);
+    return response;
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.error('GET Error:', e);
     return e;
   }
 };

--- a/server/clusters/search_relevance_plugin.ts
+++ b/server/clusters/search_relevance_plugin.ts
@@ -21,4 +21,17 @@ export default function searchRelevancePlugin(Client: any, config: any, componen
     },
     method: 'POST',
   });
+
+  searchRelevance.listQuerySets = ca({
+    url: {
+      fmt: `${SEARCH_RELEVANCE_QUERY_SET_API}/\${id}`,
+      req: {
+        id: {
+          type: 'string',
+          required: true,
+        },
+      },
+    },
+    method: 'GET',
+  });
 }

--- a/server/routes/search_relevance_route_service.ts
+++ b/server/routes/search_relevance_route_service.ts
@@ -49,6 +49,17 @@ export function registerSearchRelevanceRoutes(
     },
     searchRelevanceRoutesService.createQuerySet
   );
+  router.get(
+    {
+      path: `${BASE_QUERYSET_NODE_API_PATH}/{id}`,
+      validate: {
+        params: schema.object({
+          id: schema.string(),
+        }),
+      },
+    },
+    searchRelevanceRoutesService.listQuerySets
+  );
 }
 
 export class SearchRelevanceRoutesService {
@@ -90,6 +101,40 @@ export class SearchRelevanceRoutesService {
       return res.ok({
         body: {
           ok: false,
+          resp: err.message,
+        },
+      });
+    }
+  };
+
+  listQuerySets = async (
+    context: RequestHandlerContext,
+    req: OpenSearchDashboardsRequest,
+    res: OpenSearchDashboardsResponseFactory
+  ): Promise<IOpenSearchDashboardsResponse<any>> => {
+    const { id } = req.params;
+    const { data_source_id = '' } = req.params as { data_source_id?: string };
+    try {
+      const callWithRequest = getClientBasedOnDataSource(
+        context,
+        this.dataSourceEnabled,
+        req,
+        data_source_id,
+        this.client
+      );
+
+      const querysetResponse = await callWithRequest('searchRelevance.listQuerySets', {
+        id,
+      });
+      return res.ok({
+        body: {
+          ok: true,
+          resp: querysetResponse,
+        },
+      });
+    } catch (err) {
+      return res.ok({
+        body: {
           resp: err.message,
         },
       });


### PR DESCRIPTION
### Description
- Update backend API endpoints
- Add a get example to the router

### Test
- spin up the backend cluster with the latest backend branch - https://github.com/o19s/search-relevance/pull/60
  - run `./gradlew run`
- start your frontend server, run `yarn start`

 The QuerySetTest page now support:
- a create button that can create a query set in system index.
- and a get button that can get the query set by the id from system index.

<img width="628" alt="Screenshot 2025-04-07 at 9 22 06 PM" src="https://github.com/user-attachments/assets/3d1e99d6-3252-443f-a59b-31d1391f1951" />
