### PR TITLE
Turn GetSearchResults into a single query endpoint.

### DIFF
--- a/public/components/query_compare/search_result/index.tsx
+++ b/public/components/query_compare/search_result/index.tsx
@@ -159,19 +159,19 @@ export const SearchResult = ({ application, chrome, http, savedObjects, dataSour
         // First Query
         if (Object.keys(requestBody1).length !== 0) {
             http.post(ServiceEndpoints.GetSearchResults, {
-                body: JSON.stringify({ query1: requestBody1, dataSourceId1: datasource1? datasource1: '' }),
+                body: JSON.stringify({ query: requestBody1, dataSourceId: datasource1? datasource1: '' }),
             })
             .then((res) => {
-                if (res.result1) {
-                    setQueryResult1(res.result1);
-                    updateComparedResult1(res.result1);
+                if (res.result) {
+                    setQueryResult1(res.result);
+                    updateComparedResult1(res.result);
                 }
 
-                if (res.errorMessage1) {
+                if (res.errorMessage) {
                     setQueryError1((error: QueryError) => ({
                         ...error,
-                        queryString: res.errorMessage1,
-                        errorResponse: res.errorMessage1,
+                        queryString: res.errorMessage,
+                        errorResponse: res.errorMessage,
                     }));
                 }
             })
@@ -183,19 +183,19 @@ export const SearchResult = ({ application, chrome, http, savedObjects, dataSour
         // Second Query
         if (Object.keys(requestBody2).length !== 0) {
             http.post(ServiceEndpoints.GetSearchResults, {
-                body: JSON.stringify({ query2: requestBody2, dataSourceId2: datasource2? datasource2: '' }),
+                body: JSON.stringify({ query: requestBody2, dataSourceId: datasource2? datasource2: '' }),
             })
             .then((res) => {
-                if (res.result2) {
-                    setQueryResult2(res.result2);
-                    updateComparedResult2(res.result2);
+                if (res.result) {
+                    setQueryResult2(res.result);
+                    updateComparedResult2(res.result);
                 }
 
-                if (res.errorMessage2) {
+                if (res.errorMessage) {
                     setQueryError2((error: QueryError) => ({
                         ...error,
-                        queryString: res.errorMessage2,
-                        errorResponse: res.errorMessage2,
+                        queryString: res.errorMessage,
+                        errorResponse: res.errorMessage,
                     }));
                 }
             })

--- a/server/metrics/index.ts
+++ b/server/metrics/index.ts
@@ -17,7 +17,6 @@ export enum METRIC_NAME {
 }
 
 export enum METRIC_ACTION {
-  COMPARISON_SEARCH = 'comparison_search',
   SINGLE_SEARCH = 'single_search',
   FETCH_INDEX = 'fetch_index',
   FETCH_PIPELINE = 'fetch_pipeline',


### PR DESCRIPTION
### Description
The `GetSearchResults` endpoint takes two search queries as inputs. This makes the endpoint unnecessarily redundant while offering no advantages. This PR turns the search endpoint into a single query endpoint and updates the client accordingly.

Notes:
 * Index name validation does not reject `:` to support cross clusters.
 * Error return conventions have not been changed.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
