### PR TITLE
Fix schema validation in POST Query Sets endpoint

### DIFF
--- a/server/routes/search_relevance_route_service.ts
+++ b/server/routes/search_relevance_route_service.ts
@@ -22,6 +22,7 @@ export function registerSearchRelevanceRoutes(router: IRouter): void {
           name: schema.string(),
           description: schema.string(),
           sampling: schema.string(),
+          querySetSize: schema.number(),
         }),
       },
     },


### PR DESCRIPTION
### Description
POST Query Sets endpoint was missing querySetSize in its schema validation spec.

### Issues Resolved
https://github.com/opensearch-project/dashboards-search-relevance/issues/541

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
