### PR TITLE
Simplify entering queries by supporting plain text

### DIFF
--- a/public/components/query_set_create/query_set_create.tsx
+++ b/public/components/query_set_create/query_set_create.tsx
@@ -387,7 +387,7 @@ export const QuerySetCreate: React.FC<QuerySetCreateProps> = ({ http, notificati
                     label="Upload Queries"
                     error={manualQueriesError}
                     isInvalid={Boolean(manualQueriesError)}
-                    helpText="Upload an NDJSON file with queries (one JSON object per line containing queryText and referenceAnswer)"
+                    helpText={`Upload an NDJSON file with queries (one JSON object per line). Example: {"queryText": "what is opensearch?", "referenceAnswer": "optional reference"}`}
                     fullWidth
                   >
                     <EuiFlexGroup>
@@ -402,7 +402,7 @@ export const QuerySetCreate: React.FC<QuerySetCreateProps> = ({ http, notificati
                           accept=".txt"
                           data-test-subj="manualQueriesFilePicker"
                           compressed
-                          helpText="Upload a text file containing JSON objects (one per line) with queryText and referenceAnswer fields"
+                          helpText={`Each line should be a JSON object with queryText and optionally referenceAnswer. Example: {"queryText": "what is opensearch?"}`}
                         />
                       </EuiFlexItem>
                     </EuiFlexGroup>


### PR DESCRIPTION
### Description
This adds an additional toggle so you can either upload a file with queries, or you can plain text query per line, and the front end converts to the appropriate json data structure.  Makes it easier to quickly add some queries.


<img width="513" alt="image" src="https://github.com/user-attachments/assets/36237053-576f-47de-9444-08a4fbe0a3f2" />


### Issues Resolved
n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
