### PR TITLE
Fetch models from ml-commons and add validation

### DIFF
--- a/common/index.ts
+++ b/common/index.ts
@@ -19,6 +19,7 @@ export const ServiceEndpoints = Object.freeze({
   GetSingleSearchResults: `${SEARCH_RELEVANCE_WORKBENCH_BASE_PATH}/single_search`,
   GetStats: `${SEARCH_RELEVANCE_WORKBENCH_BASE_PATH}/stats`,
   GetClusterSettings: `${SEARCH_RELEVANCE_WORKBENCH_BASE_PATH}/cluster_settings`,
+  GetModels: `${SEARCH_RELEVANCE_WORKBENCH_BASE_PATH}/models`,
 
   // Search Relevance node APIs
   QuerySets: `${SEARCH_RELEVANCE_WORKBENCH_BASE_PATH}/query_sets`,
@@ -34,6 +35,9 @@ export const BackendEndpoints = Object.freeze({
   Judgments: `${SEARCH_RELEVANCE_PLUGIN_BASE_PATH}/judgments`,
   Experiments: `${SEARCH_RELEVANCE_PLUGIN_BASE_PATH}/experiments`,
 } as const);
+
+const ML_COMMON_PLUGIN_BASE_PATH = '_plugins/_ml';
+export const ML_MODEL_ROUTE_PREFIX = `${ML_COMMON_PLUGIN_BASE_PATH}/models`;
 
 export const SEARCH_API = '/_search';
 
@@ -58,7 +62,9 @@ export enum Routes {
   ExperimentCreateQuerySetComparison = `/experiment/create/${RouteTemplateType.QuerySetComparison}`,
   ExperimentCreateSearchEvaluation = `/experiment/create/${RouteTemplateType.SearchEvaluation}`,
   ExperimentCreateHybridOptimizer = `/experiment/create/${RouteTemplateType.HybridOptimizer}`,
-  ExperimentCreateTemplate = `/experiment/create/:templateId(${Object.values(RouteTemplateType).join('|')})`,
+  ExperimentCreateTemplate = `/experiment/create/:templateId(${Object.values(
+    RouteTemplateType
+  ).join('|')})`,
   QuerySetListing = '/querySet',
   QuerySetView = '/querySet/view/:entityId',
   QuerySetViewPrefix = '/querySet/view',

--- a/server/metrics/index.ts
+++ b/server/metrics/index.ts
@@ -22,4 +22,5 @@ export enum METRIC_ACTION {
   FETCH_INDEX = 'fetch_index',
   FETCH_PIPELINE = 'fetch_pipeline',
   FETCH_CLUSTER_SETTINGS = 'fetch_cluster_settings',
+  FETCH_MODEL = 'fetch_model',
 }

--- a/server/plugin.ts
+++ b/server/plugin.ts
@@ -23,6 +23,7 @@ import { SearchRelevancePluginConfigType } from '../config';
 import { MetricsService, MetricsServiceSetup } from './metrics/metrics_service';
 import { SearchRelevancePluginSetup, SearchRelevancePluginStart } from './types';
 import { SEARCH_RELEVANCE_EXPERIMENTAL_WORKBENCH_UI_EXPERIENCE_ENABLED } from '../common';
+import { registerMLRoutes } from './routes/ml_route_service';
 
 export interface SearchRelevancePluginSetupDependencies {
   dataSourceManagement: ReturnType<DataSourceManagementPlugin['setup']>;
@@ -81,6 +82,7 @@ export class SearchRelevancePlugin
     // Register server side APIs
     defineRoutes(router, core.opensearch, dataSourceEnabled);
     registerSearchRelevanceRoutes(router);
+    registerMLRoutes(router, dataSourceEnabled);
 
     return {};
   }

--- a/server/routes/dsl_route.ts
+++ b/server/routes/dsl_route.ts
@@ -7,10 +7,7 @@ import { RequestParams } from '@opensearch-project/opensearch';
 import { schema } from '@osd/config-schema';
 
 import { ILegacyScopedClusterClient, IRouter } from '../../../../src/core/server';
-import {
-  ServiceEndpoints,
-  SEARCH_API,
-} from '../../common';
+import { ServiceEndpoints, SEARCH_API } from '../../common';
 import { METRIC_ACTION, METRIC_NAME } from '../metrics';
 
 interface SearchResultsResponse {
@@ -136,8 +133,13 @@ export function registerDslRoute(router: IRouter, dataSourceEnabled: boolean) {
         try {
           let resp;
           const invalidCharactersPattern = /[\s,\"*+\/\\|?#><]/;
-          if (index !== index.toLowerCase() || index.startsWith('_') || index.startsWith('-') || invalidCharactersPattern.test(index)) {
-            throw new Error("Index invalid or missing.");
+          if (
+            index !== index.toLowerCase() ||
+            index.startsWith('_') ||
+            index.startsWith('-') ||
+            invalidCharactersPattern.test(index)
+          ) {
+            throw new Error('Index invalid or missing.');
           }
           if (
             pipeline !== '*' &&
@@ -214,21 +216,22 @@ export function registerDslRoute(router: IRouter, dataSourceEnabled: boolean) {
           callApi = context.core.opensearch.legacy.client.callAsCurrentUser;
         }
         let resp = await callApi('cat.indices', params);
-        const remoteConnections = await callApi('transport.request',{
+        const remoteConnections = await callApi('transport.request', {
           method: 'GET',
-          path: "/_remote/info",
+          path: '/_remote/info',
         });
-        if (Object.keys(remoteConnections).length > 0) { // fetch remote indices if remote clusters exist
+        if (Object.keys(remoteConnections).length > 0) {
+          // fetch remote indices if remote clusters exist
           const remoteClusters = Object.keys(remoteConnections)
             .map((key) => `${key}:*`)
             .join(',');
-          const resolveResponse = await callApi('transport.request',{
+          const resolveResponse = await callApi('transport.request', {
             method: 'GET',
             path: `/_resolve/index/${remoteClusters}`,
           });
           let remoteIndices = resolveResponse.indices.map((item: { name: string }) => ({
             index: item.name,
-            format: 'json'
+            format: 'json',
           }));
           resp = resp.concat(remoteIndices);
         }
@@ -368,8 +371,12 @@ export function registerDslRoute(router: IRouter, dataSourceEnabled: boolean) {
 
   router.get(
     {
-      path: ServiceEndpoints.GetClusterSettings,
-      validate: {},
+      path: `${ServiceEndpoints.GetClusterSettings}/{dataSourceId?}`,
+      validate: {
+        params: schema.object({
+          dataSourceId: schema.maybe(schema.string({ defaultValue: '' })),
+        }),
+      },
     },
     async (context, request, response) => {
       const params = {
@@ -379,7 +386,8 @@ export function registerDslRoute(router: IRouter, dataSourceEnabled: boolean) {
       try {
         let callApi: ILegacyScopedClusterClient['callAsCurrentUser'];
         if (dataSourceEnabled && request.params.dataSourceId) {
-          callApi = context.dataSource.opensearch.legacy.getClient(request.params.dataSourceId).callAPI;
+          callApi = context.dataSource.opensearch.legacy.getClient(request.params.dataSourceId)
+            .callAPI;
         } else {
           callApi = context.core.opensearch.legacy.client.callAsCurrentUser;
         }

--- a/server/routes/ml_route_service.ts
+++ b/server/routes/ml_route_service.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { schema } from '@osd/config-schema';
+import {
+  ILegacyScopedClusterClient,
+  IOpenSearchDashboardsResponse,
+  IRouter,
+  OpenSearchDashboardsRequest,
+  OpenSearchDashboardsResponseFactory,
+  RequestHandlerContext,
+} from '../../../../src/core/server';
+import { ML_MODEL_ROUTE_PREFIX, SEARCH_API, ServiceEndpoints } from '../../common';
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const performance = require('perf_hooks').performance;
+
+export function registerMLRoutes(router: IRouter, dataSourceEnabled: boolean) {
+  router.post(
+    {
+      path: `${ServiceEndpoints.GetModels}/{dataSourceId?}`,
+      validate: {
+        params: schema.object({
+          dataSourceId: schema.maybe(schema.string({ defaultValue: '' })),
+        }),
+      },
+    },
+    backendAction('POST', `${ML_MODEL_ROUTE_PREFIX}${SEARCH_API}`, dataSourceEnabled)
+  );
+}
+
+const backendAction = (method, path, dataSourceEnabled) => {
+  return async (
+    context: RequestHandlerContext,
+    request: OpenSearchDashboardsRequest,
+    response: OpenSearchDashboardsResponseFactory
+  ): Promise<IOpenSearchDashboardsResponse<any>> => {
+    try {
+      const dataSourceId = request.params.dataSourceId;
+      let callApi: ILegacyScopedClusterClient['callAsCurrentUser'];
+      if (dataSourceEnabled && dataSourceId) {
+        callApi = context.dataSource.opensearch.legacy.getClient(dataSourceId).callAPI;
+      } else {
+        callApi = context.core.opensearch.legacy.client.callAsCurrentUser;
+      }
+      const resp = await callApi('transport.request', {
+        method,
+        path,
+        body: {
+          query: {
+            match_all: {},
+          },
+        },
+      });
+      return response.ok({
+        body: resp,
+      });
+    } catch (err) {
+      console.error('Failed to call ml-commons APIs', err);
+      return response.customError({
+        statusCode: err.statusCode || 500,
+        body: {
+          message: err.message,
+          attributes: {
+            error: err.body?.error || err.message,
+          },
+        },
+      });
+    }
+  };
+};

--- a/server/routes/ml_route_service.ts
+++ b/server/routes/ml_route_service.ts
@@ -52,6 +52,7 @@ const backendAction = (method, path, dataSourceEnabled) => {
           query: {
             match_all: {},
           },
+          size: 1000,
         },
       });
       return response.ok({


### PR DESCRIPTION
### Description

LLM-as-a-Judge refers to the practice of using a Large Language Model (LLM) to evaluate the search performance/relevancy by generating judgment rating scores. The LLM remote model now being setup with ml-commons plugin.

### **Before**
- As a customer, I need to manual input the model_id that I created with ml-commons to the judgment creation page

### **After**
- As a customer, as long as I have remote model created and deployed with ml-commons, I then should be able to select the model_id from the dropdown box.

### Major change
- Added ml service to take requests to list model_id registered with ml-commons.
- Added filter to list out only `REMOTE` and `DEPLOYED` models
- Modify the judgment creation page to take model id as a selectable dropdown instead of input box.


### Issues Resolved
#554 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
