### PR TITLE
Adding @fen-qin and @epugh as maintainers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # This should match the list of maintainers in https://github.com/opensearch-project/dashboards-search-relevance/blob/main/MAINTAINERS.md
-*   @macohen @mingshl @msfroh @noCharger @sejli @sumukhswamy
+*   @macohen @mingshl @msfroh @noCharger @sejli @sumukhswamy @fen-qin @epugh

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -12,3 +12,5 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Louis Chu    | [noCharger](https://github.com/noCharger) | Amazon  |
 | Sean Li      | [sejli](https://github.com/sejli)     | Amazon |
 | Sumukh Swamy | [sumukhswamy](https://github.com/sumukhswamy) | Amazon |
+| Fen Qin      | [fen-qin](https://github.com/fen-qin) | Amazon      |
+| Eric Pugh    | [epugh](https://github.com/epugh)     | OpenSource Connections |


### PR DESCRIPTION
### Description

Adds @fen-qin and @epugh as maintainers. Thanks so much for the contributions!

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
