### PR TITLE
Remove ids from experiment table and link type instead

### DIFF
--- a/public/components/experiment_listing/experiment_listing.tsx
+++ b/public/components/experiment_listing/experiment_listing.tsx
@@ -71,34 +71,23 @@ export const ExperimentListing: React.FC<ExperimentListingProps> = ({ http, hist
   // Column definitions
   const tableColumns = [
     {
-      field: 'id',
-      name: 'ID',
-      dataType: 'string',
-      sortable: true,
-      render: (
-        id: string,
-        experiment: {
-          id: string;
-        }
-      ) => (
-        <>
-          <EuiButtonEmpty
-            size="xs"
-            {...reactRouterNavigate(history, `${Routes.ExperimentViewPrefix}/${experiment.id}`)}
-          >
-            {id}
-          </EuiButtonEmpty>
-        </>
-      ),
-    },
-    {
       field: 'type',
       name: 'Experiment Type',
       dataType: 'string',
       sortable: true,
-      render: (type: string) => {
-        return <EuiText size="s">{printType(type)}</EuiText>;
-      },
+      render: (
+        type: string,
+        experiment: {
+          id: string;
+        }
+      ) => (
+        <EuiButtonEmpty
+          size="xs"
+          {...reactRouterNavigate(history, `${Routes.ExperimentViewPrefix}/${experiment.id}`)}
+        >
+          {printType(type)}
+        </EuiButtonEmpty>
+      ),
     },
     {
       field: 'status',

--- a/public/components/experiment_listing/experiment_listing.tsx
+++ b/public/components/experiment_listing/experiment_listing.tsx
@@ -41,6 +41,8 @@ export const ExperimentListing: React.FC<ExperimentListingProps> = ({ http, hist
   const [experimentToDelete, setExperimentToDelete] = useState<any>(null);
   const [refreshKey, setRefreshKey] = useState(0);
 
+  const DISABLED_BACKEND_PLUGIN_MESSAGE = 'Search Relevance Workbench is disabled';
+
   // Handle delete function
   const handleDelete = async () => {
     setIsLoading(true);
@@ -166,8 +168,16 @@ export const ExperimentListing: React.FC<ExperimentListingProps> = ({ http, hist
         hits: filteredList,
       };
     } catch (err) {
-      console.error('Failed to load experiment', err);
-      setError('Failed to load experiments');
+      console.error('Failed to load experiments', err);
+      if (err.body && err.body.message === DISABLED_BACKEND_PLUGIN_MESSAGE) {
+        setError(DISABLED_BACKEND_PLUGIN_MESSAGE + '. Please activate the backend plugin.');
+      } else if (err.body && err.body.message) {
+        setError(err.body.message);
+      } else if (err.message) {
+        setError(err.message);
+      } else {
+        setError('Failed to load experiments due to an unknown error.');
+      }
       return {
         total: 0,
         hits: [],

--- a/public/components/judgment_listing/judgment_listing.tsx
+++ b/public/components/judgment_listing/judgment_listing.tsx
@@ -38,6 +38,8 @@ export const JudgmentListing: React.FC<JudgmentListingProps> = ({ http, history 
   const [judgmentToDelete, setJudgmentToDelete] = useState<any>(null);
   const [refreshKey, setRefreshKey] = useState(0);
 
+  const DISABLED_BACKEND_PLUGIN_MESSAGE = 'Search Relevance Workbench is disabled';
+
   // Handle delete function
   const handleDelete = async () => {
     setIsLoading(true);
@@ -142,8 +144,16 @@ export const JudgmentListing: React.FC<JudgmentListingProps> = ({ http, history 
         hits: filteredList,
       };
     } catch (err) {
-      console.error('Failed to list judgment', err);
-      setError('Failed to load judgments');
+      console.error('Failed to load judgment lists', err);
+      if (err.body && err.body.message === DISABLED_BACKEND_PLUGIN_MESSAGE) {
+        setError(DISABLED_BACKEND_PLUGIN_MESSAGE + '. Please activate the backend plugin.');
+      } else if (err.body && err.body.message) {
+        setError(err.body.message);
+      } else if (err.message) {
+        setError(err.message);
+      } else {
+        setError('Failed to load judgment lists due to an unknown error.');
+      }
       return {
         total: 0,
         hits: [],

--- a/public/components/query_set_listing/query_set_listing.tsx
+++ b/public/components/query_set_listing/query_set_listing.tsx
@@ -40,6 +40,8 @@ export const QuerySetListing: React.FC<QuerySetListingProps> = ({ http, history 
   const [querySetToDelete, setQuerySetToDelete] = useState<any>(null);
   const [refreshKey, setRefreshKey] = useState(0);
 
+  const DISABLED_BACKEND_PLUGIN_MESSAGE = 'Search Relevance Workbench is disabled';
+
   // Handle delete function
   const handleDelete = async () => {
     setIsLoading(true);
@@ -158,8 +160,16 @@ export const QuerySetListing: React.FC<QuerySetListingProps> = ({ http, history 
         hits: filteredList,
       };
     } catch (err) {
-      console.error('Failed to load query set', err);
-      setError('Failed to load query sets');
+      console.error('Failed to load query sets', err);
+      if (err.body && err.body.message === DISABLED_BACKEND_PLUGIN_MESSAGE) {
+        setError(DISABLED_BACKEND_PLUGIN_MESSAGE + '. Please activate the backend plugin.');
+      } else if (err.body && err.body.message) {
+        setError(err.body.message);
+      } else if (err.message) {
+        setError(err.message);
+      } else {
+        setError('Failed to load query sets due to an unknown error.');
+      }
       return {
         total: 0,
         hits: [],

--- a/public/components/search_config_listing/search_config_listing.tsx
+++ b/public/components/search_config_listing/search_config_listing.tsx
@@ -42,6 +42,8 @@ export const SearchConfigurationListing: React.FC<SearchConfigurationListingProp
 
   const [refreshKey, setRefreshKey] = useState(0);
 
+  const DISABLED_BACKEND_PLUGIN_MESSAGE = 'Search Relevance Workbench is disabled';
+
   // Column definitions
   // TODO: extend the table columns by adding search_pipeline & search_template once they
   // are available
@@ -177,8 +179,16 @@ export const SearchConfigurationListing: React.FC<SearchConfigurationListingProp
         hits: filteredList,
       };
     } catch (err) {
-      console.error('Failed to load search config', err);
-      setError('Failed to load search configurations');
+      console.error('Failed to load search configurations', err);
+      if (err.body && err.body.message === DISABLED_BACKEND_PLUGIN_MESSAGE) {
+        setError(DISABLED_BACKEND_PLUGIN_MESSAGE + '. Please activate the backend plugin.');
+      } else if (err.body && err.body.message) {
+        setError(err.body.message);
+      } else if (err.message) {
+        setError(err.message);
+      } else {
+        setError('Failed to load search configurations due to an unknown error.');
+      }
       return {
         total: 0,
         hits: [],

--- a/server/routes/search_relevance_route_service.ts
+++ b/server/routes/search_relevance_route_service.ts
@@ -13,6 +13,8 @@ import {
 } from '../../../../src/core/server';
 import { ServiceEndpoints, BackendEndpoints } from '../../common';
 
+const DISABLED_BACKEND_PLUGIN_MESSAGE = 'Search Relevance Workbench is disabled';
+
 export function registerSearchRelevanceRoutes(router: IRouter): void {
   router.post(
     {
@@ -258,13 +260,44 @@ const backendAction = (method, path) => {
 
       return res.ok({ body: response });
     } catch (err) {
-      console.error('Failed to call search-relevance APIs', err);
+      console.error('Failed to call search-relevance APIs', err); // Keep for full server-side logging
+
+      let clientMessage = err.message; // Default to the err.message from transport.request
+      let clientAttributesError = err.body?.error || err.message; // Default attributes error
+
+      // Check if the backend error body contains the specific message
+      // This is the crucial part that extracts the "Search Relevance Workbench is disabled"
+      if (err.body && typeof err.body === 'string' && err.body.includes(DISABLED_BACKEND_PLUGIN_MESSAGE)) {
+          clientMessage = DISABLED_BACKEND_PLUGIN_MESSAGE;
+          clientAttributesError = DISABLED_BACKEND_PLUGIN_MESSAGE;
+      }
+      // If the backend error body is a JSON object with a message/reason
+      else if (err.body && typeof err.body === 'object') {
+          // Check for common backend error formats
+          if (err.body.message && typeof err.body.message === 'string' && err.body.message.includes(DISABLED_BACKEND_PLUGIN_MESSAGE)) {
+              clientMessage = DISABLED_BACKEND_PLUGIN_MESSAGE;
+              clientAttributesError = DISABLED_BACKEND_PLUGIN_MESSAGE;
+          } else if (err.body.reason && typeof err.body.reason === 'string' && err.body.reason.includes(DISABLED_BACKEND_PLUGIN_MESSAGE)) {
+              clientMessage = DISABLED_BACKEND_PLUGIN_MESSAGE;
+              clientAttributesError = DISABLED_BACKEND_PLUGIN_MESSAGE;
+          } else if (err.body.error && typeof err.body.error === 'object' && err.body.error.reason && typeof err.body.error.reason === 'string' && err.body.error.reason.includes(DISABLED_BACKEND_PLUGIN_MESSAGE)) {
+              clientMessage = DISABLED_BACKEND_PLUGIN_MESSAGE;
+              clientAttributesError = DISABLED_BACKEND_PLUGIN_MESSAGE;
+          }
+          // Fallback if specific message not found in complex body, but body has a message
+          else if (err.body.message && typeof err.body.message === 'string') {
+              clientMessage = err.body.message;
+              clientAttributesError = err.body.message;
+          }
+      }
+
+
       return res.customError({
         statusCode: err.statusCode || 500,
         body: {
-          message: err.message,
+          message: clientMessage, // Use the determined message
           attributes: {
-            error: err.body?.error || err.message,
+            error: clientAttributesError, // Use the determined attributes error
           },
         },
       });


### PR DESCRIPTION
### Description
From a user experience point of view the least meaningful part of an experiment is shown first in the table and it's the element linked to get to the experiment results.
This PR removes the id column and links the most meaningful part of the experiment instead: the experiment type.

### Issues Resolved
Partially addresses #556 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
