### PR TITLE
Remove ids from experiment table and link type instead

### DIFF
--- a/public/components/experiment_listing/experiment_listing.tsx
+++ b/public/components/experiment_listing/experiment_listing.tsx
@@ -69,34 +69,23 @@ export const ExperimentListing: React.FC<ExperimentListingProps> = ({ http, hist
   // Column definitions
   const tableColumns = [
     {
-      field: 'id',
-      name: 'ID',
-      dataType: 'string',
-      sortable: true,
-      render: (
-        id: string,
-        experiment: {
-          id: string;
-        }
-      ) => (
-        <>
-          <EuiButtonEmpty
-            size="xs"
-            {...reactRouterNavigate(history, `${Routes.ExperimentViewPrefix}/${experiment.id}`)}
-          >
-            {id}
-          </EuiButtonEmpty>
-        </>
-      ),
-    },
-    {
       field: 'type',
       name: 'Experiment Type',
       dataType: 'string',
       sortable: true,
-      render: (type: string) => {
-        return <EuiText size="s">{printType(type)}</EuiText>;
-      },
+      render: (
+        type: string,
+        experiment: {
+          id: string;
+        }
+      ) => (
+        <EuiButtonEmpty
+          size="xs"
+          {...reactRouterNavigate(history, `${Routes.ExperimentViewPrefix}/${experiment.id}`)}
+        >
+          {printType(type)}
+        </EuiButtonEmpty>
+      ),
     },
     {
       field: 'status',


### PR DESCRIPTION
### Description
From a user experience point of view the least meaningful part of an experiment is shown first in the table and it's the element linked to get to the experiment results.
This PR removes the id column and links the most meaningful part of the experiment instead: the experiment type.

### Issues Resolved
Partially addresses #556  

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
