### PR TITLE
add tooltips for change-based metrics

### DIFF
--- a/common/index.ts
+++ b/common/index.ts
@@ -72,3 +72,9 @@ export enum Routes {
   JudgmentViewPrefix = '/judgment/view',
   JudgmentCreate = '/judgment/create',
 }
+
+// tool tip texts
+export const JACCARD_TOOL_TIP = 'Jaccard index measures the similarity between two sets of documents, defined as the size of the intersection divided by the size of the union of the sets. A higher value indicates greater overlap.';
+export const RBO50_TOOL_TIP = 'Rank-Biased Overlap (RBO) measures the similarity of two ranked lists. A higher value indicates more similar rankings, especially at the top. rbo90 stands for a 90% chance a hypothetical user continues to the next rank. The lower the number the stronger the top ranks are weighted.';
+export const RBO90_TOOL_TIP = 'Rank-Biased Overlap (RBO) measures the similarity of two ranked lists. A higher value indicates more similar rankings, especially at the top. rbo50 stands for a 50% chance a hypothetical user continues to the next rank. The lower the number the stronger the top ranks are weighted.';
+export const FREQUENCY_WEIGHTED_TOOL_TIP = 'frequencyWeighted measures the similarity of two sets of documents without duplicates. It gives higher weights to documents occurring in both result lists.';

--- a/public/components/experiment_view/metrics_summary.tsx
+++ b/public/components/experiment_view/metrics_summary.tsx
@@ -10,9 +10,16 @@ import {
   EuiStat,
   EuiTitle,
   EuiHorizontalRule,
+  EuiToolTip,
 } from '@elastic/eui';
 import React from 'react';
 import { MetricsCollection } from '../../types/index';
+import {
+  JACCARD_TOOL_TIP,
+  RBO50_TOOL_TIP,
+  RBO90_TOOL_TIP,
+  FREQUENCY_WEIGHTED_TOOL_TIP
+} from '../../../common/index';
 
 interface MetricsSummaryPanelProps {
   metrics: MetricsCollection;
@@ -24,6 +31,13 @@ export const MetricsSummaryPanel: React.FC<MetricsSummaryPanelProps> = ({ metric
     // Calculate average of the values
     const avg = values.reduce((sum, val) => sum + val, 0) / values.length;
     return avg.toFixed(2).replace(/\.00$/, '');
+  };
+  // tool tip texts
+  const metricDescriptions: { [key: string]: string } = {
+    jaccard: JACCARD_TOOL_TIP,
+    rbo50: RBO50_TOOL_TIP,
+    rbo90: RBO90_TOOL_TIP,
+    frequencyWeighted: FREQUENCY_WEIGHTED_TOOL_TIP,
   };
 
   // Get metric keys from the first element if available
@@ -40,7 +54,16 @@ export const MetricsSummaryPanel: React.FC<MetricsSummaryPanelProps> = ({ metric
           <EuiFlexItem grow={2} key={metricKey}>
             <EuiStat
               title={formatValue(metrics.map((m) => m[metricKey]))}
-              description={metricKey}
+              description={
+                <EuiToolTip
+                  content={
+                    metricDescriptions[metricKey] ||
+                    `No description available for ${metricKey}`
+                  }
+                >
+                  <span>{metricKey}</span>
+                </EuiToolTip>
+              }
               titleSize="l"
             />
           </EuiFlexItem>

--- a/public/components/experiment_view/pairwise_experiment_view.tsx
+++ b/public/components/experiment_view/pairwise_experiment_view.tsx
@@ -12,6 +12,7 @@ import {
   EuiDescriptionListTitle,
   EuiDescriptionListDescription,
   EuiSpacer,
+  EuiToolTip
 } from '@elastic/eui';
 import React, { useCallback, useEffect, useState } from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
@@ -35,6 +36,12 @@ import {
   combineResults,
 } from '../../types/index';
 import { MetricsSummaryPanel } from './metrics_summary';
+import {
+  JACCARD_TOOL_TIP,
+  RBO50_TOOL_TIP,
+  RBO90_TOOL_TIP,
+  FREQUENCY_WEIGHTED_TOOL_TIP
+} from '../../../common/index';
 
 interface PairwiseExperimentViewProps extends RouteComponentProps<{ id: string }> {
   http: CoreStart['http'];
@@ -134,10 +141,12 @@ export const PairwiseExperimentView: React.FC<PairwiseExperimentViewProps> = ({
   useEffect(() => {
     if (experiment) {
       const metricNames = extractMetricNames(queryEvaluations);
-
-      const cheatColNames = {
-        rbo90: 'RBO@' + experiment.k,
-        jaccard: 'Jaccard@' + experiment.k,
+      // metric tool tip texts
+      const metricDescriptions: { [key: string]: string } = {
+        jaccard: JACCARD_TOOL_TIP,
+        rbo50: RBO50_TOOL_TIP,
+        rbo90: RBO90_TOOL_TIP,
+        frequencyWeighted: FREQUENCY_WEIGHTED_TOOL_TIP,
       };
 
       const columns = [
@@ -163,7 +172,14 @@ export const PairwiseExperimentView: React.FC<PairwiseExperimentViewProps> = ({
       metricNames.forEach((metricName) => {
         columns.push({
           field: 'metrics.' + metricName,
-          name: metricName + '@' + experiment.size,
+          name: (
+            <EuiToolTip
+              content={
+                metricDescriptions[metricName] ||
+                `No description available for ${metricName}`}>
+              <span>{metricName + '@' + experiment.size}</span>
+            </EuiToolTip>
+          ),
           dataType: 'number',
           sortable: true,
           render: (value) => {


### PR DESCRIPTION
### Description
This change adds tooltips for the change-based metrics we show on the pairwise comparison experiment page. The aim is to increase clarity on what the different metrics measure.

### Issues Resolved
n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
