### PR TITLE
query_set_create code refactor + unit tests

### DIFF
--- a/.github/workflows/remote-integ-tests-workflow.yml
+++ b/.github/workflows/remote-integ-tests-workflow.yml
@@ -93,10 +93,10 @@ jobs:
 
       - name: Wait OpenSearch Dashboards Compiled Completed
         run: |
-          if timeout 900 grep -q "bundles compiled successfully after" <(tail -n0 -f dashboard.log); then
+          if timeout 1200 grep -q "bundles compiled successfully after" <(tail -n0 -f dashboard.log); then
             echo "OpenSearch Dashboards compiled successfully."
           else
-            echo "Timeout for 900 seconds reached. OpenSearch Dashboards did not finish compiling."
+            echo "Timeout for 1200 seconds reached. OpenSearch Dashboards did not finish compiling."
             exit 1
           fi
         working-directory: OpenSearch-Dashboards

--- a/public/components/query_set_create/README.md
+++ b/public/components/query_set_create/README.md
@@ -1,0 +1,78 @@
+# Query Set Create - Refactored Structure
+
+This directory contains the refactored Query Set Create component with separated concerns for better maintainability and testability.
+
+## Structure
+
+```
+query_set_create/
+├── components/           # UI Components
+│   ├── query_set_form.tsx    # Form component for query set fields
+│   └── query_preview.tsx     # Preview component for parsed queries
+├── hooks/               # Custom React Hooks
+│   └── use_query_set_form.ts # Form state management hook
+├── services/            # API Service Layer
+│   └── query_set_service.ts  # Query set API operations
+├── utils/               # Business Logic Utilities
+│   ├── validation.ts         # Form validation logic
+│   └── file_processor.ts     # File processing utilities
+├── __tests__/           # Unit Tests
+│   ├── validation.test.ts
+│   ├── file_processor.test.ts
+│   ├── query_set_service.test.ts
+│   ├── query_set_create.test.tsx
+│   ├── query_preview.test.tsx
+│   ├── query_set_form.test.tsx
+│   └── use_query_set_form.test.ts
+├── query_set_create.tsx # Main component (refactored)
+├── index.ts
+└── README.md
+```
+
+## Key Improvements
+
+### 1. Separation of Concerns
+- **UI Components**: Pure presentation components focused on rendering
+- **Business Logic**: Extracted to utility functions and custom hooks
+- **API Calls**: Centralized in service classes
+- **State Management**: Handled by custom hooks
+
+### 2. Custom Hook (`useQuerySetForm`)
+- Manages all form state and validation
+- Handles file processing logic
+- Provides clean interface for components
+
+### 3. Service Layer (`QuerySetService`)
+- Encapsulates API communication
+- Handles request/response transformation
+- Easy to mock for testing
+
+### 4. Utility Functions
+- **Validation**: Pure functions for form validation
+- **File Processing**: Handles query file parsing logic
+
+### 5. Comprehensive Testing
+- Unit tests for all utility functions
+- Service layer tests with mocked HTTP calls
+- Component tests with mocked dependencies
+- High test coverage for business logic
+
+## Usage
+
+```tsx
+import { QuerySetCreateWithRouter } from './query_set_create';
+
+// The component now uses the refactored structure internally
+<QuerySetCreateWithRouter 
+  http={http} 
+  notifications={notifications} 
+/>
+```
+
+## Benefits
+
+1. **Maintainability**: Clear separation makes code easier to understand and modify
+2. **Testability**: Each piece can be tested in isolation
+3. **Reusability**: Components and utilities can be reused elsewhere
+4. **Type Safety**: Strong TypeScript interfaces throughout
+5. **Performance**: Optimized with proper memoization and callbacks

--- a/public/components/query_set_create/__tests__/file_processor.test.ts
+++ b/public/components/query_set_create/__tests__/file_processor.test.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { processQueryFile } from '../utils/file_processor';
+
+describe('file_processor', () => {
+  describe('processQueryFile', () => {
+    it('should process valid NDJSON file correctly', async () => {
+      const fileContent = `{"queryText": "test query 1", "referenceAnswer": "answer 1"}
+{"queryText": "test query 2", "referenceAnswer": "answer 2"}`;
+
+      const mockFile = ({
+        text: jest.fn().mockResolvedValue(fileContent),
+      } as unknown) as File;
+
+      const result = await processQueryFile(mockFile);
+
+      expect(result.error).toBeUndefined();
+      expect(result.queries).toHaveLength(2);
+      expect(result.queries[0]).toEqual({
+        queryText: 'test query 1',
+        referenceAnswer: 'answer 1',
+      });
+      expect(result.queries[1]).toEqual({
+        queryText: 'test query 2',
+        referenceAnswer: 'answer 2',
+      });
+    });
+
+    it('should handle queries without referenceAnswer', async () => {
+      const fileContent = `{"queryText": "test query 1"}
+{"queryText": "test query 2", "referenceAnswer": "answer 2"}`;
+
+      const mockFile = ({
+        text: jest.fn().mockResolvedValue(fileContent),
+      } as unknown) as File;
+
+      const result = await processQueryFile(mockFile);
+
+      expect(result.error).toBeUndefined();
+      expect(result.queries).toHaveLength(2);
+      expect(result.queries[0]).toEqual({
+        queryText: 'test query 1',
+        referenceAnswer: '',
+      });
+    });
+
+    it('should return error when no valid queries found', async () => {
+      const fileContent = `{"invalidField": "value"}
+{"anotherField": "value"}`;
+
+      const mockFile = ({
+        text: jest.fn().mockResolvedValue(fileContent),
+      } as unknown) as File;
+
+      const result = await processQueryFile(mockFile);
+
+      expect(result.error).toBe('No valid queries found in file');
+      expect(result.queries).toHaveLength(0);
+    });
+
+    it('should handle malformed JSON gracefully', async () => {
+      const fileContent = `{"queryText": "valid query"}
+{invalid json}
+{"queryText": "another valid query"}`;
+
+      const mockFile = ({
+        text: jest.fn().mockResolvedValue(fileContent),
+      } as unknown) as File;
+
+      const result = await processQueryFile(mockFile);
+
+      expect(result.error).toBeUndefined();
+      expect(result.queries).toHaveLength(2);
+      expect(result.queries[0].queryText).toBe('valid query');
+      expect(result.queries[1].queryText).toBe('another valid query');
+    });
+
+    it('should handle file read errors', async () => {
+      const mockFile = ({
+        text: jest.fn().mockRejectedValue(new Error('File read error')),
+      } as unknown) as File;
+
+      const result = await processQueryFile(mockFile);
+
+      expect(result.error).toBe('Error reading file content');
+      expect(result.queries).toHaveLength(0);
+    });
+  });
+});

--- a/public/components/query_set_create/__tests__/query_preview.test.tsx
+++ b/public/components/query_set_create/__tests__/query_preview.test.tsx
@@ -1,0 +1,65 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { QueryPreview } from '../components/query_preview';
+
+describe('QueryPreview', () => {
+  it('renders nothing when no queries are provided', () => {
+    const { container } = render(<QueryPreview parsedQueries={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders preview with queries correctly', () => {
+    const mockQueries = [
+      JSON.stringify({ queryText: 'test query 1', referenceAnswer: 'answer 1' }),
+      JSON.stringify({ queryText: 'test query 2', referenceAnswer: 'answer 2' }),
+      JSON.stringify({ queryText: 'test query 3', referenceAnswer: 'answer 3' }),
+    ];
+
+    render(<QueryPreview parsedQueries={mockQueries} />);
+
+    expect(screen.getByText('Preview (3 queries)')).toBeInTheDocument();
+    expect(screen.getByText(/test query 1/)).toBeInTheDocument();
+    expect(screen.getByText(/answer 1/)).toBeInTheDocument();
+    expect(screen.getByText(/test query 2/)).toBeInTheDocument();
+    expect(screen.getByText(/answer 2/)).toBeInTheDocument();
+    expect(screen.getByText(/test query 3/)).toBeInTheDocument();
+    expect(screen.getByText(/answer 3/)).toBeInTheDocument();
+  });
+
+  it('shows truncated preview for more than 5 queries', () => {
+    const mockQueries = Array(10)
+      .fill(0)
+      .map((_, i) =>
+        JSON.stringify({
+          queryText: `test query ${i + 1}`,
+          referenceAnswer: `answer ${i + 1}`,
+        })
+      );
+
+    render(<QueryPreview parsedQueries={mockQueries} />);
+
+    expect(screen.getByText('Preview (10 queries)')).toBeInTheDocument();
+    expect(screen.getByText(/test query 1/)).toBeInTheDocument();
+    expect(screen.getByText(/test query 5/)).toBeInTheDocument();
+    expect(screen.queryByText(/test query 6/)).not.toBeInTheDocument();
+    expect(screen.getByText('... and 5 more queries')).toBeInTheDocument();
+  });
+
+  it('handles queries without reference answers', () => {
+    const mockQueries = [
+      JSON.stringify({ queryText: 'test query 1' }),
+      JSON.stringify({ queryText: 'test query 2', referenceAnswer: '' }),
+    ];
+
+    render(<QueryPreview parsedQueries={mockQueries} />);
+
+    expect(screen.getByText('Preview (2 queries)')).toBeInTheDocument();
+    expect(screen.getByText('test query 1')).toBeInTheDocument();
+    expect(screen.getByText('test query 2')).toBeInTheDocument();
+  });
+});

--- a/public/components/query_set_create/__tests__/query_set_create.test.tsx
+++ b/public/components/query_set_create/__tests__/query_set_create.test.tsx
@@ -1,0 +1,186 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { Router } from 'react-router-dom';
+import { createMemoryHistory } from 'history';
+import { QuerySetCreate } from '../query_set_create';
+
+// Mock the service and hooks
+jest.mock('../services/query_set_service');
+jest.mock('../hooks/use_query_set_form');
+jest.mock('../components/query_set_form', () => ({
+  QuerySetForm: ({ formState }: any) => (
+    <div data-test-subj="query-set-form">
+      <input
+        data-test-subj="name-input"
+        value={formState.name}
+        onChange={(e) => formState.setName(e.target.value)}
+      />
+    </div>
+  ),
+}));
+jest.mock('../components/query_preview', () => ({
+  QueryPreview: ({ parsedQueries }: any) => (
+    <div data-test-subj="query-preview">{parsedQueries.length} queries</div>
+  ),
+}));
+
+const mockFormState = {
+  name: 'Test Query Set',
+  setName: jest.fn(),
+  description: 'Test description',
+  setDescription: jest.fn(),
+  sampling: 'random',
+  setSampling: jest.fn(),
+  querySetSize: 10,
+  setQuerySetSize: jest.fn(),
+  isManualInput: false,
+  setIsManualInput: jest.fn(),
+  manualQueries: '',
+  setManualQueries: jest.fn(),
+  files: [],
+  setFiles: jest.fn(),
+  parsedQueries: [],
+  setParsedQueries: jest.fn(),
+  errors: {
+    nameError: '',
+    descriptionError: '',
+    querySizeError: '',
+    manualQueriesError: '',
+  },
+  validateField: jest.fn(),
+  isFormValid: jest.fn().mockReturnValue(true),
+  handleFileContent: jest.fn(),
+  clearFileData: jest.fn(),
+};
+
+const mockQuerySetServiceInstance = {
+  createQuerySet: jest.fn(),
+};
+
+describe('QuerySetCreate', () => {
+  let mockHttp: any;
+  let mockNotifications: any;
+  let history: any;
+
+  beforeEach(() => {
+    mockHttp = {};
+    mockNotifications = {
+      toasts: {
+        addSuccess: jest.fn(),
+        addError: jest.fn(),
+      },
+    };
+    history = createMemoryHistory();
+
+    // Reset mocks
+    jest.clearAllMocks();
+
+    // Mock the hook return value
+    (require('../hooks/use_query_set_form').useQuerySetForm as jest.Mock).mockReturnValue(
+      mockFormState
+    );
+    (require('../services/query_set_service').QuerySetService as jest.Mock).mockImplementation(
+      () => mockQuerySetServiceInstance
+    );
+  });
+
+  const renderComponent = () => {
+    return render(
+      <Router history={history}>
+        <QuerySetCreate
+          http={mockHttp}
+          notifications={mockNotifications}
+          history={history}
+          location={history.location}
+          match={{ params: {}, isExact: true, path: '', url: '' }}
+        />
+      </Router>
+    );
+  };
+
+  it('should render the component correctly', () => {
+    renderComponent();
+
+    expect(screen.getByText('Query Set')).toBeInTheDocument();
+    expect(screen.getByText(/Create a new query set by/)).toBeInTheDocument();
+    expect(screen.getByTestId('query-set-form')).toBeInTheDocument();
+  });
+
+  it('should handle successful form submission', async () => {
+    mockQuerySetServiceInstance.createQuerySet.mockResolvedValue({ success: true });
+
+    renderComponent();
+
+    const createButton = screen.getByTestId('createQuerySetButton');
+    fireEvent.click(createButton);
+
+    await waitFor(() => {
+      expect(mockQuerySetServiceInstance.createQuerySet).toHaveBeenCalledWith(
+        {
+          name: 'Test Query Set',
+          description: 'Test description',
+          sampling: 'random',
+          querySetSize: 10,
+          querySetQueries: undefined,
+        },
+        false
+      );
+    });
+
+    expect(mockNotifications.toasts.addSuccess).toHaveBeenCalledWith(
+      'Query set "Test Query Set" created successfully'
+    );
+    expect(history.location.pathname).toBe('/querySet');
+  });
+
+  it('should handle form submission errors', async () => {
+    const error = new Error('API Error');
+    mockQuerySetServiceInstance.createQuerySet.mockRejectedValue(error);
+
+    renderComponent();
+
+    const createButton = screen.getByTestId('createQuerySetButton');
+    fireEvent.click(createButton);
+
+    await waitFor(() => {
+      expect(mockNotifications.toasts.addError).toHaveBeenCalledWith(error, {
+        title: 'Failed to create query set',
+      });
+    });
+  });
+
+  it('should not submit when form is invalid', async () => {
+    mockFormState.isFormValid.mockReturnValue(false);
+
+    renderComponent();
+
+    const createButton = screen.getByTestId('createQuerySetButton');
+    fireEvent.click(createButton);
+
+    expect(mockQuerySetServiceInstance.createQuerySet).not.toHaveBeenCalled();
+  });
+
+  it('should handle cancel action', () => {
+    renderComponent();
+
+    const cancelButton = screen.getByTestId('cancelQuerySetButton');
+    fireEvent.click(cancelButton);
+
+    expect(history.location.pathname).toBe('/querySet');
+  });
+
+  it('should show query preview when in manual input mode', () => {
+    mockFormState.isManualInput = true;
+    mockFormState.parsedQueries = ['query1', 'query2'];
+
+    renderComponent();
+
+    expect(screen.getByTestId('query-preview')).toBeInTheDocument();
+    expect(screen.getByText('2 queries')).toBeInTheDocument();
+  });
+});

--- a/public/components/query_set_create/__tests__/query_set_form.test.tsx
+++ b/public/components/query_set_create/__tests__/query_set_form.test.tsx
@@ -1,0 +1,143 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { QuerySetForm } from '../components/query_set_form';
+
+describe('QuerySetForm', () => {
+  const mockFormState = {
+    name: 'Test Query Set',
+    setName: jest.fn(),
+    description: 'Test description',
+    setDescription: jest.fn(),
+    sampling: 'random',
+    setSampling: jest.fn(),
+    querySetSize: 10,
+    setQuerySetSize: jest.fn(),
+    isManualInput: false,
+    setIsManualInput: jest.fn(),
+    manualQueries: '',
+    setManualQueries: jest.fn(),
+    files: [],
+    setFiles: jest.fn(),
+    parsedQueries: [],
+    setParsedQueries: jest.fn(),
+    errors: {
+      nameError: '',
+      descriptionError: '',
+      querySizeError: '',
+      manualQueriesError: '',
+    },
+    validateField: jest.fn(),
+    isFormValid: jest.fn(),
+    handleFileContent: jest.fn(),
+    clearFileData: jest.fn(),
+  };
+
+  const mockFilePickerId = 'test-file-picker-id';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the form with sampling mode correctly', () => {
+    render(<QuerySetForm formState={mockFormState} filePickerId={mockFilePickerId} />);
+
+    expect(screen.getByText('Switch to manually adding queries')).toBeInTheDocument();
+    expect(screen.getByTestId('querySetNameInput')).toHaveValue('Test Query Set');
+    expect(screen.getByTestId('querySetDescriptionInput')).toHaveValue('Test description');
+    expect(screen.getByTestId('querySetSamplingSelect')).toHaveValue('random');
+    expect(screen.getByTestId('querySetSizeInput')).toHaveValue(10);
+  });
+
+  it('renders the form with manual input mode correctly', () => {
+    const manualInputFormState = {
+      ...mockFormState,
+      isManualInput: true,
+    };
+
+    render(<QuerySetForm formState={manualInputFormState} filePickerId={mockFilePickerId} />);
+
+    expect(screen.getByText('Switch to sampling queries from UBI data')).toBeInTheDocument();
+    expect(screen.getByTestId('querySetNameInput')).toHaveValue('Test Query Set');
+    expect(screen.getByTestId('querySetDescriptionInput')).toHaveValue('Test description');
+    expect(screen.getByTestId('manualQueriesFilePicker')).toBeInTheDocument();
+    expect(screen.queryByTestId('querySetSamplingSelect')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('querySetSizeInput')).not.toBeInTheDocument();
+  });
+
+  it('handles name input change', () => {
+    render(<QuerySetForm formState={mockFormState} filePickerId={mockFilePickerId} />);
+
+    const nameInput = screen.getByTestId('querySetNameInput');
+    fireEvent.change(nameInput, { target: { value: 'New Name' } });
+
+    expect(mockFormState.setName).toHaveBeenCalledWith('New Name');
+  });
+
+  it('handles description input change', () => {
+    render(<QuerySetForm formState={mockFormState} filePickerId={mockFilePickerId} />);
+
+    const descriptionInput = screen.getByTestId('querySetDescriptionInput');
+    fireEvent.change(descriptionInput, { target: { value: 'New Description' } });
+
+    expect(mockFormState.setDescription).toHaveBeenCalledWith('New Description');
+  });
+
+  it('handles sampling method change', () => {
+    render(<QuerySetForm formState={mockFormState} filePickerId={mockFilePickerId} />);
+
+    const samplingSelect = screen.getByTestId('querySetSamplingSelect');
+    fireEvent.change(samplingSelect, { target: { value: 'topn' } });
+
+    expect(mockFormState.setSampling).toHaveBeenCalledWith('topn');
+  });
+
+  it('handles query set size change', () => {
+    render(<QuerySetForm formState={mockFormState} filePickerId={mockFilePickerId} />);
+
+    const sizeInput = screen.getByTestId('querySetSizeInput');
+    fireEvent.change(sizeInput, { target: { value: '20' } });
+
+    expect(mockFormState.setQuerySetSize).toHaveBeenCalledWith(20);
+  });
+
+  it('handles input mode toggle', () => {
+    render(<QuerySetForm formState={mockFormState} filePickerId={mockFilePickerId} />);
+
+    const toggleButton = screen.getByText('Switch to manually adding queries');
+    fireEvent.click(toggleButton);
+
+    expect(mockFormState.setIsManualInput).toHaveBeenCalledWith(true);
+  });
+
+  it('displays validation errors', () => {
+    const formStateWithErrors = {
+      ...mockFormState,
+      errors: {
+        nameError: 'Name is required',
+        descriptionError: 'Description is required',
+        querySizeError: 'Size must be positive',
+        manualQueriesError: '',
+      },
+    };
+
+    render(<QuerySetForm formState={formStateWithErrors} filePickerId={mockFilePickerId} />);
+
+    expect(screen.getByText('Name is required')).toBeInTheDocument();
+    expect(screen.getByText('Description is required')).toBeInTheDocument();
+    expect(screen.getByText('Size must be positive')).toBeInTheDocument();
+  });
+
+  it('validates fields on blur', () => {
+    render(<QuerySetForm formState={mockFormState} filePickerId={mockFilePickerId} />);
+
+    const nameInput = screen.getByTestId('querySetNameInput');
+    fireEvent.blur(nameInput);
+
+    expect(mockFormState.validateField).toHaveBeenCalledWith('name', 'Test Query Set');
+  });
+});

--- a/public/components/query_set_create/__tests__/query_set_service.test.ts
+++ b/public/components/query_set_create/__tests__/query_set_service.test.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { QuerySetService } from '../services/query_set_service';
+
+describe('QuerySetService', () => {
+  let mockHttp: any;
+  let service: QuerySetService;
+
+  beforeEach(() => {
+    mockHttp = {
+      post: jest.fn(),
+      put: jest.fn(),
+    };
+    service = new QuerySetService(mockHttp);
+  });
+
+  describe('createQuerySet', () => {
+    it('should call POST for non-manual input', async () => {
+      const querySetData = {
+        name: 'Test Query Set',
+        description: 'Test description',
+        sampling: 'random',
+        querySetSize: 10,
+      };
+
+      mockHttp.post.mockResolvedValue({ success: true });
+
+      await service.createQuerySet(querySetData, false);
+
+      expect(mockHttp.post).toHaveBeenCalledWith('/api/relevancy/query_sets', {
+        body: JSON.stringify({
+          name: 'Test Query Set',
+          description: 'Test description',
+          sampling: 'random',
+          querySetSize: 10,
+        }),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+      expect(mockHttp.put).not.toHaveBeenCalled();
+    });
+
+    it('should call PUT for manual input', async () => {
+      const querySetData = {
+        name: 'Test Query Set',
+        description: 'Test description',
+        sampling: 'random',
+        querySetQueries: [{ queryText: 'test query', referenceAnswer: 'test answer' }],
+      };
+
+      mockHttp.put.mockResolvedValue({ success: true });
+
+      await service.createQuerySet(querySetData, true);
+
+      expect(mockHttp.put).toHaveBeenCalledWith('/api/relevancy/query_sets', {
+        body: JSON.stringify({
+          name: 'Test Query Set',
+          description: 'Test description',
+          sampling: 'manual',
+          querySetQueries: [{ queryText: 'test query', referenceAnswer: 'test answer' }],
+        }),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+      expect(mockHttp.post).not.toHaveBeenCalled();
+    });
+
+    it('should handle API errors', async () => {
+      const querySetData = {
+        name: 'Test Query Set',
+        description: 'Test description',
+        sampling: 'random',
+        querySetSize: 10,
+      };
+
+      const error = new Error('API Error');
+      mockHttp.post.mockRejectedValue(error);
+
+      await expect(service.createQuerySet(querySetData, false)).rejects.toThrow('API Error');
+    });
+  });
+});

--- a/public/components/query_set_create/__tests__/use_query_set_form.test.ts
+++ b/public/components/query_set_create/__tests__/use_query_set_form.test.ts
@@ -1,0 +1,210 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { renderHook, act } from '@testing-library/react-hooks';
+import { useQuerySetForm } from '../hooks/use_query_set_form';
+import * as validation from '../utils/validation';
+import * as fileProcessor from '../utils/file_processor';
+
+jest.mock('../utils/validation');
+jest.mock('../utils/file_processor');
+
+describe('useQuerySetForm', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (validation.validateForm as jest.Mock).mockReturnValue({
+      nameError: '',
+      descriptionError: '',
+      querySizeError: '',
+      manualQueriesError: '',
+    });
+    (validation.hasValidationErrors as jest.Mock).mockReturnValue(false);
+    (fileProcessor.processQueryFile as jest.Mock).mockResolvedValue({
+      queries: [{ queryText: 'test query', referenceAnswer: 'test answer' }],
+      error: undefined,
+    });
+  });
+
+  it('initializes with default values', () => {
+    const { result } = renderHook(() => useQuerySetForm());
+
+    expect(result.current.name).toBe('');
+    expect(result.current.description).toBe('');
+    expect(result.current.sampling).toBe('random');
+    expect(result.current.querySetSize).toBe(10);
+    expect(result.current.isManualInput).toBe(false);
+    expect(result.current.manualQueries).toBe('');
+    expect(result.current.files).toEqual([]);
+    expect(result.current.parsedQueries).toEqual([]);
+    expect(result.current.errors).toEqual({
+      nameError: '',
+      descriptionError: '',
+      querySizeError: '',
+      manualQueriesError: '',
+    });
+  });
+
+  it('updates name correctly', () => {
+    const { result } = renderHook(() => useQuerySetForm());
+
+    act(() => {
+      result.current.setName('New Query Set');
+    });
+
+    expect(result.current.name).toBe('New Query Set');
+  });
+
+  it('updates description correctly', () => {
+    const { result } = renderHook(() => useQuerySetForm());
+
+    act(() => {
+      result.current.setDescription('New Description');
+    });
+
+    expect(result.current.description).toBe('New Description');
+  });
+
+  it('updates sampling correctly', () => {
+    const { result } = renderHook(() => useQuerySetForm());
+
+    act(() => {
+      result.current.setSampling('topn');
+    });
+
+    expect(result.current.sampling).toBe('topn');
+  });
+
+  it('updates querySetSize correctly', () => {
+    const { result } = renderHook(() => useQuerySetForm());
+
+    act(() => {
+      result.current.setQuerySetSize(20);
+    });
+
+    expect(result.current.querySetSize).toBe(20);
+  });
+
+  it('toggles isManualInput correctly', () => {
+    const { result } = renderHook(() => useQuerySetForm());
+
+    act(() => {
+      result.current.setIsManualInput(true);
+    });
+
+    expect(result.current.isManualInput).toBe(true);
+  });
+
+  it('validates fields correctly', () => {
+    // Mock validateForm to return the expected error for empty name
+    (validation.validateForm as jest.Mock).mockReturnValue({
+      nameError: 'Name is a required parameter.',
+      descriptionError: '',
+      querySizeError: '',
+      manualQueriesError: '',
+    });
+    
+    const { result } = renderHook(() => useQuerySetForm());
+
+    act(() => {
+      result.current.validateField('name', '');
+    });
+
+    expect(result.current.errors.nameError).toBe('Name is a required parameter.');
+  });
+
+  it('validates form correctly', () => {
+    (validation.validateForm as jest.Mock).mockReturnValue({
+      nameError: 'Name is required',
+      descriptionError: '',
+      querySizeError: '',
+      manualQueriesError: '',
+    });
+    (validation.hasValidationErrors as jest.Mock).mockReturnValue(true);
+
+    const { result } = renderHook(() => useQuerySetForm());
+
+    let isValid;
+    act(() => {
+      isValid = result.current.isFormValid();
+    });
+
+    expect(isValid).toBe(false);
+    expect(validation.validateForm).toHaveBeenCalled();
+    expect(validation.hasValidationErrors).toHaveBeenCalled();
+  });
+
+  it('handles file content correctly', async () => {
+    const mockFile = new File(['test content'], 'test.txt', { type: 'text/plain' });
+    const mockFileList = ({
+      0: mockFile,
+      length: 1,
+      item: () => mockFile,
+    } as unknown) as FileList;
+
+    const { result, waitForNextUpdate } = renderHook(() => useQuerySetForm());
+
+    act(() => {
+      result.current.handleFileContent(mockFileList);
+    });
+
+    await waitForNextUpdate();
+
+    expect(fileProcessor.processQueryFile).toHaveBeenCalledWith(mockFile);
+    expect(result.current.manualQueries).toBe(
+      JSON.stringify([{ queryText: 'test query', referenceAnswer: 'test answer' }])
+    );
+    expect(result.current.parsedQueries).toEqual([
+      JSON.stringify({ queryText: 'test query', referenceAnswer: 'test answer' }),
+    ]);
+    expect(result.current.files).toEqual([mockFile]);
+  });
+
+  it('handles file processing errors', async () => {
+    (fileProcessor.processQueryFile as jest.Mock).mockResolvedValue({
+      queries: [],
+      error: 'Invalid file format',
+    });
+
+    const mockFile = new File(['invalid content'], 'test.txt', { type: 'text/plain' });
+    const mockFileList = ({
+      0: mockFile,
+      length: 1,
+      item: () => mockFile,
+    } as unknown) as FileList;
+
+    const { result, waitForNextUpdate } = renderHook(() => useQuerySetForm());
+
+    act(() => {
+      result.current.handleFileContent(mockFileList);
+    });
+
+    await waitForNextUpdate();
+
+    expect(result.current.errors.manualQueriesError).toBe('Invalid file format');
+    expect(result.current.files).toEqual([]);
+    expect(result.current.manualQueries).toBe('');
+    expect(result.current.parsedQueries).toEqual([]);
+  });
+
+  it('clears file data correctly', () => {
+    const { result } = renderHook(() => useQuerySetForm());
+
+    // Set some initial data
+    act(() => {
+      result.current.setFiles([new File(['test'], 'test.txt')]);
+      result.current.setManualQueries('test queries');
+      result.current.setParsedQueries(['query1', 'query2']);
+    });
+
+    // Clear the data
+    act(() => {
+      result.current.clearFileData();
+    });
+
+    expect(result.current.files).toEqual([]);
+    expect(result.current.manualQueries).toBe('');
+    expect(result.current.parsedQueries).toEqual([]);
+  });
+});

--- a/public/components/query_set_create/__tests__/validation.test.ts
+++ b/public/components/query_set_create/__tests__/validation.test.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { validateForm, hasValidationErrors } from '../utils/validation';
+
+describe('validation utils', () => {
+  describe('validateForm', () => {
+    it('should return no errors for valid form data', () => {
+      const formData = {
+        name: 'Test Query Set',
+        description: 'Test description',
+        querySetSize: 10,
+        manualQueries: '',
+        isManualInput: false,
+      };
+
+      const errors = validateForm(formData);
+
+      expect(errors.nameError).toBe('');
+      expect(errors.descriptionError).toBe('');
+      expect(errors.querySizeError).toBe('');
+      expect(errors.manualQueriesError).toBe('');
+    });
+
+    it('should return name error when name is empty', () => {
+      const formData = {
+        name: '',
+        description: 'Test description',
+        querySetSize: 10,
+        manualQueries: '',
+        isManualInput: false,
+      };
+
+      const errors = validateForm(formData);
+
+      expect(errors.nameError).toBe('Name is a required parameter.');
+    });
+
+    it('should return description error when description is empty', () => {
+      const formData = {
+        name: 'Test Query Set',
+        description: '',
+        querySetSize: 10,
+        manualQueries: '',
+        isManualInput: false,
+      };
+
+      const errors = validateForm(formData);
+
+      expect(errors.descriptionError).toBe('Description is a required parameter.');
+    });
+
+    it('should return query size error when size is invalid for non-manual input', () => {
+      const formData = {
+        name: 'Test Query Set',
+        description: 'Test description',
+        querySetSize: 0,
+        manualQueries: '',
+        isManualInput: false,
+      };
+
+      const errors = validateForm(formData);
+
+      expect(errors.querySizeError).toBe('Query Set Size must be a positive integer.');
+    });
+
+    it('should return manual queries error when manual input is empty', () => {
+      const formData = {
+        name: 'Test Query Set',
+        description: 'Test description',
+        querySetSize: 10,
+        manualQueries: '',
+        isManualInput: true,
+      };
+
+      const errors = validateForm(formData);
+
+      expect(errors.manualQueriesError).toBe('Manual queries are required.');
+    });
+  });
+
+  describe('hasValidationErrors', () => {
+    it('should return false when no errors exist', () => {
+      const errors = {
+        nameError: '',
+        descriptionError: '',
+        querySizeError: '',
+        manualQueriesError: '',
+      };
+
+      expect(hasValidationErrors(errors)).toBe(false);
+    });
+
+    it('should return true when errors exist', () => {
+      const errors = {
+        nameError: 'Name is required',
+        descriptionError: '',
+        querySizeError: '',
+        manualQueriesError: '',
+      };
+
+      expect(hasValidationErrors(errors)).toBe(true);
+    });
+  });
+});

--- a/public/components/query_set_create/components/query_preview.tsx
+++ b/public/components/query_set_create/components/query_preview.tsx
@@ -1,0 +1,40 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { EuiFormRow, EuiPanel, EuiText } from '@elastic/eui';
+
+interface QueryPreviewProps {
+  parsedQueries: string[];
+}
+
+export const QueryPreview: React.FC<QueryPreviewProps> = ({ parsedQueries }) => {
+  if (parsedQueries.length === 0) {
+    return null;
+  }
+
+  return (
+    <EuiFormRow fullWidth label="Parsed Queries Preview">
+      <EuiPanel paddingSize="s">
+        <EuiText size="s">
+          <h4>Preview ({parsedQueries.length} queries)</h4>
+          <ul>
+            {parsedQueries.slice(0, 5).map((query, idx) => {
+              const parsed = JSON.parse(query);
+              return (
+                <li key={idx}>
+                  <strong>Query:</strong> {parsed.queryText}
+                  <br />
+                  <strong>Reference:</strong> {parsed.referenceAnswer}
+                </li>
+              );
+            })}
+          </ul>
+          {parsedQueries.length > 5 && <p>... and {parsedQueries.length - 5} more queries</p>}
+        </EuiText>
+      </EuiPanel>
+    </EuiFormRow>
+  );
+};

--- a/public/components/query_set_create/components/query_set_form.tsx
+++ b/public/components/query_set_create/components/query_set_form.tsx
@@ -1,0 +1,159 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import {
+  EuiButton,
+  EuiFieldNumber,
+  EuiFlexGroup,
+  EuiCompressedFormRow,
+  EuiCompressedTextArea,
+  EuiFlexItem,
+  EuiSelect,
+  EuiFormRow,
+  EuiForm,
+  EuiFilePicker,
+} from '@elastic/eui';
+import { UseQuerySetFormReturn } from '../hooks/use_query_set_form';
+
+interface QuerySetFormProps {
+  formState: UseQuerySetFormReturn;
+  filePickerId: string;
+}
+
+const samplingOptions = [
+  { value: 'random', text: 'Random' },
+  { value: 'pptss', text: 'Probability-Proportional-to-Size Sampling' },
+  { value: 'topn', text: 'Top N' },
+];
+
+export const QuerySetForm: React.FC<QuerySetFormProps> = ({ formState, filePickerId }) => {
+  const {
+    name,
+    setName,
+    description,
+    setDescription,
+    sampling,
+    setSampling,
+    querySetSize,
+    setQuerySetSize,
+    isManualInput,
+    setIsManualInput,
+    errors,
+    validateField,
+    handleFileContent,
+  } = formState;
+
+  return (
+    <EuiForm component="form" isInvalid={Object.values(errors).some((error) => error.length > 0)}>
+      <EuiFormRow fullWidth>
+        <EuiButton
+          onClick={() => setIsManualInput(!isManualInput)}
+          size="s"
+          iconType={isManualInput ? 'aggregate' : 'inputOutput'}
+        >
+          Switch to {isManualInput ? 'sampling queries from UBI data' : 'manually adding queries'}
+        </EuiButton>
+      </EuiFormRow>
+
+      <EuiCompressedFormRow
+        label="Name"
+        isInvalid={errors.nameError.length > 0}
+        error={errors.nameError}
+        helpText="A unique name for this query set."
+        fullWidth
+      >
+        <EuiCompressedTextArea
+          placeholder="Enter query set name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          onBlur={(e) => validateField('name', e.target.value)}
+          isInvalid={errors.nameError.length > 0}
+          data-test-subj="querySetNameInput"
+          fullWidth
+        />
+      </EuiCompressedFormRow>
+
+      <EuiCompressedFormRow
+        label="Description"
+        isInvalid={errors.descriptionError.length > 0}
+        error={errors.descriptionError}
+        helpText="Detailed description of the query set purpose."
+        fullWidth
+      >
+        <EuiCompressedTextArea
+          placeholder="Describe the purpose of this query set"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          onBlur={(e) => validateField('description', e.target.value)}
+          isInvalid={errors.descriptionError.length > 0}
+          data-test-subj="querySetDescriptionInput"
+          fullWidth
+        />
+      </EuiCompressedFormRow>
+
+      {isManualInput ? (
+        <EuiFormRow
+          label="Manual Queries"
+          error={errors.manualQueriesError}
+          isInvalid={Boolean(errors.manualQueriesError)}
+          helpText="Upload an NDJSON file with queries (one JSON object per line containing queryText and referenceAnswer)"
+          fullWidth
+        >
+          <EuiFlexGroup>
+            <EuiFlexItem>
+              <EuiFilePicker
+                id={filePickerId}
+                initialPromptText="Select or drag and drop a query file"
+                onChange={(files) => handleFileContent(files)}
+                display="large"
+                aria-label="Upload query file"
+                accept=".txt"
+                data-test-subj="manualQueriesFilePicker"
+                compressed
+              />
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiFormRow>
+      ) : (
+        <>
+          <EuiFormRow
+            label="Sampling Method"
+            helpText="Select the sampling method for this query set."
+            fullWidth
+          >
+            <EuiSelect
+              options={samplingOptions}
+              value={sampling}
+              onChange={(e) => setSampling(e.target.value)}
+              data-test-subj="querySetSamplingSelect"
+              fullWidth
+            />
+          </EuiFormRow>
+
+          <EuiFormRow
+            label="Query Set Size"
+            error={errors.querySizeError}
+            isInvalid={Boolean(errors.querySizeError)}
+            helpText="Number of queries in the set (must be positive)."
+            fullWidth
+          >
+            <EuiFieldNumber
+              value={querySetSize}
+              min={1}
+              onChange={(e) => {
+                const value = parseInt(e.target.value, 10);
+                setQuerySetSize(isNaN(value) ? 0 : value);
+              }}
+              isInvalid={Boolean(errors.querySizeError)}
+              fullWidth
+              data-test-subj="querySetSizeInput"
+            />
+          </EuiFormRow>
+        </>
+      )}
+    </EuiForm>
+  );
+};

--- a/public/components/query_set_create/hooks/use_query_set_form.ts
+++ b/public/components/query_set_create/hooks/use_query_set_form.ts
@@ -1,0 +1,135 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useState, useCallback } from 'react';
+import { validateForm, ValidationErrors, hasValidationErrors } from '../utils/validation';
+import { processQueryFile, QueryItem } from '../utils/file_processor';
+
+export interface UseQuerySetFormReturn {
+  // Form state
+  name: string;
+  setName: (name: string) => void;
+  description: string;
+  setDescription: (description: string) => void;
+  sampling: string;
+  setSampling: (sampling: string) => void;
+  querySetSize: number;
+  setQuerySetSize: (size: number) => void;
+  isManualInput: boolean;
+  setIsManualInput: (manual: boolean) => void;
+  manualQueries: string;
+  setManualQueries: (queries: string) => void;
+  files: File[];
+  setFiles: (files: File[]) => void;
+  parsedQueries: string[];
+  setParsedQueries: (queries: string[]) => void;
+
+  // Validation
+  errors: ValidationErrors;
+  validateField: (field: string, value: string) => void;
+  isFormValid: () => boolean;
+
+  // File handling
+  handleFileContent: (files: FileList) => Promise<void>;
+  clearFileData: () => void;
+}
+
+export const useQuerySetForm = (): UseQuerySetFormReturn => {
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [sampling, setSampling] = useState('random');
+  const [querySetSize, setQuerySetSize] = useState<number>(10);
+  const [isManualInput, setIsManualInput] = useState(false);
+  const [manualQueries, setManualQueries] = useState('');
+  const [files, setFiles] = useState<File[]>([]);
+  const [parsedQueries, setParsedQueries] = useState<string[]>([]);
+
+  const [errors, setErrors] = useState<ValidationErrors>({
+    nameError: '',
+    descriptionError: '',
+    querySizeError: '',
+    manualQueriesError: '',
+  });
+
+  const validateField = useCallback(
+    (field: string, value: string) => {
+      // Create a partial form data object with just the field being validated
+      const partialData = {
+        name: field === 'name' ? value : name,
+        description: field === 'description' ? value : description,
+        querySetSize,
+        manualQueries,
+        isManualInput,
+      };
+
+      // Get full validation results
+      const validationResults = validateForm(partialData);
+
+      // Only update the error for the specific field
+      setErrors((prev) => ({
+        ...prev,
+        [`${field}Error`]: validationResults[`${field}Error`],
+      }));
+    },
+    [name, description, querySetSize, manualQueries, isManualInput]
+  );
+
+  const isFormValid = useCallback(() => {
+    const formData = { name, description, querySetSize, manualQueries, isManualInput };
+    const validationErrors = validateForm(formData);
+    setErrors(validationErrors);
+    return !hasValidationErrors(validationErrors);
+  }, [name, description, querySetSize, manualQueries, isManualInput]);
+
+  const handleFileContent = useCallback(async (files: FileList) => {
+    if (files && files.length > 0) {
+      const file = files[0];
+      const result = await processQueryFile(file);
+
+      if (result.error) {
+        setErrors((prev) => ({ ...prev, manualQueriesError: result.error! }));
+        clearFileData();
+        return;
+      }
+
+      setManualQueries(JSON.stringify(result.queries));
+      setParsedQueries(result.queries.map((q) => JSON.stringify(q)));
+      setFiles([file]);
+      setErrors((prev) => ({ ...prev, manualQueriesError: '' }));
+    } else {
+      clearFileData();
+    }
+  }, []);
+
+  const clearFileData = useCallback(() => {
+    setFiles([]);
+    setManualQueries('');
+    setParsedQueries([]);
+  }, []);
+
+  return {
+    name,
+    setName,
+    description,
+    setDescription,
+    sampling,
+    setSampling,
+    querySetSize,
+    setQuerySetSize,
+    isManualInput,
+    setIsManualInput,
+    manualQueries,
+    setManualQueries,
+    files,
+    setFiles,
+    parsedQueries,
+    setParsedQueries,
+    errors,
+    validateField,
+    isFormValid,
+    handleFileContent,
+    clearFileData,
+  };
+};

--- a/public/components/query_set_create/query_set_create.tsx
+++ b/public/components/query_set_create/query_set_create.tsx
@@ -7,278 +7,74 @@ import {
   EuiButton,
   EuiButtonEmpty,
   EuiPageTemplate,
-  EuiFieldNumber,
-  EuiFlexGroup,
-  EuiCompressedFormRow,
-  EuiCompressedTextArea,
   EuiFlexItem,
   EuiPanel,
-  EuiSelect,
-  EuiFormRow,
-  EuiForm,
-  EuiTextArea,
-  EuiText,
-  EuiFilePicker,
   EuiPageHeader,
 } from '@elastic/eui';
-import React, { useCallback, useRef, useState } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { CoreStart, NotificationsStart } from '../../../../../core/public';
-import { ServiceEndpoints } from '../../../common';
+import { QuerySetService } from './services/query_set_service';
+import { useQuerySetForm } from './hooks/use_query_set_form';
+import { QuerySetForm } from './components/query_set_form';
+import { QueryPreview } from './components/query_preview';
 
 interface QuerySetCreateProps extends RouteComponentProps {
   http: CoreStart['http'];
   notifications: NotificationsStart;
 }
 
-interface FilePickerRef {
-  removeFiles: () => void;
-}
-
 export const QuerySetCreate: React.FC<QuerySetCreateProps> = ({ http, notifications, history }) => {
-  // Form states for ubi sampling
-  const [name, setName] = useState('');
-  const [nameError, setNameError] = useState('');
-  const [description, setDescription] = useState('');
-  const [descriptionError, setDescriptionError] = useState('');
-  const [sampling, setSampling] = useState('random');
-  const [querySetSize, setQuerySetSize] = useState<number>(10);
-  const [querySizeError, setQuerySizeError] = useState('');
+  const formState = useQuerySetForm();
+  const querySetService = useMemo(() => new QuerySetService(http), [http]);
+  const filePickerId = useMemo(() => `filePicker-${Math.random().toString(36).substr(2, 9)}`, []);
 
-  // Form states for manual input
-  const [isManualInput, setIsManualInput] = useState(false);
-  const [manualQueries, setManualQueries] = useState('');
-  const [manualQueriesError, setManualQueriesError] = useState('');
-
-  // file picker
-  const [files, setFiles] = useState<File[]>([]);
-  const filePickerRef = useRef<FilePickerRef>(null);
-  const generateId = (prefix: string) => `${prefix}-${Math.random().toString(36).substr(2, 9)}`;
-  const filePickerId = generateId('filePicker');
-  const [parsedQueries, setParsedQueries] = useState<string[]>([]);
-
-  const isValidInputString = (input: string): boolean => {
-      // Regex to detect characters that might break JSON parsing or cause XSS:
-      // - Double quotes (")
-      // - Backslashes (\)
-      // - HTML tags (<, >)
-      // - Control characters (U+0000 to U+001F) and other problematic unicode characters
-      //   that could interfere with JSON or string parsing.
-      // This regex primarily focuses on characters that would require escaping in JSON or are HTML-specific.
-      const forbiddenCharsRegex = /[<>"\\\x00-\x1F]/;
-      return !forbiddenCharsRegex.test(input);
-    };
-
-  const handleFileContent = async (files: FileList) => {
-    if (files && files.length > 0) {
-      try {
-        const file = files[0];
-        const text = await file.text();
-        const lines = text.trim().split('\n');
-        const queryList: Array<{ queryText: string; referenceAnswer: string }> = [];
-
-        for (const line of lines) {
-          try {
-            const parsed = JSON.parse(line.trim());
-            if (parsed.queryText) {
-              queryList.push({
-                queryText: String(parsed.queryText).trim(),
-                referenceAnswer: parsed.referenceAnswer
-                  ? String(parsed.referenceAnswer).trim()
-                  : '',
-              });
-            }
-          } catch (e) {
-            console.error('Error parsing line:', line, e);
-          }
-        }
-
-        if (queryList.length === 0) {
-          setManualQueriesError('No valid queries found in file');
-          setFiles([]);
-          setManualQueries('');
-          setParsedQueries([]);
-          return;
-        }
-
-        if (queryList.length > 1000000) {
-          setManualQueriesError('Too many queries found (> 1.000.000)');
-          setFiles([]);
-          setManualQueries('');
-          setParsedQueries([]);
-          return;
-        }
-
-        // Store the raw query objects instead of converting to string
-        setManualQueries(JSON.stringify(queryList));
-        setParsedQueries(queryList.map((q) => JSON.stringify(q)));
-        setFiles([file]);
-        setManualQueriesError('');
-      } catch (error) {
-        console.error('Error processing file:', error);
-        setManualQueriesError('Error reading file content');
-        setFiles([]);
-        setManualQueries('');
-        setParsedQueries([]);
-      }
-    } else {
-      setFiles([]);
-      setManualQueries('');
-      setParsedQueries([]);
-    }
-  };
-
-  const samplingOptions = [
-    { value: 'random', text: 'Random' },
-    { value: 'pptss', text: 'Probability-Proportional-to-Size Sampling' },
-    { value: 'topn', text: 'Top N' },
-  ];
-
-  // Validate form fields
-  const validateForm = () => {
-    let isValid = true;
-
-    // Validate name
-    if (!name.trim()) {
-      setNameError('Name is a required parameter.');
-      isValid = false;
-    } else if (name.length > 50) {
-      setNameError('Name is too long (> 50 characters).');
-    } else if (!isValidInputString(name)) {
-      setNameError('Name contains invalid characters (e.g., quotes, backslashes, or HTML tags).');
-      isValid = false;
-    } else {
-      setNameError('');
-    }
-
-    // Validate description
-    if (!description.trim()) {
-      setDescriptionError('Description is a required parameter.');
-      isValid = false;
-    } else if (description.length > 250) {
-      setDescriptionError('Description is too long (> 250 characters).');
-    } else if (!isValidInputString(description)) {
-      setDescriptionError('Description contains invalid characters (e.g., quotes, backslashes, or HTML tags).');
-      isValid = false;
-    } else {
-      setDescriptionError('');
-    }
-
-    // Validate based on input mode
-    if (isManualInput) {
-      if (!manualQueries.trim()) {
-        setManualQueriesError('Manual queries are required.');
-        isValid = false;
-      } else {
-        setManualQueriesError('');
-      }
-    } else {
-      if (querySetSize <= 0) {
-        setQuerySizeError('Query Set Size must be a positive integer.');
-        isValid = false;
-      } else {
-        setQuerySizeError('');
-      }
-    }
-
-    return isValid;
-  };
-
-  // Handle form submission
-  const createQuerySet = useCallback(() => {
-    if (!validateForm()) {
+  const createQuerySet = useCallback(async () => {
+    if (!formState.isFormValid()) {
       return;
     }
 
-    const endpoint = ServiceEndpoints.QuerySets;
-    const method = isManualInput ? 'put' : 'post';
+    try {
+      const querySetData = {
+        name: formState.name,
+        description: formState.description,
+        sampling: formState.sampling,
+        querySetSize: formState.querySetSize,
+        querySetQueries: formState.manualQueries ? JSON.parse(formState.manualQueries) : undefined,
+      };
 
-    const body = isManualInput
-      ? {
-          name,
-          description,
-          sampling: 'manual',
-          querySetQueries: JSON.parse(manualQueries),
-        }
-      : {
-          name,
-          description,
-          sampling,
-          querySetSize,
-        };
-
-    http[method](endpoint, {
-      body: JSON.stringify(body),
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    })
-      .then((response) => {
-        notifications.toasts.addSuccess(`Query set "${name}" created successfully`);
-        history.push('/querySet');
-      })
-      .catch((err) => {
-        notifications.toasts.addError(err, {
-          title: 'Failed to create query set',
-        });
+      await querySetService.createQuerySet(querySetData, formState.isManualInput);
+      notifications.toasts.addSuccess(`Query set "${formState.name}" created successfully`);
+      history.push('/querySet');
+    } catch (err) {
+      notifications.toasts.addError(err, {
+        title: 'Failed to create query set',
       });
-  }, [
-    name,
-    description,
-    sampling,
-    querySetSize,
-    manualQueries,
-    isManualInput,
-    history,
-    notifications.toasts,
-  ]);
+    }
+  }, [formState, querySetService, notifications.toasts, history]);
 
-  // Handle cancel action
-  const handleCancel = () => {
+  const handleCancel = useCallback(() => {
     history.push('/querySet');
-  };
-
-  // Validate name field on blur
-  const validateName = (e) => {
-    const value = e.target.value;
-    if (!value.trim()) {
-      setNameError('Name is a required parameter.');
-    } else if (value.length > 50) {
-      setNameError('Name is too long (> 50 characters).');
-    } else if (!isValidInputString(value)) {
-      setNameError('Name contains invalid characters (e.g., quotes, backslashes, or HTML tags).');
-    } else {
-      setNameError('');
-    }
-  };
-
-  // Validate description field on blur
-  const validateDescription = (e) => {
-    const value = e.target.value;
-    if (!value.trim()) {
-      setDescriptionError('Description is a required parameter.');
-    } else if (value.length > 250) {
-      setDescriptionError('Description is too long (> 250 characters).');
-    } else if (!isValidInputString(value)) {
-      setDescriptionError('Description contains invalid characters (e.g., quotes, backslashes, or HTML tags).');
-    } else {
-      setDescriptionError('');
-    }
-  };
+  }, [history]);
 
   return (
     <EuiPageTemplate paddingSize="l" restrictWidth="100%">
       <EuiPageHeader
         pageTitle="Query Set"
         description={
-                <span>
-                  Create a new query set by{' '}
-                  <a href="https://docs.opensearch.org/docs/latest/search-plugins/search-relevance/query-sets/" target="_blank" rel="noopener noreferrer">
-                    either sampling from UBI data stored in the ubi_queries index or manually uploading a file
-                  </a>
-                  .
-                </span>
-              }
+          <span>
+            Create a new query set by{' '}
+            <a
+              href="https://docs.opensearch.org/docs/latest/search-plugins/search-relevance/query-sets/"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              either sampling from UBI data stored in the ubi_queries index or manually uploading a
+              file
+            </a>
+            .
+          </span>
+        }
         rightSideItems={[
           <EuiButtonEmpty
             onClick={handleCancel}
@@ -301,160 +97,10 @@ export const QuerySetCreate: React.FC<QuerySetCreateProps> = ({ http, notificati
         ]}
       />
 
-      {/* Form Content */}
       <EuiPanel hasBorder={true}>
         <EuiFlexItem>
-          <EuiForm
-            component="form"
-            isInvalid={Boolean(
-              nameError || descriptionError || querySizeError || manualQueriesError
-            )}
-          >
-            <EuiFormRow fullWidth>
-              <EuiButton
-                onClick={() => setIsManualInput(!isManualInput)}
-                size="s"
-                iconType={isManualInput ? 'aggregate' : 'inputOutput'}
-              >
-                Switch to{' '}
-                {isManualInput ? 'sampling queries from UBI data' : 'manually adding queries'}
-              </EuiButton>
-            </EuiFormRow>
-            {/* Name field */}
-            <EuiCompressedFormRow
-              label="Name"
-              isInvalid={nameError.length > 0}
-              error={nameError}
-              helpText="A unique name for this query set."
-              fullWidth
-            >
-              <EuiCompressedTextArea
-                placeholder="Enter query set name"
-                value={name}
-                onChange={(e) => setName(e.target.value)}
-                onBlur={validateName}
-                isInvalid={nameError.length > 0}
-                data-test-subj="querySetNameInput"
-                fullWidth
-              />
-            </EuiCompressedFormRow>
-            {/* Description field */}
-            <EuiCompressedFormRow
-              label="Description"
-              isInvalid={descriptionError.length > 0}
-              error={descriptionError}
-              helpText="Detailed description of the query set purpose."
-              fullWidth
-            >
-              <EuiCompressedTextArea
-                placeholder="Describe the purpose of this query set"
-                value={description}
-                onChange={(e) => setDescription(e.target.value)}
-                onBlur={validateDescription}
-                isInvalid={descriptionError.length > 0}
-                data-test-subj="querySetDescriptionInput"
-                fullWidth
-              />
-            </EuiCompressedFormRow>
-            {isManualInput ? (
-              <EuiFormRow
-                label="Manual Queries"
-                error={manualQueriesError}
-                isInvalid={Boolean(manualQueriesError)}
-                helpText="Upload an NDJSON file with queries (one JSON object per line containing queryText and referenceAnswer)"
-                fullWidth
-              >
-                <EuiFlexGroup>
-                  <EuiFlexItem>
-                    <EuiFilePicker
-                      ref={filePickerRef}
-                      id={filePickerId}
-                      initialPromptText="Select or drag and drop a query file"
-                      onChange={(files) => handleFileContent(files)}
-                      display="large"
-                      aria-label="Upload query file"
-                      accept=".txt"
-                      data-test-subj="manualQueriesFilePicker"
-                      compressed
-                      helpText="Upload a text file containing JSON objects (one per line) with queryText and referenceAnswer fields"
-                    />
-                  </EuiFlexItem>
-                </EuiFlexGroup>
-              </EuiFormRow>
-            ) : (
-              <>
-                {/* Sampling method field */}
-                <EuiFormRow
-                  label="Sampling Method"
-                  helpText={
-                    <span>
-                    Select the sampling method for this query set. Requires ubi_queries index and query events adhering to the{' '}
-                    <a href="https://docs.opensearch.org/docs/latest/search-plugins/ubi/schemas/#ubi-queries-index" target="_blank" rel="noopener noreferrer">
-                      UBI schema
-                    </a>
-                    .<br />
-                    "Random" picks a random sample, "Probability-Proportional-to-Size Sampling" picks a frequency-weighted sample, "Top N" picks the N most frequent queries.
-                    </span>
-                    }
-                  fullWidth
-                >
-                  <EuiSelect
-                    options={samplingOptions}
-                    value={sampling}
-                    onChange={(e) => setSampling(e.target.value)}
-                    data-test-subj="querySetSamplingSelect"
-                    fullWidth
-                  />
-                </EuiFormRow>
-
-                {/* Query set size field */}
-                <EuiFormRow
-                  label="Query Set Size"
-                  error={querySizeError}
-                  isInvalid={Boolean(querySizeError)}
-                  helpText="Number of queries in the set (must be positive)."
-                  fullWidth
-                >
-                  <EuiFieldNumber
-                    value={querySetSize}
-                    min={1}
-                    onChange={(e) => {
-                      const value = parseInt(e.target.value, 10);
-                      setQuerySetSize(isNaN(value) ? 0 : value);
-                      setQuerySizeError(value < 1 ? 'Query Set Size must be positive.' : '');
-                    }}
-                    isInvalid={Boolean(querySizeError)}
-                    fullWidth
-                    data-test-subj="querySetSizeInput"
-                  />
-                </EuiFormRow>
-              </>
-            )}
-          </EuiForm>
-          {isManualInput && parsedQueries.length > 0 && (
-            <EuiFormRow fullWidth label="Parsed Queries Preview">
-              <EuiPanel paddingSize="s">
-                <EuiText size="s">
-                  <h4>Preview ({parsedQueries.length} queries)</h4>
-                  <ul>
-                    {parsedQueries.slice(0, 5).map((query, idx) => {
-                      const parsed = JSON.parse(query);
-                      return (
-                        <li key={idx}>
-                          <strong>Query:</strong> {parsed.queryText}
-                          <br />
-                          <strong>Reference:</strong> {parsed.referenceAnswer}
-                        </li>
-                      );
-                    })}
-                  </ul>
-                  {parsedQueries.length > 5 && (
-                    <p>... and {parsedQueries.length - 5} more queries</p>
-                  )}
-                </EuiText>
-              </EuiPanel>
-            </EuiFormRow>
-          )}
+          <QuerySetForm formState={formState} filePickerId={filePickerId} />
+          {formState.isManualInput && <QueryPreview parsedQueries={formState.parsedQueries} />}
         </EuiFlexItem>
       </EuiPanel>
     </EuiPageTemplate>

--- a/public/components/query_set_create/services/query_set_service.ts
+++ b/public/components/query_set_create/services/query_set_service.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { CoreStart } from '../../../../../../core/public';
+import { ServiceEndpoints } from '../../../../common';
+
+export interface QuerySetData {
+  name: string;
+  description: string;
+  sampling: string;
+  querySetSize?: number;
+  querySetQueries?: Array<{ queryText: string; referenceAnswer: string }>;
+}
+
+export class QuerySetService {
+  constructor(private http: CoreStart['http']) {}
+
+  async createQuerySet(data: QuerySetData, isManualInput: boolean): Promise<any> {
+    const endpoint = ServiceEndpoints.QuerySets;
+    const method = isManualInput ? 'put' : 'post';
+
+    const body = isManualInput
+      ? {
+          name: data.name,
+          description: data.description,
+          sampling: 'manual',
+          querySetQueries: data.querySetQueries,
+        }
+      : {
+          name: data.name,
+          description: data.description,
+          sampling: data.sampling,
+          querySetSize: data.querySetSize,
+        };
+
+    return this.http[method](endpoint, {
+      body: JSON.stringify(body),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+  }
+}

--- a/public/components/query_set_create/utils/file_processor.ts
+++ b/public/components/query_set_create/utils/file_processor.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export interface QueryItem {
+  queryText: string;
+  referenceAnswer: string;
+}
+
+export interface FileProcessResult {
+  queries: QueryItem[];
+  error?: string;
+}
+
+export const processQueryFile = async (file: File): Promise<FileProcessResult> => {
+  try {
+    const text = await file.text();
+    const lines = text.trim().split('\n');
+    const queryList: QueryItem[] = [];
+
+    for (const line of lines) {
+      try {
+        const parsed = JSON.parse(line.trim());
+        if (parsed.queryText) {
+          queryList.push({
+            queryText: String(parsed.queryText).trim(),
+            referenceAnswer: parsed.referenceAnswer ? String(parsed.referenceAnswer).trim() : '',
+          });
+        }
+      } catch (e) {
+        // console.error('Error parsing line:', line, e);
+      }
+    }
+
+    if (queryList.length === 0) {
+      return { queries: [], error: 'No valid queries found in file' };
+    }
+
+    if (queryList.length > 1000000) {
+      return { queries: [], error: 'Too many queries found (> 1,000,000)' };
+    }
+
+    return { queries: queryList };
+  } catch (error) {
+    // console.error('Error processing file:', error);
+    return { queries: [], error: 'Error reading file content' };
+  }
+};

--- a/public/components/query_set_create/utils/validation.ts
+++ b/public/components/query_set_create/utils/validation.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export interface ValidationErrors {
+  nameError: string;
+  descriptionError: string;
+  querySizeError: string;
+  manualQueriesError: string;
+}
+
+export interface FormData {
+  name: string;
+  description: string;
+  querySetSize: number;
+  manualQueries: string;
+  isManualInput: boolean;
+}
+
+/**
+ * Validates if a string contains characters that might break JSON parsing or cause XSS
+ * @param input The string to validate
+ * @returns true if the string is valid, false otherwise
+ */
+export const isValidInputString = (input: string): boolean => {
+  // Regex to detect characters that might break JSON parsing or cause XSS:
+  // - Double quotes (")
+  // - Backslashes (\)
+  // - HTML tags (<, >)
+  // - Control characters (U+0000 to U+001F) and other problematic unicode characters
+  //   that could interfere with JSON or string parsing.
+  const forbiddenCharsRegex = /[<>"\\\x00-\x1F]/;
+  return !forbiddenCharsRegex.test(input);
+};
+
+export const validateForm = (data: FormData): ValidationErrors => {
+  const errors: ValidationErrors = {
+    nameError: '',
+    descriptionError: '',
+    querySizeError: '',
+    manualQueriesError: '',
+  };
+
+  if (!data.name.trim()) {
+    errors.nameError = 'Name is a required parameter.';
+  } else if (data.name.length > 50) {
+    errors.nameError = 'Name is too long (> 50 characters).';
+  } else if (!isValidInputString(data.name)) {
+    errors.nameError =
+      'Name contains invalid characters (e.g., quotes, backslashes, or HTML tags).';
+  }
+
+  if (!data.description.trim()) {
+    errors.descriptionError = 'Description is a required parameter.';
+  } else if (data.description.length > 250) {
+    errors.descriptionError = 'Description is too long (> 250 characters).';
+  } else if (!isValidInputString(data.description)) {
+    errors.descriptionError =
+      'Description contains invalid characters (e.g., quotes, backslashes, or HTML tags).';
+  }
+
+  if (data.isManualInput) {
+    if (!data.manualQueries.trim()) {
+      errors.manualQueriesError = 'Manual queries are required.';
+    }
+  } else {
+    if (data.querySetSize <= 0) {
+      errors.querySizeError = 'Query Set Size must be a positive integer.';
+    }
+  }
+
+  return errors;
+};
+
+export const hasValidationErrors = (errors: ValidationErrors): boolean => {
+  return Object.values(errors).some((error) => error.length > 0);
+};

--- a/test/setup.jest.ts
+++ b/test/setup.jest.ts
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-// import '@testing-library/jest-dom/extend-expect';
-// import { configure } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import { configure } from '@testing-library/react';
 
-// configure({ testIdAttribute: 'data-test-subj' });
+configure({ testIdAttribute: 'data-test-subj' });
 
 window.URL.createObjectURL = () => '';
 HTMLCanvasElement.prototype.getContext = () => '';


### PR DESCRIPTION
### Description
As one of the operation goals, we would like to add unit tests for search relevance workbench new UI/UX experience. 

## Structure

```
query_set_create/
├── components/           # UI Components
│   ├── query_set_form.tsx    # Form component for query set fields
│   └── query_preview.tsx     # Preview component for parsed queries
├── hooks/               # Custom React Hooks
│   └── use_query_set_form.ts # Form state management hook
├── services/            # API Service Layer
│   └── query_set_service.ts  # Query set API operations
├── utils/               # Business Logic Utilities
│   ├── validation.ts         # Form validation logic
│   └── file_processor.ts     # File processing utilities
├── __tests__/           # Unit Tests
│   ├── validation.test.ts
│   ├── file_processor.test.ts
│   ├── query_set_service.test.ts
│   ├── query_set_create.test.tsx
│   ├── query_preview.test.tsx
│   ├── query_set_form.test.tsx
│   └── use_query_set_form.test.ts
├── query_set_create.tsx # Main component (refactored)
├── index.ts
└── README.md
```
### Issues Resolved
- #562 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
