### PR TITLE
Do not show Pipeline error if there are no pipelines yet.

### DIFF
--- a/public/components/query_compare/home.tsx
+++ b/public/components/query_compare/home.tsx
@@ -117,7 +117,10 @@ export const Home = ({
         } else {
           setFetchedPipelines2('');
         }
-        console.error(err);
+        // only log error if it's not a 404, see: https://github.com/opensearch-project/OpenSearch/issues/15917
+        if (err.body.statusCode !== 404) {
+          console.error(err);
+        }
       });
   };
 

--- a/public/components/search_config_create/search_config_create.tsx
+++ b/public/components/search_config_create/search_config_create.tsx
@@ -153,7 +153,11 @@ export const SearchConfigurationCreate: React.FC<SearchConfigurationCreateProps>
       }));
       setPipelineOptions(options);
     } catch (error) {
-      notifications.toasts.addDanger('Failed to fetch search pipelines');
+      // only log error if it's not a 404, see: https://github.com/opensearch-project/OpenSearch/issues/15917
+      if (error.body.statusCode !== 404) {
+        notifications.toasts.addDanger('Failed to fetch search pipelines');
+        console.error(error);
+      }
     } finally {
       setIsLoadingPipelines(false);
     }

--- a/server/routes/dsl_route.ts
+++ b/server/routes/dsl_route.ts
@@ -314,7 +314,7 @@ export function registerDslRoute(router: IRouter, dataSourceEnabled: boolean) {
         );
         if (error.statusCode !== 404) console.error(error);
         return response.customError({
-          statusCode: 404,
+          statusCode: error.statusCode || 400,
           body: error,
         });
       }


### PR DESCRIPTION
### Description
An error is shown to the user when no Pipelines exist yet. This is not a real error, the cause is that OpenSearch returns 404 when searching for pipelines when none exist yet (see https://github.com/opensearch-project/OpenSearch/issues/15917). This PR avoids reporting the 404 to not give the wrong impression that an error happened to the user.

### Screenshots
This screenshot for example shows that prior to this PR, when the Search Configuration creation page is open, an error fetching pipelines notification is shown:
<img width="1480" height="806" alt="Screenshot 2025-07-22 at 12 44 13" src="https://github.com/user-attachments/assets/3ce4d3dd-1ee3-433c-8f49-16afdf7e45cb" />

### Issues Resolved
It resolves the pipelines part of https://github.com/opensearch-project/dashboards-search-relevance/issues/557

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
