### PR TITLE
Timeout being exceed, copilot suggests starting with extending timeout

### DIFF
--- a/.github/workflows/remote-integ-tests-workflow.yml
+++ b/.github/workflows/remote-integ-tests-workflow.yml
@@ -93,10 +93,10 @@ jobs:
 
       - name: Wait OpenSearch Dashboards Compiled Completed
         run: |
-          if timeout 900 grep -q "bundles compiled successfully after" <(tail -n0 -f dashboard.log); then
+          if timeout 1800 grep -q "bundles compiled successfully after" <(tail -n0 -f dashboard.log); then
             echo "OpenSearch Dashboards compiled successfully."
           else
-            echo "Timeout for 900 seconds reached. OpenSearch Dashboards did not finish compiling."
+            echo "Timeout for 1800 seconds reached. OpenSearch Dashboards did not finish compiling."
             exit 1
           fi
         working-directory: OpenSearch-Dashboards

--- a/.github/workflows/remote-integ-tests-workflow.yml
+++ b/.github/workflows/remote-integ-tests-workflow.yml
@@ -108,7 +108,7 @@ jobs:
 
       - name: Health check
         run: |
-          timeout 600 bash -c 'while [[ "$(curl -k http://localhost:5601/api/status | jq -r '.status.overall.state')" != "green" ]]; do sleep 5; done'
+          timeout 1200 bash -c 'while [[ "$(curl -k http://localhost:5601/api/status | jq -r '.status.overall.state')" != "green" ]]; do sleep 5; done'
         shell: bash
 
       - name: Check OpenSearch Dashboards Running on Linux


### PR DESCRIPTION
### Description
See if extending timeout gets E2E test to pass, maybe resource constrained?

### Issues Resolved
n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
