### PR TITLE
Avoid validation results overflow in the creation of Search Configuration

### DIFF
--- a/public/components/search_config_create/results_panel.scss
+++ b/public/components/search_config_create/results_panel.scss
@@ -1,0 +1,9 @@
+.resultsPanel__scrollContainer {
+  width: 100%;
+  overflow-x: auto;
+  max-width: 100%;
+}
+
+.osd-table {
+  min-width: max-content;
+} 

--- a/public/components/search_config_create/results_panel.tsx
+++ b/public/components/search_config_create/results_panel.tsx
@@ -6,6 +6,7 @@
 import React from 'react';
 import { EuiLoadingSpinner, EuiPanel, EuiSpacer } from '@elastic/eui';
 import { uniqueId } from 'lodash';
+import './results_panel.scss';
 
 interface ResultsPanelProps {
   isValidating: boolean;
@@ -38,9 +39,13 @@ export const ResultsPanel: React.FC<ResultsPanelProps> = ({ isValidating, search
     ];
 
     Object.entries(document._source).forEach(([key, value]) => {
+      let displayValue = String(value);
+      if (displayValue.length > 50) {
+        displayValue = displayValue.slice(0, 50) + '…';
+      }
       cells.push(
         <td key={key} className="osdDocTable__cell">
-          {String(value)}
+          {displayValue}
         </td>
       );
     });
@@ -85,7 +90,7 @@ export const ResultsPanel: React.FC<ResultsPanelProps> = ({ isValidating, search
     <EuiPanel>
       <h3>Search Results ({hits.length} hits)</h3>
       <EuiSpacer size="s" />
-      <div className="dscTable dscTableFixedScroll">
+      <div className="resultsPanel__scrollContainer dscTable dscTableFixedScroll">
         <table className="osd-table table" data-test-subj="docTable">
           <thead>
             <tr className="osdDocTable__headerRow">{getHeaders()}</tr>


### PR DESCRIPTION
### Description
In the Search Configuration create screen, the validation results table may overflow horizontally.

### Issues Resolved
https://github.com/opensearch-project/dashboards-search-relevance/issues/584

### Screenshots
Here are screenshots that show that the overflow does not happen anymore:
<img width="1447" height="684" alt="Screenshot 2025-07-22 at 21 31 04" src="https://github.com/user-attachments/assets/dd4418ca-58ab-4ab2-9d1c-c7548fb0ebfb" />
<img width="1444" height="686" alt="Screenshot 2025-07-22 at 21 31 19" src="https://github.com/user-attachments/assets/c92bed07-f122-41b4-ace9-e6dc8946d906" />
<img width="1443" height="684" alt="Screenshot 2025-07-22 at 21 31 35" src="https://github.com/user-attachments/assets/a6eced16-d276-464f-8a78-1cbaa798d895" />


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
