### PR TITLE
Fix wrong unique number of results in Venn diagram

### DIFF
--- a/public/components/query_compare/search_result/visual_comparison/connection_lines.tsx
+++ b/public/components/query_compare/search_result/visual_comparison/connection_lines.tsx
@@ -11,7 +11,7 @@ interface ConnectionLinesProps {
   result2: any[];
   result1ItemsRef: React.MutableRefObject<{ [key: string]: HTMLDivElement }>;
   result2ItemsRef: React.MutableRefObject<{ [key: string]: HTMLDivElement }>;
-  lineColors: { [key: string]: string };
+  lineColors: { [key: string]: { stroke: string; strokeWidth: number } };
 }
 
 export const ConnectionLines: React.FC<ConnectionLinesProps> = ({


### PR DESCRIPTION
### Description
In some circumstances, the Venn diagram in the eyeballing tool may display a non-zero number of unique results although the eyeballing clearly shows that no results were retrieved.

Explanation of the problem: the eyeballing component gets two arguments `queryResult1` and `queryResult2` which are then used to populate other state variables like `result1`, `result2` and statistical information for the Venn diagram `statistics`. Sometimes when changing between queries in the comparison window, resul1 and statistics are updated in different `useEffect` blocks. While this happens, the Venn diagram is rendered with the information from the previous query (non-zero). The fix consists in computing the Venn diagram statistics and the results to be rendered in the same `useEffect` block.

There are some additional fixes to ensure connection lines are drawn after the change. Also some removal of dead code and type signature corrections.

### Screenshots
Screenshot of the issue:
<img width="1086" height="772" alt="Screenshot 2025-07-23 at 11 21 16" src="https://github.com/user-attachments/assets/231b3420-4da0-451e-8fdb-b592a53efea4" />

After the fix, the correct 0 unique results are reported.

### Issues Resolved
https://github.com/opensearch-project/dashboards-search-relevance/issues/529

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
