### PR TITLE
Change wording for query set creation to improve consistency and clarity

### DIFF
--- a/public/components/query_set_create/components/query_set_form.tsx
+++ b/public/components/query_set_create/components/query_set_form.tsx
@@ -62,7 +62,7 @@ export const QuerySetForm: React.FC<QuerySetFormProps> = ({ formState, filePicke
         label="Name"
         isInvalid={errors.nameError.length > 0}
         error={errors.nameError}
-        helpText="A unique name for this query set."
+        helpText="Choose an expressive name for this query set (< 50 characters)."
         fullWidth
       >
         <EuiCompressedTextArea
@@ -80,7 +80,7 @@ export const QuerySetForm: React.FC<QuerySetFormProps> = ({ formState, filePicke
         label="Description"
         isInvalid={errors.descriptionError.length > 0}
         error={errors.descriptionError}
-        helpText="Detailed description of the query set purpose."
+        helpText="Describe the query set (< 250 characters)."
         fullWidth
       >
         <EuiCompressedTextArea
@@ -137,7 +137,7 @@ export const QuerySetForm: React.FC<QuerySetFormProps> = ({ formState, filePicke
             label="Query Set Size"
             error={errors.querySizeError}
             isInvalid={Boolean(errors.querySizeError)}
-            helpText="Number of queries in the set (must be positive)."
+            helpText="Pick the amount of queries for this query set (must be positive)."
             fullWidth
           >
             <EuiFieldNumber


### PR DESCRIPTION
### Description
Change the `helpText` definitions for the input form creating query sets:

* "A unique name for this query set." --> "Choose an expressive name for this query set (< 50 characters)."
* "Detailed description of the query set purpose." --> "Describe the query set (< 250 characters)."
* "Number of queries in the set (must be positive)" --> "Pick the amount of queries for this query set (must be positive)."

### Issues Resolved
#589 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
