### PR TITLE
Publish metrics stats without authorization to make it accessible to monitoring systems

### DIFF
--- a/server/routes/metrics_route.ts
+++ b/server/routes/metrics_route.ts
@@ -11,6 +11,9 @@ export function registerMetricsRoute(router: IRouter) {
     {
       path: ServiceEndpoints.GetStats,
       validate: false,
+      options: {
+        authRequired: false,
+      },
     },
     async (context, _, response) => {
       try {


### PR DESCRIPTION
### Description
Followed metrics stats endpoints that are specifically designed to be publicly accessible, likely because stats are considered non-sensitive operational data that monitoring systems need to access without authentication.

- `/api/status` - https://github.com/opensearch-project/OpenSearch-Dashboards/blob/086ebe228c769a5572361fe13c15c3255d2dca93/src/core/server/status/routes/status.ts#L129
- `/api/reporting/stas` - https://github.com/opensearch-project/security-dashboards-plugin/blob/4e6e71e7f4242cef15dd146da38c9a89a9ea4878/server/index.ts#L116

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
