### PR TITLE
Add polling mechanism to experiment_listing and judgment_listing view

### DIFF
--- a/public/components/experiment_create/configuration/form/llm_form.tsx
+++ b/public/components/experiment_create/configuration/form/llm_form.tsx
@@ -30,7 +30,7 @@ export const LLMForm = ({ formData, onChange }: LLMFormProps) => {
               onChange={handleQuerySetsChange}
               isClearable={true}
               isInvalid={formData.querySets.length === 0}
-              multi={true}
+              singleSelection={false}
             />
           </EuiFormRow>
         </EuiFlexItem>

--- a/public/components/experiment_create/configuration/search_configuration_form.tsx
+++ b/public/components/experiment_create/configuration/search_configuration_form.tsx
@@ -72,7 +72,7 @@ export const SearchConfigForm = ({
       isClearable={true}
       isInvalid={selectedOptions.length === 0}
       isLoading={isLoadingConfigs}
-      multi={true}
+      singleSelection={maxNumberOfOptions === 1 ? { asPlainText: true } : false}
       fullWidth
     />
   );
@@ -84,7 +84,7 @@ export const SearchConfigForm = ({
     return (
       <EuiFormRow
         label="Search Configurations"
-        helpText={`Select ${maxNumberOfOptions} search configuration${
+        helpText={`Select ${maxNumberOfOptions === 1 ? '1' : 'up to ' + maxNumberOfOptions} search configuration${
           maxNumberOfOptions > 1 ? 's' : ''
         }${maxNumberOfOptions > 1 ? ' to compare against each other' : ''}.`}
       >

--- a/public/components/experiment_create/configuration/template_configuration.tsx
+++ b/public/components/experiment_create/configuration/template_configuration.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 
 import {
   EuiFlexItem,
@@ -33,6 +33,13 @@ export const TemplateConfiguration = ({
   const [showTemplateConfigError, setShowTemplateConfigError] = useState<boolean>(false);
 
   const configurationFormRef = useRef<ConfigurationFormRef>(null);
+  const isMountedRef = useRef(true);
+
+  useEffect(() => {
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
 
   const {
     services: { http, notifications },
@@ -57,7 +64,9 @@ export const TemplateConfiguration = ({
         });
 
         if (response.experiment_id) {
-          setExperimentId(response.experiment_id);
+          if (isMountedRef.current) {
+            setExperimentId(response.experiment_id);
+          }
           notifications.toasts.addSuccess(
             `Experiment ${response.experiment_id} created successfully`
           );
@@ -73,7 +82,9 @@ export const TemplateConfiguration = ({
           title: 'Failed to create experiment',
         });
       } finally {
-        setIsCreating(false);
+        if (isMountedRef.current) {
+          setIsCreating(false);
+        }
       }
     } else {
       // This case should ideally not happen if the form is rendered,


### PR DESCRIPTION
### Description
Currently, Listing pages don't have polling mechanism, which means when a experiment status changes from "PROCESSING" to "COMPLETED", a user has to refresh the page manually to reflect the up to date status. Also, judgment listing is lack of status tracking.

## Changes
- Add polling mechanism to auto refreshing the table items status
  - refreshing interval - 15 seconds
  - timeout - 10 minutes
- Add judgment status to judgment_listing table
- Add colors to status
  - ERROR - danger red
  - PROCESSING - warning yellow
  - COMPLETE - success green 

## Screenshots

- experiment listing page

<img width="1199" height="871" alt="Screenshot 2025-07-28 at 11 49 58 AM" src="https://github.com/user-attachments/assets/4ebb3a63-fe56-4463-a5c8-2b5b66cd95d7" />

- judgment listing page

<img width="1204" height="725" alt="Screenshot 2025-07-28 at 11 49 38 AM" src="https://github.com/user-attachments/assets/c24c5110-1fbc-4f8e-aa5d-4be190748f71" />





### Issues Resolved
- #556 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
