### PR TITLE
Default to new SRW UI, while allowing opt out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * Use Dashboards to visualize results of Evaluation and Hybrid Experiments ([#570](https://github.com/opensearch-project/dashboards-search-relevance/pull/570))
 * Enable AutoPopulated Fields in SearchRelevance Query Compare Plugin Page ([#577](https://github.com/opensearch-project/dashboards-search-relevance/pull/577))
 * Add polling mechanism to experiment_listing and judgment_listing view ([#594](https://github.com/opensearch-project/dashboards-search-relevance/pull/594))
+* Change default UI to the new SRW interface, preserve opt out option ([#614](https://github.com/opensearch-project/dashboards-search-relevance/pull/614))
 
 ### Enhancements
 * Fetch models from ml-commons and add validation ([#568](https://github.com/opensearch-project/dashboards-search-relevance/pull/568))

--- a/server/plugin.ts
+++ b/server/plugin.ts
@@ -51,7 +51,7 @@ export class SearchRelevancePlugin
     core.uiSettings.register({
       [SEARCH_RELEVANCE_EXPERIMENTAL_WORKBENCH_UI_EXPERIENCE_ENABLED]: {
         name: 'Experimental Search Relevance Workbench',
-        value: false,
+        value: true,
         description: 'Whether to opt-in the experimental search relevance workbench feature',
         schema: schema.boolean(),
         category: ['search relevance'],


### PR DESCRIPTION
### Description

Changes the default UI to new the SRW UI.  Users can still opt out for the original one.

### Issues Resolved
Closes #605 

### Check List

- [ x] New functionality includes testing.
  - [ x] All tests pass, including unit test, integration test
- [ ] New functionality has been documented.
- [x ] Commits are signed per the DCO using `--signoff`

We have a seperate ticket to update docs in 3.2

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
