### PR TITLE
Update delete-backport-branch workflow to include release-chores branches

### DIFF
--- a/.github/workflows/delete-backport-branch.yml
+++ b/.github/workflows/delete-backport-branch.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   delete-branch:
     runs-on: ubuntu-latest
-    if: startsWith(github.event.pull_request.head.ref,'backport-')
+    if: startsWith(github.event.pull_request.head.ref,'backport-') || startsWith(github.event.pull_request.head.ref,'release-chores/')
     steps:
       - name: Delete merged branch
         uses: SvanBoxel/delete-merged-branch@main


### PR DESCRIPTION
This PR updates the delete-backport-branch workflow to automatically delete branches that start with 'release-chores/' after they are merged, in addition to the existing condition for 'backport-' branches.