### PR TITLE
Replace delete-merged-branch action with GitHub script

### DIFF
--- a/.github/workflows/delete-backport-branch.yml
+++ b/.github/workflows/delete-backport-branch.yml
@@ -10,6 +10,11 @@ jobs:
     if: startsWith(github.event.pull_request.head.ref,'backport-') || startsWith(github.event.pull_request.head.ref,'release-chores/')
     steps:
       - name: Delete merged branch
-        uses: SvanBoxel/delete-merged-branch@main
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.git.deleteRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: `heads/${context.payload.pull_request.head.ref}`,
+            })


### PR DESCRIPTION
This PR replaces the SvanBoxel/delete-merged-branch action with a custom GitHub script using actions/github-script@v7. This provides a more direct approach using the GitHub API to delete branches after they are merged.