### PR TITLE
Update delete-backport-branch workflow permissions

### DIFF
--- a/.github/workflows/delete-backport-branch.yml
+++ b/.github/workflows/delete-backport-branch.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   delete-branch:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     if: startsWith(github.event.pull_request.head.ref,'backport-') || startsWith(github.event.pull_request.head.ref,'release-chores/')
     steps:
       - name: Delete merged branch


### PR DESCRIPTION
This PR updates the delete-backport-branch workflow to use the proper permissions configuration with  instead of . This ensures that the workflow has the necessary permissions to delete branches after PRs are merged.