### PR TITLE
Update delete-backport-branch workflow permissions

### DIFF
--- a/.github/workflows/delete-backport-branch.yml
+++ b/.github/workflows/delete-backport-branch.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   delete-branch:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     if: startsWith(github.event.pull_request.head.ref,'backport-') || startsWith(github.event.pull_request.head.ref,'release-chores/')
     steps:
       - name: Delete merged branch

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Bug Fixes
 
 ### Infrastructure
+- Update delete-backport-branch workflow permissions to use contents:write instead of pull-requests:write
 
 ### Documentation
 


### PR DESCRIPTION
This PR updates the delete-backport-branch workflow to use the proper permissions configuration with contents:write instead of pull-requests:write. This ensures that the workflow has the necessary permissions to delete branches after PRs are merged.