### PR TITLE
Improve color codings for search result comparison to be less misleading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Support semantic highlighting and dynamic image sizing ([#627](https://github.com/opensearch-project/dashboards-search-relevance/pull/627))
 
 ### Enhancements
-- Improve color coding ()
+- Improve color coding ([#632](https://github.com/opensearch-project/dashboards-search-relevance/pull/632))
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Support semantic highlighting and dynamic image sizing ([#627](https://github.com/opensearch-project/dashboards-search-relevance/pull/627))
 
 ### Enhancements
+- Improve color coding ()
 
 ### Bug Fixes
 

--- a/public/components/query_compare/search_result/visual_comparison/__tests__/visual_comparison.test.tsx
+++ b/public/components/query_compare/search_result/visual_comparison/__tests__/visual_comparison.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { VisualComparison, convertFromSearchResult } from '../visual_comparison';
 
 const mockQueryResult1 = [
@@ -156,5 +156,15 @@ describe('convertFromSearchResult', () => {
     // Assert that the element with class 'bg-unchanged' exists inside the specific item
     const commonElement = result2Item2.querySelector('.bg-result-set-2');
     expect(commonElement).toBeInTheDocument();
+  });
+
+  it('shows ItemDetailHoverPane on item click', () => {
+    render(<VisualComparison {...defaultProps} />);
+    // Text is not there without click
+    expect(screen.queryByText('Test Document 1')).not.toBeInTheDocument();
+    // Click the first item by its unique ID
+    fireEvent.click(document.getElementById('r1-item-1'));
+    // Assert that the title from the mock data appears in the document
+    expect(screen.getByText('Test Document 1')).toBeInTheDocument();
   });
 });

--- a/public/components/query_compare/search_result/visual_comparison/__tests__/visual_comparison.test.tsx
+++ b/public/components/query_compare/search_result/visual_comparison/__tests__/visual_comparison.test.tsx
@@ -109,4 +109,52 @@ describe('convertFromSearchResult', () => {
     const result = convertFromSearchResult(undefined);
     expect(result).toBeUndefined();
   });
+
+  it('correctly applies status colors for elements in both results', () => {
+    const { container } = render(<VisualComparison {...defaultProps} />);
+
+    // Find the parent container by its ID
+    const result2ItemsContainer = container.querySelector('#result2-items');
+    expect(result2ItemsContainer).toBeInTheDocument();
+
+    // Find the specific result item within the container by its ID
+    const result2Item1 = result2ItemsContainer.querySelector('#r2-item-1');
+    expect(result2Item1).toBeInTheDocument();
+
+    // Assert that the element with class 'bg-unchanged' exists inside the specific item
+    const commonElement = result2Item1.querySelector('.bg-unchanged');
+    expect(commonElement).toBeInTheDocument();
+  });
+
+  it('correctly applies status colors for elements only in left result', () => {
+    const { container } = render(<VisualComparison {...defaultProps} />);
+
+    // Find the parent container by its ID
+    const result1ItemsContainer = container.querySelector('#result1-items');
+    expect(result1ItemsContainer).toBeInTheDocument();
+
+    // Find the specific result item within the container by its ID
+    const result1Item2 = result1ItemsContainer.querySelector('#r1-item-2');
+    expect(result1Item2).toBeInTheDocument();
+
+    // Assert that the element with class 'bg-unchanged' exists inside the specific item
+    const commonElement = result1Item2.querySelector('.bg-result-set-1');
+    expect(commonElement).toBeInTheDocument();
+  });
+
+  it('correctly applies status colors for elements only in right result', () => {
+    const { container } = render(<VisualComparison {...defaultProps} />);
+
+    // Find the parent container by its ID
+    const result2ItemsContainer = container.querySelector('#result2-items');
+    expect(result2ItemsContainer).toBeInTheDocument();
+
+    // Find the specific result item within the container by its ID
+    const result2Item2 = result2ItemsContainer.querySelector('#r2-item-3');
+    expect(result2Item2).toBeInTheDocument();
+
+    // Assert that the element with class 'bg-unchanged' exists inside the specific item
+    const commonElement = result2Item2.querySelector('.bg-result-set-2');
+    expect(commonElement).toBeInTheDocument();
+  });
 });

--- a/public/components/query_compare/search_result/visual_comparison/__tests__/visual_comparison.test.tsx
+++ b/public/components/query_compare/search_result/visual_comparison/__tests__/visual_comparison.test.tsx
@@ -80,11 +80,6 @@ describe('VisualComparison', () => {
     render(<VisualComparison {...defaultProps} queryResult1={[]} queryResult2={[]} />);
     expect(screen.getAllByText('(0 results)')).toHaveLength(2);
   });
-
-  it('displays style selector accordion', () => {
-    render(<VisualComparison {...defaultProps} />);
-    expect(screen.getByText('Visualization Style Options')).toBeInTheDocument();
-  });
 });
 
 describe('convertFromSearchResult', () => {

--- a/public/components/query_compare/search_result/visual_comparison/visual_comparison.scss
+++ b/public/components/query_compare/search_result/visual_comparison/visual_comparison.scss
@@ -1,4 +1,4 @@
-/* 
+/*
  * Enhanced OpenSearch Comparison Component Styles
  * Compatible with OpenSearch Dashboards
  */
@@ -380,12 +380,12 @@
   background-color: #eff6ff;
 }
 
-.bg-blue-100 {
-  background-color: #dbeafe;
-}
-
 .bg-blue-300 {
   background-color: #93c5fd;
+}
+
+.bg-unchanged {
+  background-color: #d8f9d5;
 }
 
 .bg-green-50 {
@@ -394,10 +394,6 @@
 
 .bg-green-100 {
   background-color: #d1fae5;
-}
-
-.bg-green-300 {
-  background-color: #86efac;
 }
 
 .bg-yellow-50 {
@@ -410,8 +406,12 @@
   --gray-custom: 240, 242, 244;
 }
 
-.bg-yellow-custom {
-  background-color: rgb(var(--yellow-custom));
+.bg-result-set-1 {
+  background-color: #859fd1;
+}
+
+.bg-result-set-2 {
+  background-color: #abeb14;
 }
 
 .bg-yellow-300 {
@@ -428,19 +428,6 @@
 
 .bg-purple-300 {
   background-color: #c4b5fd;
-}
-
-.bg-purple-custom {
-  background-color: rgb(var(--purple-custom));
-}
-
-.rank-no-change {
-  background-color: rgb(var(--gray-custom));
-  // border: 1px solid #000;
-}
-
-.bg-red-300 {
-  background-color: #fca5a5;
 }
 
 .text-gray-600 {
@@ -533,27 +520,27 @@ svg line {
   .bg-white {
     background-color: #1d1e24;
   }
-  
+
   .bg-gray-50 {
     background-color: #25262e;
   }
-  
+
   .bg-gray-100 {
     background-color: #2d2e36;
   }
-  
+
   .border, .border-t, .border-b {
     border-color: #343741;
   }
-  
+
   .text-gray-600 {
     color: #a7a8ad;
   }
-  
+
   .text-gray-700 {
     color: #d3dae6;
   }
-  
+
   .comparison-tooltip {
     background-color: #1d1e24;
     border-color: #343741;

--- a/public/components/query_compare/search_result/visual_comparison/visual_comparison.tsx
+++ b/public/components/query_compare/search_result/visual_comparison/visual_comparison.tsx
@@ -45,86 +45,23 @@ export const convertFromSearchResult = (searchResult) => {
 
 export const defaultStyleConfig = {
   lineColors: {
-    unchanged: { stroke: '#93C5FD', strokeWidth: 4 },
-    increased: { stroke: '#86EFAC', strokeWidth: 4 },
-    decreased: { stroke: '#FCA5A5', strokeWidth: 4 },
+    unchanged: { stroke: '#d8f9d5', strokeWidth: 4 },
+    increased: { stroke: '#d8f9d5', strokeWidth: 4 },
+    decreased: { stroke: '#d8f9d5', strokeWidth: 4 },
   },
   statusClassName: {
-    unchanged: 'bg-blue-300',
-    increased: 'bg-green-300',
-    decreased: 'bg-red-300',
-    inResult1: 'bg-yellow-custom',
-    inResult2: 'bg-purple-custom',
+    unchanged: 'bg-unchanged',
+    increased: 'bg-unchanged',
+    decreased: 'bg-unchanged',
+    inResult1: 'bg-result-set-1',
+    inResult2: 'bg-result-set-2',
   },
   vennDiagramStyle: {
-    left: { backgroundColor: 'rgba(var(--yellow-custom), 0.9)' },
-    middle: { backgroundColor: 'rgba(219, 234, 254, 0.7)' },
-    right: { backgroundColor: 'rgba(var(--purple-custom), 0.9)' },
+    left: { backgroundColor: 'rgba(133, 159, 209, 1.0)' },
+    middle: { backgroundColor: 'rgba(216,249,213, 0.7)' },
+    right: { backgroundColor: 'rgba(170, 235, 20, 1.0)' },
   },
-  hideLegend: [],
-};
-
-export const rankingChangeStyleConfig = {
-  lineColors: {
-    unchanged: { stroke: '#93C5FD', strokeWidth: 4 },
-    increased: { stroke: '#86EFAC', strokeWidth: 4 },
-    decreased: { stroke: '#FCA5A5', strokeWidth: 4 },
-  },
-  statusClassName: {
-    unchanged: 'bg-blue-300',
-    increased: 'bg-green-300',
-    decreased: 'bg-red-300',
-    inResult1: 'bg-purple-custom',
-    inResult2: 'bg-purple-custom',
-  },
-  vennDiagramStyle: {
-    left: { backgroundColor: 'rgba(var(--purple-custom), 0.9)' },
-    middle: { backgroundColor: 'rgba(219, 234, 254, 0.7)' },
-    right: { backgroundColor: 'rgba(var(--purple-custom), 0.9)' },
-  },
-  hideLegend: ['inResult1', 'inResult2'],
-};
-
-export const rankingChange2StyleConfig = {
-  lineColors: {
-    unchanged: { stroke: '#93C5FD', strokeWidth: 4 },
-    increased: { stroke: '#86EFAC', strokeWidth: 4 },
-    decreased: { stroke: '#FCA5A5', strokeWidth: 4 },
-  },
-  statusClassName: {
-    unchanged: 'bg-blue-300',
-    increased: 'bg-green-300',
-    decreased: 'bg-red-300',
-    inResult1: 'rank-no-change',
-    inResult2: 'rank-no-change',
-  },
-  vennDiagramStyle: {
-    left: { backgroundColor: 'rgba(var(--gray-custom), 0.9)' },
-    middle: { backgroundColor: 'rgba(var(--gray-custom), 0.7)' },
-    right: { backgroundColor: 'rgba(var(--gray-custom), 0.9)' },
-  },
-  hideLegend: ['inResult1', 'inResult2'],
-};
-
-export const vennDiagramStyleConfig = {
-  lineColors: {
-    unchanged: { stroke: 'black', strokeWidth: 2 },
-    increased: { stroke: 'black', strokeWidth: 2 },
-    decreased: { stroke: 'black', strokeWidth: 2 },
-  },
-  statusClassName: {
-    unchanged: 'bg-blue-100',
-    increased: 'bg-blue-100',
-    decreased: 'bg-blue-100',
-    inResult1: 'bg-purple-custom',
-    inResult2: 'bg-purple-custom',
-  },
-  vennDiagramStyle: {
-    left: { backgroundColor: 'rgba(var(--purple-custom), 0.9)' },
-    middle: { backgroundColor: 'rgba(219, 234, 254, 0.7)' },
-    right: { backgroundColor: 'rgba(var(--purple-custom), 0.9)' },
-  },
-  hideLegend: ['inResult1', 'inResult2', 'unchanged', 'increased', 'decreased'],
+  hideLegend: ['unchanged', 'increased', 'decreased', 'inResult1', 'inResult2'],
 };
 
 // Utility function to determine display fields and image field
@@ -203,16 +140,8 @@ export const VisualComparison = ({
 
   // Get the style based on selection
   const getCurrentStyle = () => {
-    switch (selectedStyle) {
-      case 'simpler':
-        return rankingChangeStyleConfig;
-      case 'simpler2':
-        return rankingChange2StyleConfig;
-      case 'twoColor':
-        return vennDiagramStyleConfig;
-      default:
-        return defaultStyleConfig;
-    }
+    // Return the default style config. Keep this in case the need for additional styles turns up.
+    return defaultStyleConfig;
   };
 
   const { lineColors, statusClassName, vennDiagramStyle, hideLegend } = getCurrentStyle();
@@ -545,47 +474,6 @@ export const VisualComparison = ({
                 {resultText2}
               </div>
             )}
-          </div>
-
-          {/* Style selector dropdown */}
-          <div className="mt-4">
-            <EuiAccordion
-              id="styleSelectorAccordion"
-              buttonContent={<span className="text-xs">Visualization Style Options</span>}
-              paddingSize="m"
-            >
-              <EuiFormRow label="Visualization Style:" id="styleSelectorForm">
-                <EuiSuperSelect
-                  id="style-selector"
-                  options={[
-                    {
-                      value: 'default',
-                      inputDisplay: 'Default Style',
-                      dropdownDisplay: 'Default Style',
-                    },
-                    {
-                      value: 'simpler',
-                      inputDisplay: 'Ranking Change Color Coding',
-                      dropdownDisplay: 'Ranking Change Color Coding',
-                    },
-                    {
-                      value: 'simpler2',
-                      inputDisplay: 'Ranking Change Color Coding 2',
-                      dropdownDisplay: 'Ranking Change Color Coding 2',
-                    },
-                    {
-                      value: 'twoColor',
-                      inputDisplay: 'Venn Diagram Color Coding',
-                      dropdownDisplay: 'Venn Diagram Color Coding',
-                    },
-                  ]}
-                  valueOfSelected={selectedStyle}
-                  onChange={(value) => setSelectedStyle(value)}
-                  fullWidth
-                  hasDividers
-                />
-              </EuiFormRow>
-            </EuiAccordion>
           </div>
 
           {/* Item Details Tooltip on Click */}


### PR DESCRIPTION
### Description

This PR improves the color codings of the search result comparison visualization pages:

* red/green lines are changed to one common color. Red/green lines indicated improvements/decline of search quality that cannot be derived from change alone.
* new colors for the left and right set of the comparisons as well as the common results.
* removed the dropdown box that supported different styles to choose from. Only one style remains.
* removed all styles that are now unnecessary with the removal of the dropdown.

### Issues Resolved

n/a

### Check List

- [x] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
