### PR TITLE
Support a metric being a string value as well as a numeric value

### DIFF
--- a/public/components/experiment/metrics/metrics_summary.tsx
+++ b/public/components/experiment/metrics/metrics_summary.tsx
@@ -30,10 +30,20 @@ interface MetricsSummaryPanelProps {
 }
 
 export const MetricsSummaryPanel: React.FC<MetricsSummaryPanelProps> = ({ metrics }) => {
-  const formatValue = (values: number[] | undefined) => {
+  const formatValue = (values: (number | string)[] | undefined) => {
     if (!values || values.length === 0) return '-';
-    // Calculate average of the values
-    const avg = values.reduce((sum, val) => sum + val, 0) / values.length;
+    
+    // Check if any value is a string
+    const stringValues = values.filter(val => typeof val === 'string');
+    if (stringValues.length > 0) {
+      // If we have string values, return the first one
+      return stringValues[0];
+    }
+    
+    // For numeric values, calculate average as before
+    const numericValues = values.filter(val => typeof val === 'number') as number[];
+    if (numericValues.length === 0) return '-';
+    const avg = numericValues.reduce((sum, val) => sum + val, 0) / numericValues.length;
     return avg.toFixed(2).replace(/\.00$/, '');
   };
   // tool tip texts

--- a/public/components/experiment/views/evaluation_experiment_view.tsx
+++ b/public/components/experiment/views/evaluation_experiment_view.tsx
@@ -248,6 +248,9 @@ export const EvaluationExperimentView: React.FC<EvaluationExperimentViewProps> =
           sortable: true,
           render: (value) => {
             if (value !== undefined && value !== null) {
+              if (typeof value === 'string') {
+                return value; // Return string values directly
+              }
               return new Intl.NumberFormat(undefined, {
                 minimumFractionDigits: 2,
                 maximumFractionDigits: 2,

--- a/public/components/experiment/views/hybrid_optimizer_experiment_view.tsx
+++ b/public/components/experiment/views/hybrid_optimizer_experiment_view.tsx
@@ -31,7 +31,7 @@ import {
 } from '../../../../common';
 
 interface VariantEvaluation {
-  metrics: Record<string, number>;
+  metrics: Record<string, number | string>;
 }
 
 interface QueryVariantEvaluations {
@@ -262,6 +262,9 @@ export const HybridOptimizerExperimentView: React.FC<HybridOptimizerExperimentVi
             sortable: true,
             render: (value) => {
               if (value !== undefined && value !== null) {
+                if (typeof value === 'string') {
+                  return value; // Return string values directly
+                }
                 return new Intl.NumberFormat(undefined, {
                   minimumFractionDigits: 2,
                   maximumFractionDigits: 2,

--- a/public/components/experiment/views/pairwise_experiment_view.tsx
+++ b/public/components/experiment/views/pairwise_experiment_view.tsx
@@ -185,6 +185,9 @@ export const PairwiseExperimentView: React.FC<PairwiseExperimentViewProps> = ({
           sortable: true,
           render: (value) => {
             if (value !== undefined && value !== null) {
+              if (typeof value === 'string') {
+                return value; // Return string values directly
+              }
               return new Intl.NumberFormat(undefined, {
                 minimumFractionDigits: 2,
                 maximumFractionDigits: 2,

--- a/public/types/index.ts
+++ b/public/types/index.ts
@@ -159,7 +159,7 @@ export const printType = (type: string) => {
 };
 
 export interface Metrics {
-  [key: string]: number;
+  [key: string]: number | string;
 }
 
 export type MetricsCollection = Metrics[];
@@ -197,7 +197,7 @@ export function combineResults(...results: Array<ParseResult<any>>): ParseResult
   return errors.length > 0 ? { success: false, errors } : { success: true, data: values };
 }
 
-export const parseMetrics = (metricsArray: Array<{ metric: string; value: number }>): Metrics => {
+export const parseMetrics = (metricsArray: Array<{ metric: string; value: number | string }>): Metrics => {
   return Object.fromEntries(
     metricsArray.map(({ metric, value }) => [metric, value])
   ) as Metrics;


### PR DESCRIPTION
In working with @frejonb on using the RAGElo project (https://github.com/zetaalphavector/RAGElo) we found that sometimes a the query and overall score level we want a string value, not a number.

For example, at the per query level, we wanted to know which agent was the winner, A or B.  Yes, we could have modeled that as a 0 or a 1, but that is awkward.

We also discovered that the assumption that at the top level we would just roll up the average of all query level metrics was flawed.   You can't average a string, so in our POC we just took the first value as the value to show at the Experiment level.

This PR doesn't touch on the idea that we need to store Experiment level metrics at the Experiment level instead of just averaging all the query level data.

 

### Description

If a value is a String, treat it as String.

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [ x] New functionality includes testing.
  - [ x] All tests pass, including unit test, integration test
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
