### PR TITLE
modify highlighting feature after demo

### DIFF
--- a/public/components/query_compare/search_result/index.tsx
+++ b/public/components/query_compare/search_result/index.tsx
@@ -294,6 +294,21 @@ export const SearchResult = ({
     }
   };
 
+  const extractHighlightTags = (queryString: string) => {
+    try {
+      const query = JSON.parse(queryString);
+      if (query.highlight?.pre_tags && query.highlight?.post_tags) {
+        return {
+          preTags: query.highlight.pre_tags,
+          postTags: query.highlight.post_tags
+        };
+      }
+    } catch {
+      // Ignore parsing errors
+    }
+    return { preTags: ['<em>'], postTags: ['</em>'] };
+  };
+
   const handleQuery = (
     queryError: QueryError,
     selectedIndex: string,
@@ -497,6 +512,10 @@ export const SearchResult = ({
             queryText={searchBarValue}
             resultText1="Result 1"
             resultText2="Result 2"
+            highlightPreTags1={extractHighlightTags(queryString1).preTags}
+            highlightPostTags1={extractHighlightTags(queryString1).postTags}
+            highlightPreTags2={extractHighlightTags(queryString2).preTags}
+            highlightPostTags2={extractHighlightTags(queryString2).postTags}
           />
         )}
       </EuiPageContentBody>

--- a/public/components/query_compare/search_result/visual_comparison/__tests__/highlight_text.test.tsx
+++ b/public/components/query_compare/search_result/visual_comparison/__tests__/highlight_text.test.tsx
@@ -1,0 +1,73 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { HighlightText } from '../highlight_text';
+
+describe('HighlightText', () => {
+  it('should highlight text with default em tags', () => {
+    const text = 'This is <em>highlighted</em> text';
+    const { container } = render(<HighlightText text={text} />);
+    
+    const mark = container.querySelector('mark');
+    expect(mark).toBeInTheDocument();
+    expect(mark).toHaveTextContent('highlighted');
+    expect(mark).toHaveStyle({ backgroundColor: '#ffeb3b', color: '#000' });
+  });
+
+  it('should highlight text with HTML entity em tags', () => {
+    const text = 'This is &lt;em&gt;highlighted&lt;/em&gt; text';
+    const { container } = render(<HighlightText text={text} />);
+    
+    const mark = container.querySelector('mark');
+    expect(mark).toBeInTheDocument();
+    expect(mark).toHaveTextContent('highlighted');
+  });
+
+  it('should highlight text with custom strong tags', () => {
+    const text = 'This is <strong>highlighted</strong> text';
+    const preTags = ['<strong>', '&lt;strong&gt;'];
+    const postTags = ['</strong>', '&lt;/strong&gt;'];
+    
+    const { container } = render(
+      <HighlightText text={text} preTags={preTags} postTags={postTags} />
+    );
+    
+    const mark = container.querySelector('mark');
+    expect(mark).toBeInTheDocument();
+    expect(mark).toHaveTextContent('highlighted');
+  });
+
+  it('should highlight multiple segments in the same text', () => {
+    const text = 'This <em>first</em> and <em>second</em> are highlighted';
+    const { container } = render(<HighlightText text={text} />);
+    
+    const marks = container.querySelectorAll('mark');
+    expect(marks).toHaveLength(2);
+    expect(marks[0]).toHaveTextContent('first');
+    expect(marks[1]).toHaveTextContent('second');
+  });
+
+  it('should render plain text when no highlight tags are present', () => {
+    const text = 'This is plain text';
+    const { container } = render(<HighlightText text={text} />);
+    
+    const mark = container.querySelector('mark');
+    expect(mark).not.toBeInTheDocument();
+    expect(container).toHaveTextContent('This is plain text');
+  });
+
+  it('should use default tags when preTags and postTags are empty', () => {
+    const text = 'This is <em>highlighted</em> text';
+    const { container } = render(
+      <HighlightText text={text} preTags={[]} postTags={[]} />
+    );
+    
+    const mark = container.querySelector('mark');
+    expect(mark).toBeInTheDocument();
+    expect(mark).toHaveTextContent('highlighted');
+  });
+});

--- a/public/components/query_compare/search_result/visual_comparison/__tests__/item_detail_hover_pane.test.tsx
+++ b/public/components/query_compare/search_result/visual_comparison/__tests__/item_detail_hover_pane.test.tsx
@@ -4,63 +4,140 @@
  */
 
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 import { ItemDetailHoverPane } from '../item_detail_hover_pane';
 
 const mockItem = {
-  _id: '1',
+  _id: 'test-id',
+  _score: 0.95,
   rank: 1,
   title: 'Test Document',
-  description: 'Test description',
-  image: 'https://example.com/image.jpg',
+  content: 'This is <em>highlighted</em> content',
+  highlight: {
+    content: ['This is <em>highlighted</em> content'],
+    title: ['Test <em>Document</em>']
+  }
 };
 
 const mockMousePosition = { x: 100, y: 100 };
 
-const defaultProps = {
-  item: mockItem,
-  mousePosition: mockMousePosition,
-  onMouseEnter: jest.fn(),
-  onMouseLeave: jest.fn(),
-  imageFieldName: 'image',
-};
-
 describe('ItemDetailHoverPane', () => {
-  it('renders nothing when item is null', () => {
-    const { container } = render(<ItemDetailHoverPane {...defaultProps} item={null} />);
+  const defaultProps = {
+    item: mockItem,
+    mousePosition: mockMousePosition,
+    onMouseEnter: jest.fn(),
+    onMouseLeave: jest.fn(),
+    imageFieldName: null,
+  };
+
+  beforeEach(() => {
+    // Mock window dimensions
+    Object.defineProperty(window, 'innerWidth', { value: 1024, writable: true });
+    Object.defineProperty(window, 'innerHeight', { value: 768, writable: true });
+  });
+
+  it('should render item details with highlighted text', () => {
+    const { container, getByText } = render(<ItemDetailHoverPane {...defaultProps} />);
+    
+    expect(getByText('Item Details')).toBeInTheDocument();
+    expect(getByText('test-id')).toBeInTheDocument();
+    
+    // Check that highlighted content is rendered
+    const marks = container.querySelectorAll('mark');
+    expect(marks.length).toBeGreaterThan(0);
+  });
+
+  it('should use highlighted text from item.highlight when available', () => {
+    const { container } = render(<ItemDetailHoverPane {...defaultProps} />);
+    
+    const marks = container.querySelectorAll('mark');
+    expect(marks).toHaveLength(2); // One for content, one for title
+    expect(marks[1]).toHaveTextContent('highlighted');
+    expect(marks[0]).toHaveTextContent('Document');
+  });
+
+  it('should use custom highlight tags when provided', () => {
+    const itemWithStrongTags = {
+      ...mockItem,
+      highlight: {
+        content: ['This is <strong>highlighted</strong> content'],
+      }
+    };
+    
+    const preTags = ['<strong>', '&lt;strong&gt;'];
+    const postTags = ['</strong>', '&lt;/strong&gt;'];
+    
+    const { container } = render(
+      <ItemDetailHoverPane 
+        {...defaultProps} 
+        item={itemWithStrongTags}
+        highlightPreTags={preTags}
+        highlightPostTags={postTags}
+      />
+    );
+    
+    const mark = container.querySelector('mark');
+    expect(mark).toBeInTheDocument();
+    expect(mark).toHaveTextContent('highlighted');
+  });
+
+  it('should fall back to original text when no highlight is available', () => {
+    const itemWithoutHighlight = {
+      ...mockItem,
+      highlight: undefined,
+      content: 'Plain text content'
+    };
+    
+    const { getByText } = render(
+      <ItemDetailHoverPane {...defaultProps} item={itemWithoutHighlight} />
+    );
+    
+    expect(getByText('Plain text content')).toBeInTheDocument();
+  });
+
+  it('should call onMouseLeave when close button is clicked', () => {
+    const onMouseLeave = jest.fn();
+    const { getByText } = render(
+      <ItemDetailHoverPane {...defaultProps} onMouseLeave={onMouseLeave} />
+    );
+    
+    const closeButton = getByText('✕');
+    fireEvent.click(closeButton);
+    
+    expect(onMouseLeave).toHaveBeenCalled();
+  });
+
+  it('should not render when item is null', () => {
+    const { container } = render(
+      <ItemDetailHoverPane {...defaultProps} item={null} />
+    );
+    
     expect(container.firstChild).toBeNull();
   });
 
-  it('renders with default position when mousePosition is null', () => {
-    const { container } = render(<ItemDetailHoverPane {...defaultProps} mousePosition={null} />);
-    const tooltip = container.querySelector('.comparison-tooltip');
-    expect(tooltip).toBeInTheDocument();
-    expect(tooltip).toHaveStyle({ left: '0px', top: '0px' });
-  });
-
-  it('renders item details when item and mousePosition are provided', () => {
-    render(<ItemDetailHoverPane {...defaultProps} />);
-    expect(screen.getByText('Test Document')).toBeInTheDocument();
-    expect(screen.getByText('Test description')).toBeInTheDocument();
-  });
-
-  it('renders image when imageFieldName matches', () => {
-    render(<ItemDetailHoverPane {...defaultProps} />);
-    const image = screen.getByRole('img');
-    expect(image).toHaveAttribute('src', 'https://example.com/image.jpg');
-  });
-
-  it('calls onMouseLeave when mouse leaves', () => {
-    render(<ItemDetailHoverPane {...defaultProps} />);
-    const tooltip = screen.getByText('Test Document').closest('div');
-    fireEvent.mouseLeave(tooltip);
-    expect(defaultProps.onMouseLeave).toHaveBeenCalled();
-  });
-
-  it('positions tooltip based on mousePosition with adjustments', () => {
+  it('should position tooltip based on mouse position', () => {
     const { container } = render(<ItemDetailHoverPane {...defaultProps} />);
-    const tooltip = container.querySelector('.comparison-tooltip');
-    expect(tooltip).toBeInTheDocument();
+    
+    const tooltip = container.firstChild as HTMLElement;
     expect(tooltip).toHaveClass('fixed');
+  });
+
+  it('should render image when imageFieldName is provided and item has image', () => {
+    const itemWithImage = {
+      ...mockItem,
+      thumbnail: 'https://example.com/image.jpg'
+    };
+    
+    const { container } = render(
+      <ItemDetailHoverPane 
+        {...defaultProps} 
+        item={itemWithImage}
+        imageFieldName="thumbnail"
+      />
+    );
+    
+    const img = container.querySelector('img');
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveAttribute('src', 'https://example.com/image.jpg');
   });
 });

--- a/public/components/query_compare/search_result/visual_comparison/__tests__/result_items.test.tsx
+++ b/public/components/query_compare/search_result/visual_comparison/__tests__/result_items.test.tsx
@@ -79,7 +79,20 @@ describe('ResultItems', () => {
   });
 
   it('applies correct size multiplier', () => {
-    const { container } = render(<ResultItems {...defaultProps} sizeMultiplier={3} />);
+    const propsWithImage = {
+      ...defaultProps,
+      imageFieldName: 'image',
+      sizeMultiplier: 3,
+      items: [
+        {
+          _id: '1',
+          rank: 1,
+          title: 'Test Document 1',
+          image: 'https://example.com/image.jpg',
+        },
+      ],
+    };
+    const { container } = render(<ResultItems {...propsWithImage} />);
     const imageContainer = container.querySelector('[style*="width: 96px"]');
     expect(imageContainer).toBeInTheDocument();
   });

--- a/public/components/query_compare/search_result/visual_comparison/highlight_text.tsx
+++ b/public/components/query_compare/search_result/visual_comparison/highlight_text.tsx
@@ -1,0 +1,45 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+
+interface HighlightTextProps {
+  text: string;
+  preTags?: string[];
+  postTags?: string[];
+}
+
+export const HighlightText: React.FC<HighlightTextProps> = ({ text, preTags, postTags }) => {
+  const defaultPreTags = ['<em>', '&lt;em&gt;'];
+  const defaultPostTags = ['</em>', '&lt;/em&gt;'];
+  const actualPreTags = preTags && preTags.length > 0 ? preTags : defaultPreTags;
+  const actualPostTags = postTags && postTags.length > 0 ? postTags : defaultPostTags;
+  
+  const allTags = [...actualPreTags, ...actualPostTags].map(tag => tag.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|');
+  const parts = text.split(new RegExp(`(${allTags})`));
+  let isHighlighted = false;
+
+  return (
+    <>
+      {parts.map((part, index) => {
+        if (actualPreTags.includes(part)) {
+          isHighlighted = true;
+          return null;
+        }
+        if (actualPostTags.includes(part)) {
+          isHighlighted = false;
+          return null;
+        }
+        return isHighlighted ? (
+          <mark key={index} style={{ backgroundColor: '#ffeb3b', color: '#000' }}>
+            {part}
+          </mark>
+        ) : (
+          <span key={index}>{part}</span>
+        );
+      })}
+    </>
+  );
+};

--- a/public/components/query_compare/search_result/visual_comparison/item_detail_hover_pane.tsx
+++ b/public/components/query_compare/search_result/visual_comparison/item_detail_hover_pane.tsx
@@ -4,6 +4,7 @@
  */
 
 import React, { useRef, useEffect, useState } from 'react';
+import { HighlightText } from './highlight_text';
 
 interface Position {
   top: number;
@@ -16,6 +17,8 @@ interface ItemDetailHoverPaneProps {
   onMouseEnter: () => void;
   onMouseLeave: () => void;
   imageFieldName: string | null;
+  highlightPreTags?: string[];
+  highlightPostTags?: string[];
 }
 
 const EXCLUDED_FIELDS = [
@@ -37,6 +40,8 @@ export const ItemDetailHoverPane: React.FC<ItemDetailHoverPaneProps> = ({
   onMouseEnter,
   onMouseLeave,
   imageFieldName,
+  highlightPreTags,
+  highlightPostTags,
 }) => {
   const [tooltipPosition, setTooltipPosition] = useState<Position>({ top: 0, left: 0 });
 
@@ -81,11 +86,12 @@ export const ItemDetailHoverPane: React.FC<ItemDetailHoverPaneProps> = ({
 
   return (
     <div
-      className="fixed bg-white shadow-lg rounded-lg p-4 max-w-md z-20 border comparison-tooltip"
+      className="fixed bg-white shadow-lg rounded-lg p-6 z-20 border comparison-tooltip"
       style={{
         left: `${tooltipPosition.left}px`,
         top: `${tooltipPosition.top}px`,
-        maxHeight: '400px',
+        width: '500px',
+        maxHeight: '600px',
         overflow: 'auto',
       }}
       onMouseEnter={onMouseEnter}
@@ -124,16 +130,21 @@ export const ItemDetailHoverPane: React.FC<ItemDetailHoverPaneProps> = ({
       {Object.entries(item)
         .filter(([key]) => !EXCLUDED_FIELDS.includes(key))
         .filter(([key, value]) => typeof value === 'string')
-        .map(([key, value]) => (
-          <div key={key} className="mb-1 text-sm">
-            <span className="font-semibold">{key.charAt(0).toUpperCase() + key.slice(1)}:</span>
-            {typeof value === 'string' && value.length > 100 ? (
-              <p className="text-xs mt-1">{String(value)}</p>
-            ) : (
-              <span> {String(value)}</span>
-            )}
-          </div>
-        ))}
+        .map(([key, value]) => {
+          const highlightedText = item.highlight && item.highlight[key] ? item.highlight[key][0] : String(value);
+          return (
+            <div key={key} className="mb-1 text-sm">
+              <span className="font-semibold">{key.charAt(0).toUpperCase() + key.slice(1)}:</span>
+              {typeof value === 'string' && value.length > 100 ? (
+                <p className="text-xs mt-1">
+                  <HighlightText text={highlightedText} preTags={highlightPreTags} postTags={highlightPostTags} />
+                </p>
+              ) : (
+                <span> <HighlightText text={highlightedText} preTags={highlightPreTags} postTags={highlightPostTags} /></span>
+              )}
+            </div>
+          );
+        })}
     </div>
   );
 };

--- a/public/components/query_compare/search_result/visual_comparison/result_items.tsx
+++ b/public/components/query_compare/search_result/visual_comparison/result_items.tsx
@@ -4,6 +4,7 @@
  */
 
 import React from 'react';
+import { HighlightText } from './highlight_text';
 
 interface ResultItemsProps {
   items: any[];
@@ -15,6 +16,8 @@ interface ResultItemsProps {
   result1ItemsRef: React.MutableRefObject<{ [key: string]: HTMLDivElement }>;
   result2ItemsRef: React.MutableRefObject<{ [key: string]: HTMLDivElement }>;
   sizeMultiplier: number;
+  highlightPreTags?: string[];
+  highlightPostTags?: string[];
 }
 
 export const ResultItems: React.FC<ResultItemsProps> = ({
@@ -27,6 +30,8 @@ export const ResultItems: React.FC<ResultItemsProps> = ({
   result1ItemsRef,
   result2ItemsRef,
   sizeMultiplier,
+  highlightPreTags,
+  highlightPostTags,
 }) => {
   const imageSize = 32 * sizeMultiplier;
   const imageSizeClass = `w-${Math.min(sizeMultiplier * 4, 64)} h-${Math.min(sizeMultiplier * 4, 64)}`;
@@ -45,7 +50,7 @@ export const ResultItems: React.FC<ResultItemsProps> = ({
           className={`flex ${
             resultNum === 1 ? 'flex-row-reverse' : ''
           } items-center mb-2 hover:bg-gray-100 p-1 rounded cursor-pointer`}
-          onClick={(event) => handleItemClick(item, event)}
+          onClick={(event) => handleItemClick(item, event, resultNum)}
         >
           <div
             className={`w-8 h-8 rounded-full ${getStatusColor(
@@ -57,10 +62,10 @@ export const ResultItems: React.FC<ResultItemsProps> = ({
           >
             {item.rank}
           </div>
-          <div className={`${resultNum === 1 ? 'ml-2' : 'mr-2'} flex-shrink-0`} style={{ width: `${imageSize}px`, height: `${imageSize}px` }}>
-            {imageFieldName &&
-            item[imageFieldName] &&
-            item[imageFieldName].match(/\.(jpg|jpeg|png|gif|svg|webp)($|\?)/i) ? (
+          {imageFieldName &&
+          item[imageFieldName] &&
+          item[imageFieldName].match(/\.(jpg|jpeg|png|gif|svg|webp)($|\?)/i) && (
+            <div className={`${resultNum === 1 ? 'ml-2' : 'mr-2'} flex-shrink-0`} style={{ width: `${imageSize}px`, height: `${imageSize}px` }}>
               <img
                 width={imageSize}
                 height={imageSize}
@@ -68,10 +73,8 @@ export const ResultItems: React.FC<ResultItemsProps> = ({
                 className="object-contain rounded"
                 style={{ width: `${imageSize}px`, height: `${imageSize}px` }}
               />
-            ) : (
-              <div className="rounded" style={{ width: `${imageSize}px`, height: `${imageSize}px` }} />
-            )}
-          </div>
+            </div>
+          )}
           <div 
             className="font-mono text-xs break-words overflow-hidden flex-grow"
             style={{ 
@@ -81,9 +84,11 @@ export const ResultItems: React.FC<ResultItemsProps> = ({
             }}
           >
             {item.highlight && item.highlight[displayField] ? (
-              <span dangerouslySetInnerHTML={{ 
-                __html: item.highlight[displayField][0].replace(/<em>/g, '<mark style="background-color: yellow;">').replace(/<\/em>/g, '</mark>') 
-              }} />
+              <HighlightText 
+                text={item.highlight[displayField][0]} 
+                preTags={highlightPreTags}
+                postTags={highlightPostTags}
+              />
             ) : (
               item[displayField] || item._id
             )}

--- a/public/components/query_compare/search_result/visual_comparison/visual_comparison.tsx
+++ b/public/components/query_compare/search_result/visual_comparison/visual_comparison.tsx
@@ -29,6 +29,10 @@ interface OpenSearchComparisonProps {
   queryText: string;
   resultText1: string;
   resultText2: string;
+  highlightPreTags1?: string[];
+  highlightPostTags1?: string[];
+  highlightPreTags2?: string[];
+  highlightPostTags2?: string[];
 }
 
 export const convertFromSearchResult = (searchResult) => {
@@ -134,6 +138,10 @@ export const VisualComparison = ({
   queryText,
   resultText1,
   resultText2,
+  highlightPreTags1,
+  highlightPostTags1,
+  highlightPreTags2,
+  highlightPostTags2,
 }: OpenSearchComparisonProps) => {
   // Add state for selected style
   const [selectedStyle, setSelectedStyle] = useState('default');
@@ -296,12 +304,12 @@ export const VisualComparison = ({
   };
 
   // Function to handle click for item details
-  const handleItemClick = (item, event) => {
+  const handleItemClick = (item, event, resultNum) => {
     // Toggle the selected item - if clicking the same item, close it
     if (selectedItem && selectedItem._id === item._id) {
       setSelectedItem(null);
     } else {
-      setSelectedItem(item);
+      setSelectedItem({ ...item, resultNum });
       setMousePosition({ x: event.clientX, y: event.clientY });
     }
   };
@@ -371,6 +379,11 @@ export const VisualComparison = ({
                       { value: 3, inputDisplay: '3 (96px)', dropdownDisplay: '3 (96px)' },
                       { value: 4, inputDisplay: '4 (128px)', dropdownDisplay: '4 (128px)' },
                       { value: 5, inputDisplay: '5 (160px)', dropdownDisplay: '5 (160px)' },
+                      { value: 6, inputDisplay: '6 (192px)', dropdownDisplay: '6 (192px)' },
+                      { value: 7, inputDisplay: '7 (224px)', dropdownDisplay: '7 (224px)' },
+                      { value: 8, inputDisplay: '8 (256px)', dropdownDisplay: '8 (256px)' },
+                      { value: 9, inputDisplay: '9 (288px)', dropdownDisplay: '9 (288px)' },
+                      { value: 10, inputDisplay: '10 (320px)', dropdownDisplay: '10 (320px)' },
                     ]}
                     valueOfSelected={sizeMultiplier}
                     onChange={(value) => setSizeMultiplier(Number(value))}
@@ -411,6 +424,8 @@ export const VisualComparison = ({
                   result1ItemsRef={result1ItemsRef}
                   result2ItemsRef={result2ItemsRef}
                   sizeMultiplier={sizeMultiplier}
+                  highlightPreTags={highlightPreTags1}
+                  highlightPostTags={highlightPostTags1}
                 />
               </div>
 
@@ -441,6 +456,8 @@ export const VisualComparison = ({
                   result1ItemsRef={result1ItemsRef}
                   result2ItemsRef={result2ItemsRef}
                   sizeMultiplier={sizeMultiplier}
+                  highlightPreTags={highlightPreTags2}
+                  highlightPostTags={highlightPostTags2}
                 />
               </div>
             </div>
@@ -483,6 +500,8 @@ export const VisualComparison = ({
             onMouseEnter={() => {}}
             onMouseLeave={() => setSelectedItem(null)}
             imageFieldName={imageFieldName}
+            highlightPreTags={selectedItem?.resultNum === 1 ? highlightPreTags1 : highlightPreTags2}
+            highlightPostTags={selectedItem?.resultNum === 1 ? highlightPostTags1 : highlightPostTags2}
           />
         </EuiPageContent>
       </EuiPageBody>


### PR DESCRIPTION
### Description

Improve highlighting feature after the demo.
1. remove image container if there is no image, making more room for paragraphs
2. add customized pre_tags and post_tags. By default `<em></em>`, but users can define in query body in highlight
3. provide more size selection from up to 5 to up to 10
4. add highlights to hover panel. now hover panel also provides highlights. 

<img width="1302" height="1161" alt="Screenshot 2025-10-03 at 5 26 26 PM" src="https://github.com/user-attachments/assets/b9af2f4e-2d01-4cef-8c77-74ad84731a3c" />


### Issues Resolved
#627 

### Check List

- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
