### PR TITLE
[Backport]Add release note for 3.4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ coverage/
 .cypress/screenshots
 .cypress/videos
 yarn-error.log
+.idea/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Breaking Changes
 
 ### Features
-- Add scheduling and descheduling experiments in the UI ([#636](https://github.com/opensearch-project/dashboards-search-relevance/pull/636))
-- Add support for agent search in pariwise comparison ([#693](https://github.com/opensearch-project/dashboards-search-relevance/pull/693))
 
 ### Enhancements
-* Added client-side filtering in experiment list by `type` and `status`, in addition to `id` (GUID). ([#686](https://github.com/opensearch-project/dashboards-search-relevance/pull/686))
-* Added GUID search support to the Search Configuration listing to allow filtering by configuration ID in addition to name. ([#685](https://github.com/opensearch-project/dashboards-search-relevance/pull/685))
-* Added support for filtering Query Sets by GUID and aligned QuerySetItem typing with existing structure ([#687](https://github.com/opensearch-project/dashboards-search-relevance/pull/687))
-* Added support for filtering Judgment Lists by GUID (`id`) in the search bar, improving discoverability and navigation when working with judgment identifiers. ([#687](https://github.com/opensearch-project/dashboards-search-relevance/pull/687))
-
-* Use appropriate title on the Experiment Detail page. ([#670](https://github.com/opensearch-project/dashboards-search-relevance/pull/670))
 
 ### Bug Fixes
 

--- a/release-notes/opensearch-dashboards-search-relevance.release-notes-3.4.0.0.md
+++ b/release-notes/opensearch-dashboards-search-relevance.release-notes-3.4.0.0.md
@@ -1,0 +1,15 @@
+## Version 3.4.0 Release Notes
+
+Compatible with OpenSearch and OpenSearch Dashboards version 3.4.0
+
+### Features
+- Add scheduling and descheduling experiments in the UI ([#636](https://github.com/opensearch-project/dashboards-search-relevance/pull/636))
+- Add support for agent search in pariwise comparison ([#693](https://github.com/opensearch-project/dashboards-search-relevance/pull/693))
+
+### Enhancements
+* Added client-side filtering in experiment list by `type` and `status`, in addition to `id` (GUID). ([#686](https://github.com/opensearch-project/dashboards-search-relevance/pull/686))
+* Added GUID search support to the Search Configuration listing to allow filtering by configuration ID in addition to name. ([#685](https://github.com/opensearch-project/dashboards-search-relevance/pull/685))
+* Added support for filtering Query Sets by GUID and aligned QuerySetItem typing with existing structure ([#687](https://github.com/opensearch-project/dashboards-search-relevance/pull/687))
+* Added support for filtering Judgment Lists by GUID (`id`) in the search bar, improving discoverability and navigation when working with judgment identifiers. ([#687](https://github.com/opensearch-project/dashboards-search-relevance/pull/687))
+
+* Use appropriate title on the Experiment Detail page. ([#670](https://github.com/opensearch-project/dashboards-search-relevance/pull/670))


### PR DESCRIPTION
### Description

Manually backport release note PR to 3.4 branch. It seems like there're some issue with automated PR that cut by the bot, no CI was trigger, see https://github.com/opensearch-project/dashboards-search-relevance/pull/717

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
