### PR TITLE
Move #720 message from release-note-3.4.0 to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Bug Fixes
 
 ### Infrastructure
+- * Enable CI workflows for automated backport PRs. ([#720](https://github.com/opensearch-project/dashboards-search-relevance/pull/720))
 
 ### Documentation
 

--- a/release-notes/opensearch-dashboards-search-relevance.release-notes-3.4.0.0.md
+++ b/release-notes/opensearch-dashboards-search-relevance.release-notes-3.4.0.0.md
@@ -13,4 +13,3 @@ Compatible with OpenSearch and OpenSearch Dashboards version 3.4.0
 * Added support for filtering Judgment Lists by GUID (`id`) in the search bar, improving discoverability and navigation when working with judgment identifiers. ([#687](https://github.com/opensearch-project/dashboards-search-relevance/pull/687))
 
 * Use appropriate title on the Experiment Detail page. ([#670](https://github.com/opensearch-project/dashboards-search-relevance/pull/670))
-* Enable CI workflows for automated backport PRs. ([#720](https://github.com/opensearch-project/dashboards-search-relevance/pull/720))


### PR DESCRIPTION
### Description

Move #720 message from release-note-3.4.0 to CHANGELOG, as we don't want the change backport to 3.4 branch

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
