### PR TITLE
[FEATURE] Rename "Single Query Comparison" to "Query Analysis"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Bug Fixes
 * Bug bugs on pairwise comparison experiment view page. ([#735]https://github.com/opensearch-project/dashboards-search-relevance/pull/735)
 * Fix link to Pointwise Daily Scheduled Runs dashboard to set date range from first experiment to NOW to include the most recent run. ([#738]https://github.com/opensearch-project/dashboards-search-relevance/pull/738)
-* Fix text alignment and excessive spacing in Single Query Comparison results view. ([#752](https://github.com/opensearch-project/dashboards-search-relevance/pull/752))
+* Fix text alignment and excessive spacing in Query Analysis results view. ([#752](https://github.com/opensearch-project/dashboards-search-relevance/pull/752))
 * Allow a single query setup to be executed in the search comparison UI. ([#746](https://github.com/opensearch-project/dashboards-search-relevance/pull/746))
 * Fix error when deleting judgment ratings by ensuring the judgments list refreshes correctly and removes deleted entries from UI state. ([#751](https://github.com/opensearch-project/dashboards-search-relevance/pull/751))
 

--- a/common/index.ts
+++ b/common/index.ts
@@ -50,7 +50,7 @@ export const QUERY_NUMBER_ONE = '1';
 export const QUERY_NUMBER_TWO = '2';
 
 export enum RouteTemplateType {
-  SingleQueryComparison = 'singleQueryComparison',
+  QueryAnalysis = 'queryAnalysis',
   QuerySetComparison = 'querySetComparison',
   SearchEvaluation = 'searchEvaluation',
   HybridOptimizer = 'hybridOptimizer',
@@ -62,7 +62,7 @@ export enum Routes {
   ExperimentView = '/experiment/view/:entityId',
   ExperimentViewPrefix = '/experiment/view',
   ExperimentCreate = '/experiment/create',
-  ExperimentCreateSingleQueryComparison = `/experiment/create/${RouteTemplateType.SingleQueryComparison}`,
+  ExperimentCreateQueryAnalysis = `/experiment/create/${RouteTemplateType.QueryAnalysis}`,
   ExperimentCreateQuerySetComparison = `/experiment/create/${RouteTemplateType.QuerySetComparison}`,
   ExperimentCreateSearchEvaluation = `/experiment/create/${RouteTemplateType.SearchEvaluation}`,
   ExperimentCreateHybridOptimizer = `/experiment/create/${RouteTemplateType.HybridOptimizer}`,

--- a/public/components/app.tsx
+++ b/public/components/app.tsx
@@ -46,7 +46,7 @@ enum Navigation {
   SRW = 'Search Relevance Workbench',
   Overview = 'Overview',
   Experiments = 'Experiments',
-  ExperimentsSingleQueryComparison = 'Single Query Comparison',
+  ExperimentsQueryAnalysis = 'Query Analysis',
   ExperimentsQuerySetComparison = 'Query Set Comparison',
   ExperimentsSearchEvaluation = 'Search Evaluation',
   ExperimentsHybridOptimizer = 'Hybrid Optimizer',
@@ -120,13 +120,13 @@ const SearchRelevancePage = ({
           forceOpen: true,
           items: [
             {
-              name: Navigation.ExperimentsSingleQueryComparison,
-              id: Navigation.ExperimentsSingleQueryComparison,
+              name: Navigation.ExperimentsQueryAnalysis,
+              id: Navigation.ExperimentsQueryAnalysis,
               onClick: () => {
-                history.push(Routes.ExperimentCreateSingleQueryComparison);
+                history.push(Routes.ExperimentCreateQueryAnalysis);
               },
               isSelected: location.pathname.startsWith(
-                Routes.ExperimentCreateSingleQueryComparison
+                Routes.ExperimentCreateQueryAnalysis
               ),
             },
             {
@@ -208,9 +208,9 @@ const SearchRelevancePage = ({
               const configParam = urlParams.get('config');
 
               if (configParam) {
-                // Redirect to single query comparison with the config parameter as search param
+                // Redirect to query analysis with the config parameter as search param
                 history.push(
-                  `${Routes.ExperimentCreateSingleQueryComparison}?config=${configParam}`
+                  `${Routes.ExperimentCreateQueryAnalysis}?config=${configParam}`
                 );
                 return null;
               } else {
@@ -286,7 +286,7 @@ const SearchRelevancePage = ({
             exact
             render={(props) => {
               const templateId = routeToTemplateType(props.match.params.templateId);
-              if (templateId === TemplateType.SingleQueryComparison) {
+              if (templateId === TemplateType.QueryAnalysis) {
                 return (
                   <QueryCompareHome
                     application={application}
@@ -321,7 +321,7 @@ const SearchRelevancePage = ({
                     onBack={() => {
                       history.goBack();
                     }}
-                    onClose={() => {}}
+                    onClose={() => { }}
                   />
                 );
               }

--- a/public/components/experiment/__tests__/get_started_accordion.test.tsx
+++ b/public/components/experiment/__tests__/get_started_accordion.test.tsx
@@ -36,8 +36,8 @@ describe('GetStartedAccordion', () => {
     expect(screen.getByText('5. Assess Results')).toBeInTheDocument();
   });
 
-  it('renders SingleQueryComparison content', () => {
-    render(<GetStartedAccordion templateType={TemplateType.SingleQueryComparison} />);
+  it('renders QueryAnalysis content', () => {
+    render(<GetStartedAccordion templateType={TemplateType.QueryAnalysis} />);
 
     expect(screen.getByText('1. Define Your Query')).toBeInTheDocument();
     expect(screen.getByText('2. Configure Search Parameters')).toBeInTheDocument();

--- a/public/components/experiment/__tests__/template_cards.test.tsx
+++ b/public/components/experiment/__tests__/template_cards.test.tsx
@@ -28,7 +28,7 @@ describe('TemplateCards', () => {
   it('renders all template cards', () => {
     render(<TemplateCards history={mockHistory} />);
 
-    expect(screen.getByText('Single Query Comparison')).toBeInTheDocument();
+    expect(screen.getByText('Query Analysis')).toBeInTheDocument();
     expect(screen.getByText('Query Set Comparison')).toBeInTheDocument();
     expect(screen.getByText('Search Evaluation')).toBeInTheDocument();
     expect(screen.getByText('Hybrid Search Optimizer')).toBeInTheDocument();
@@ -37,8 +37,8 @@ describe('TemplateCards', () => {
   it('navigates to correct routes when cards are clicked', () => {
     render(<TemplateCards history={mockHistory} />);
 
-    fireEvent.click(screen.getByText('Single Query Comparison'));
-    expect(mockHistory.push).toHaveBeenCalledWith(Routes.ExperimentCreateSingleQueryComparison);
+    fireEvent.click(screen.getByText('Query Analysis'));
+    expect(mockHistory.push).toHaveBeenCalledWith(Routes.ExperimentCreateQueryAnalysis);
 
     fireEvent.click(screen.getByText('Query Set Comparison'));
     expect(mockHistory.push).toHaveBeenCalledWith(Routes.ExperimentCreateQuerySetComparison);

--- a/public/components/experiment/configuration/types.ts
+++ b/public/components/experiment/configuration/types.ts
@@ -7,7 +7,7 @@ import { RouteComponentProps } from 'react-router-dom';
 import { RouteTemplateType } from '../../../../common';
 
 export enum TemplateType {
-  SingleQueryComparison = 'Single Query Comparison',
+  QueryAnalysis = 'Query Analysis',
   QuerySetComparison = 'Query Set Comparison',
   SearchEvaluation = 'Search Evaluation',
   HybridSearchOptimizer = 'Hybrid Search Optimizer',
@@ -15,8 +15,8 @@ export enum TemplateType {
 
 export const routeToTemplateType = (templateId: string) => {
   switch (templateId) {
-    case RouteTemplateType.SingleQueryComparison:
-      return TemplateType.SingleQueryComparison;
+    case RouteTemplateType.QueryAnalysis:
+      return TemplateType.QueryAnalysis;
     case RouteTemplateType.QuerySetComparison:
       return TemplateType.QuerySetComparison;
     case RouteTemplateType.SearchEvaluation:

--- a/public/components/experiment/get_started_accordion.tsx
+++ b/public/components/experiment/get_started_accordion.tsx
@@ -90,7 +90,7 @@ const TEMPLATE_STEPS: Record<TemplateType, Step[]> = {
       description: 'Look at the tabular result data to understand which variant performed best.',
     },
   ],
-  [TemplateType.SingleQueryComparison]: [
+  [TemplateType.QueryAnalysis]: [
     {
       title: '1. Define Your Query',
       description: 'Specify a single query that you want to compare results for.',

--- a/public/components/experiment/template_card/template_cards.tsx
+++ b/public/components/experiment/template_card/template_cards.tsx
@@ -21,10 +21,10 @@ interface Template {
 
 const TEMPLATES: Template[] = [
   {
-    id: TemplateType.SingleQueryComparison,
-    name: 'Single Query Comparison',
+    id: TemplateType.QueryAnalysis,
+    name: 'Query Analysis',
     description:
-      'Test two search configurations with a single query. View side-by-side results to find the best performer.',
+      'Run and analyze a single query. Optionally view side-by-side results to find the best performer.',
     isDisabled: false,
   },
   {
@@ -51,7 +51,7 @@ const TEMPLATES: Template[] = [
 const TEMPLATE_ICON = 'beaker';
 
 const ROUTE_MAP: Record<TemplateType, string> = {
-  [TemplateType.SingleQueryComparison]: Routes.ExperimentCreateSingleQueryComparison,
+  [TemplateType.QueryAnalysis]: Routes.ExperimentCreateQueryAnalysis,
   [TemplateType.QuerySetComparison]: Routes.ExperimentCreateQuerySetComparison,
   [TemplateType.SearchEvaluation]: Routes.ExperimentCreateSearchEvaluation,
   [TemplateType.HybridSearchOptimizer]: Routes.ExperimentCreateHybridOptimizer,

--- a/public/components/query_compare/search_result/__tests__/search_result_base64_config.test.tsx
+++ b/public/components/query_compare/search_result/__tests__/search_result_base64_config.test.tsx
@@ -128,7 +128,7 @@ describe('SearchResult Base64 Config Loading', () => {
 
       // Set up default useLocation mock
       mockUseLocation.mockReturnValue({
-        pathname: '/experiment/create/singleQueryComparison',
+        pathname: '/experiment/create/queryAnalysis',
         search: window.location.search || '',
         hash: window.location.hash || '',
       });
@@ -348,7 +348,7 @@ describe('SearchResult Base64 Config Loading', () => {
 
       // Set up default useLocation mock
       mockUseLocation.mockReturnValue({
-        pathname: '/experiment/create/singleQueryComparison',
+        pathname: '/experiment/create/queryAnalysis',
         search: window.location.search || '',
         hash: window.location.hash || '',
       });
@@ -382,7 +382,7 @@ describe('SearchResult Base64 Config Loading', () => {
 
       // Mock useLocation to return the search parameters
       mockUseLocation.mockReturnValue({
-        pathname: '/experiment/create/singleQueryComparison',
+        pathname: '/experiment/create/queryAnalysis',
         search: `?config=${base64Config}`,
         hash: '',
       });
@@ -444,7 +444,7 @@ describe('SearchResult Base64 Config Loading', () => {
 
       // Mock useLocation to return the search parameters (which should take priority)
       mockUseLocation.mockReturnValue({
-        pathname: '/experiment/create/singleQueryComparison',
+        pathname: '/experiment/create/queryAnalysis',
         search: `?config=${base64QueryConfig}`,
         hash: `#/?config=${base64HashConfig}`,
       });
@@ -479,7 +479,7 @@ describe('SearchResult Base64 Config Loading', () => {
 
       // Mock useLocation to return the malformed search parameters
       mockUseLocation.mockReturnValue({
-        pathname: '/experiment/create/singleQueryComparison',
+        pathname: '/experiment/create/queryAnalysis',
         search: '?config=malformed_base64',
         hash: '',
       });
@@ -509,7 +509,7 @@ describe('SearchResult Base64 Config Loading', () => {
 
       // Mock useLocation to return the valid search parameters
       mockUseLocation.mockReturnValue({
-        pathname: '/experiment/create/singleQueryComparison',
+        pathname: '/experiment/create/queryAnalysis',
         search: `?config=${validBase64Config}`,
         hash: '#/?config=invalid_hash_config',
       });


### PR DESCRIPTION
### Description

This PR renames the "Single Query Comparison" feature to "Query Analysis" across the codebase.

The original name incorrectly implied that a comparison was required. The updated name more accurately reflects the current functionality, which allows users to run and evaluate a single query directly, with comparison being an optional feature rather than a mandatory workflow.

### Issues Resolved

Resolves: #749 

### Check List

- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
