### PR TITLE
[FEATURE] Rename %SearchText% to %queryText% #698

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * Support manually creating a Query Set using plain text, key-value, or NDJSON input directly in the UI. ([#754](https://github.com/opensearch-project/dashboards-search-relevance/pull/754))
 
 ### Enhancements
+* Rename `%SearchText%` to `%queryText%` in Query Template ([#774](https://github.com/opensearch-project/dashboards-search-relevance/pull/774))
 
 ### Bug Fixes
 * Bug bugs on pairwise comparison experiment view page. ([#735]https://github.com/opensearch-project/dashboards-search-relevance/pull/735)

--- a/public/components/common/__test__/__snapshots__/flyout.test.tsx.snap
+++ b/public/components/common/__test__/__snapshots__/flyout.test.tsx.snap
@@ -123,7 +123,7 @@ exports[`Flyout component Renders flyout component 1`] = `
                               <code
                                 class="euiCodeBlock__code"
                               >
-                                %SearchText%
+                                %queryText%
                               </code>
                             </span>
                              variable to refer to the text in the search bar. When you enter 
@@ -325,7 +325,7 @@ exports[`Flyout component Renders flyout component 1`] = `
                                   <span
                                     class="token string"
                                   >
-                                    "%SearchText%"
+                                    "%queryText%"
                                   </span>
                                   <span
                                     class="token punctuation"
@@ -563,7 +563,7 @@ exports[`Flyout component Renders flyout component 1`] = `
                                   <span
                                     class="token string"
                                   >
-                                    "%SearchText%"
+                                    "%queryText%"
                                   </span>
                                   <span
                                     class="token punctuation"
@@ -926,7 +926,7 @@ exports[`Flyout component Renders flyout component 1`] = `
                                       <code
                                         class="euiCodeBlock__code"
                                       >
-                                        %SearchText%
+                                        %queryText%
                                       </code>
                                     </span>
                                      variable to refer to the text in the search bar. When you enter 
@@ -1128,7 +1128,7 @@ exports[`Flyout component Renders flyout component 1`] = `
                                           <span
                                             class="token string"
                                           >
-                                            "%SearchText%"
+                                            "%queryText%"
                                           </span>
                                           <span
                                             class="token punctuation"
@@ -1366,7 +1366,7 @@ exports[`Flyout component Renders flyout component 1`] = `
                                           <span
                                             class="token string"
                                           >
-                                            "%SearchText%"
+                                            "%queryText%"
                                           </span>
                                           <span
                                             class="token punctuation"
@@ -1661,7 +1661,7 @@ exports[`Flyout component Renders flyout component 1`] = `
                                         <code
                                           class="euiCodeBlock__code"
                                         >
-                                          %SearchText%
+                                          %queryText%
                                         </code>
                                       </span>
                                        variable to refer to the text in the search bar. When you enter 
@@ -1863,7 +1863,7 @@ exports[`Flyout component Renders flyout component 1`] = `
                                             <span
                                               class="token string"
                                             >
-                                              "%SearchText%"
+                                              "%queryText%"
                                             </span>
                                             <span
                                               class="token punctuation"
@@ -2101,7 +2101,7 @@ exports[`Flyout component Renders flyout component 1`] = `
                                             <span
                                               class="token string"
                                             >
-                                              "%SearchText%"
+                                              "%queryText%"
                                             </span>
                                             <span
                                               class="token punctuation"
@@ -2396,7 +2396,7 @@ exports[`Flyout component Renders flyout component 1`] = `
                                           <code
                                             class="euiCodeBlock__code"
                                           >
-                                            %SearchText%
+                                            %queryText%
                                           </code>
                                         </span>
                                          variable to refer to the text in the search bar. When you enter 
@@ -2598,7 +2598,7 @@ exports[`Flyout component Renders flyout component 1`] = `
                                               <span
                                                 class="token string"
                                               >
-                                                "%SearchText%"
+                                                "%queryText%"
                                               </span>
                                               <span
                                                 class="token punctuation"
@@ -2836,7 +2836,7 @@ exports[`Flyout component Renders flyout component 1`] = `
                                               <span
                                                 class="token string"
                                               >
-                                                "%SearchText%"
+                                                "%queryText%"
                                               </span>
                                               <span
                                                 class="token punctuation"
@@ -3119,7 +3119,7 @@ exports[`Flyout component Renders flyout component 1`] = `
                                             <code
                                               class="euiCodeBlock__code"
                                             >
-                                              %SearchText%
+                                              %queryText%
                                             </code>
                                           </span>
                                            variable to refer to the text in the search bar. When you enter 
@@ -3321,7 +3321,7 @@ exports[`Flyout component Renders flyout component 1`] = `
                                                 <span
                                                   class="token string"
                                                 >
-                                                  "%SearchText%"
+                                                  "%queryText%"
                                                 </span>
                                                 <span
                                                   class="token punctuation"
@@ -3559,7 +3559,7 @@ exports[`Flyout component Renders flyout component 1`] = `
                                                 <span
                                                   class="token string"
                                                 >
-                                                  "%SearchText%"
+                                                  "%queryText%"
                                                 </span>
                                                 <span
                                                   class="token punctuation"
@@ -3943,7 +3943,7 @@ exports[`Flyout component Renders flyout component 1`] = `
                                               <code
                                                 className="euiCodeBlock__code"
                                               >
-                                                %SearchText%
+                                                %queryText%
                                               </code>
                                             </span>
                                           </EuiCodeBlockImpl>
@@ -4237,7 +4237,7 @@ exports[`Flyout component Renders flyout component 1`] = `
                                                     className="token string"
                                                     key="node-1-4"
                                                   >
-                                                    "%SearchText%"
+                                                    "%queryText%"
                                                   </span>
                                                   <span
                                                     className="token punctuation"
@@ -4363,7 +4363,7 @@ exports[`Flyout component Renders flyout component 1`] = `
 {
   \\"query\\": {
     \\"multi_match\\": {
-      \\"query\\": \\"%SearchText%\\",
+      \\"query\\": \\"%queryText%\\",
       \\"fields\\": [\\"speaker\\", \\"text_entry\\"]
     }
   }
@@ -4584,7 +4584,7 @@ exports[`Flyout component Renders flyout component 1`] = `
                                                     className="token string"
                                                     key="node-1-4"
                                                   >
-                                                    "%SearchText%"
+                                                    "%queryText%"
                                                   </span>
                                                   <span
                                                     className="token punctuation"
@@ -4710,7 +4710,7 @@ exports[`Flyout component Renders flyout component 1`] = `
 {
   \\"query\\": {
     \\"multi_match\\": {
-      \\"query\\": \\"%SearchText%\\",
+      \\"query\\": \\"%queryText%\\",
       \\"fields\\": [\\"speaker^3\\", \\"text_entry\\"]
     }
   }

--- a/public/components/common/flyout.tsx
+++ b/public/components/common/flyout.tsx
@@ -21,7 +21,7 @@ const query1 = `
 {
   "query": {
     "multi_match": {
-      "query": "%SearchText%",
+      "query": "%queryText%",
       "fields": ["speaker", "text_entry"]
     }
   }
@@ -32,7 +32,7 @@ const query2 = `
 {
   "query": {
     "multi_match": {
-      "query": "%SearchText%",
+      "query": "%queryText%",
       "fields": ["speaker^3", "text_entry"]
     }
   }
@@ -43,7 +43,7 @@ const agenticQuery = `
 {
   "query": {
     "agentic": {
-      "question": "%SearchText%"
+      "question": "%queryText%"
     }
   }
 }
@@ -75,7 +75,7 @@ export const Flyout = () => {
             >
               OpenSearch Query DSL
             </EuiLink>
-            . Use the <EuiCode>%SearchText%</EuiCode> variable to refer to the text in the search
+            . Use the <EuiCode>%queryText%</EuiCode> variable to refer to the text in the search
             bar. When you enter <strong>Search</strong>, the queries are sent to the search engine
             using the <EuiCode>GET</EuiCode> HTTP method and the <EuiCode>_search</EuiCode>{' '}
             endpoint.

--- a/public/components/query_compare/search_result/search/query_processor.test.ts
+++ b/public/components/query_compare/search_result/search/query_processor.test.ts
@@ -30,10 +30,12 @@ describe('query_processor', () => {
   });
 
   describe('rewriteQuery', () => {
-    it('should replace %SearchText% with search value', () => {
+    it('should replace %SearchText% and %queryText% with search value', () => {
       const queryError: QueryError = { ...initialQueryErrorState };
-      const result = rewriteQuery('test', '{"query": {"match": {"title": "%SearchText%"}}}', queryError);
-      expect(result.query.match.title).toBe('test');
+      const result1 = rewriteQuery('test', '{"query": {"match": {"title": "%SearchText%"}}}', queryError);
+      const result2 = rewriteQuery('test', '{"query": {"match": {"title": "%queryText%"}}}', queryError);
+      expect((result1 as any).query.match.title).toBe('test');
+      expect((result2 as any).query.match.title).toBe('test');
     });
 
     it('should set error for invalid JSON', () => {
@@ -79,11 +81,11 @@ describe('query_processor', () => {
         'index1',
         'index2',
         '{"query": {"match": {"title": "%SearchText%"}}}',
-        '{"query": {"term": {"status": "%SearchText%"}}}'
+        '{"query": {"term": {"status": "%queryText%"}}}'
       );
 
-      expect(result.jsonQueries[0].query.match.title).toBe('search-term');
-      expect(result.jsonQueries[1].query.term.status).toBe('search-term');
+      expect((result.jsonQueries[0] as any).query.match.title).toBe('search-term');
+      expect((result.jsonQueries[1] as any).query.term.status).toBe('search-term');
       expect(result.queryErrors).toHaveLength(2);
     });
 

--- a/public/components/query_compare/search_result/search/query_processor.ts
+++ b/public/components/query_compare/search_result/search/query_processor.ts
@@ -21,7 +21,7 @@ export const validateQuery = (selectedIndex: string, queryString: string, queryE
 export const rewriteQuery = (value: string, queryString: string, queryError: QueryError) => {
   if (queryString.trim().length > 0) {
     try {
-      return JSON.parse(queryString.replace(/%SearchText%/g, value));
+      return JSON.parse(queryString.replace(/%SearchText%|%queryText%/g, value));
     } catch {
       queryError.queryString = QueryStringError.invalid;
       queryError.errorResponse.statusCode = 400;

--- a/public/components/query_compare/search_result/search_components/__tests__/__snapshots__/search_configs.test.tsx.snap
+++ b/public/components/query_compare/search_result/search_components/__tests__/__snapshots__/search_configs.test.tsx.snap
@@ -844,7 +844,7 @@ exports[`Flyout component Renders flyout component 1`] = `
                         >
                           OpenSearch Query DSL
                         </a>
-                        . Use %SearchText% to refer to the text in the search bar
+                        . Use %queryText% to refer to the text in the search bar
                       </p>
                     }
                     isInvalid={false}
@@ -1088,7 +1088,7 @@ exports[`Flyout component Renders flyout component 1`] = `
                               >
                                 OpenSearch Query DSL
                               </a>
-                              . Use %SearchText% to refer to the text in the search bar
+                              . Use %queryText% to refer to the text in the search bar
                             </p>
                           </div>
                         </EuiFormHelpText>
@@ -1891,7 +1891,7 @@ exports[`Flyout component Renders flyout component 1`] = `
                         >
                           OpenSearch Query DSL
                         </a>
-                        . Use %SearchText% to refer to the text in the search bar
+                        . Use %queryText% to refer to the text in the search bar
                       </p>
                     }
                     isInvalid={false}
@@ -2135,7 +2135,7 @@ exports[`Flyout component Renders flyout component 1`] = `
                               >
                                 OpenSearch Query DSL
                               </a>
-                              . Use %SearchText% to refer to the text in the search bar
+                              . Use %queryText% to refer to the text in the search bar
                             </p>
                           </div>
                         </EuiFormHelpText>
@@ -2988,7 +2988,7 @@ exports[`Flyout component Renders flyout component when multi dataSource enabled
                         >
                           OpenSearch Query DSL
                         </a>
-                        . Use %SearchText% to refer to the text in the search bar
+                        . Use %queryText% to refer to the text in the search bar
                       </p>
                     }
                     isInvalid={false}
@@ -3232,7 +3232,7 @@ exports[`Flyout component Renders flyout component when multi dataSource enabled
                               >
                                 OpenSearch Query DSL
                               </a>
-                              . Use %SearchText% to refer to the text in the search bar
+                              . Use %queryText% to refer to the text in the search bar
                             </p>
                           </div>
                         </EuiFormHelpText>
@@ -4032,7 +4032,7 @@ exports[`Flyout component Renders flyout component when multi dataSource enabled
                         >
                           OpenSearch Query DSL
                         </a>
-                        . Use %SearchText% to refer to the text in the search bar
+                        . Use %queryText% to refer to the text in the search bar
                       </p>
                     }
                     isInvalid={false}
@@ -4276,7 +4276,7 @@ exports[`Flyout component Renders flyout component when multi dataSource enabled
                               >
                                 OpenSearch Query DSL
                               </a>
-                              . Use %SearchText% to refer to the text in the search bar
+                              . Use %queryText% to refer to the text in the search bar
                             </p>
                           </div>
                         </EuiFormHelpText>
@@ -5129,7 +5129,7 @@ exports[`Flyout component handles search configuration selection without crashin
                         >
                           OpenSearch Query DSL
                         </a>
-                        . Use %SearchText% to refer to the text in the search bar
+                        . Use %queryText% to refer to the text in the search bar
                       </p>
                     }
                     isInvalid={false}
@@ -5373,7 +5373,7 @@ exports[`Flyout component handles search configuration selection without crashin
                               >
                                 OpenSearch Query DSL
                               </a>
-                              . Use %SearchText% to refer to the text in the search bar
+                              . Use %queryText% to refer to the text in the search bar
                             </p>
                           </div>
                         </EuiFormHelpText>
@@ -6173,7 +6173,7 @@ exports[`Flyout component handles search configuration selection without crashin
                         >
                           OpenSearch Query DSL
                         </a>
-                        . Use %SearchText% to refer to the text in the search bar
+                        . Use %queryText% to refer to the text in the search bar
                       </p>
                     }
                     isInvalid={false}
@@ -6417,7 +6417,7 @@ exports[`Flyout component handles search configuration selection without crashin
                               >
                                 OpenSearch Query DSL
                               </a>
-                              . Use %SearchText% to refer to the text in the search bar
+                              . Use %queryText% to refer to the text in the search bar
                             </p>
                           </div>
                         </EuiFormHelpText>

--- a/public/components/query_compare/search_result/search_components/search_configs/search_config.tsx
+++ b/public/components/query_compare/search_result/search_components/search_configs/search_config.tsx
@@ -353,7 +353,7 @@ export const SearchConfig: FunctionComponent<SearchConfigProps> = ({
           <p>
             Enter a query in{' '}
             <a href="https://opensearch.org/docs/latest/query-dsl/index/">OpenSearch Query DSL</a>.
-            Use %SearchText% to refer to the text in the search bar
+            Use %queryText% to refer to the text in the search bar
           </p>
         }
       >

--- a/public/components/search_configuration/__tests__/query_processor.test.ts
+++ b/public/components/search_configuration/__tests__/query_processor.test.ts
@@ -13,7 +13,7 @@ import {
 describe('query_processor', () => {
   describe('processQuery', () => {
     it('should replace placeholder with search text', () => {
-      const query = '{"query": {"match": {"title": "%SearchText%"}}}';
+      const query = '{"query": {"match": {"title": "%queryText%"}}}';
       const searchText = 'test search';
 
       const result = processQuery(query, searchText);
@@ -23,7 +23,7 @@ describe('query_processor', () => {
 
     it('should handle multiple placeholders', () => {
       const query =
-        '{"query": {"bool": {"must": [{"match": {"title": "%SearchText%"}}, {"match": {"content": "%SearchText%"}}]}}}';
+        '{"query": {"bool": {"must": [{"match": {"title": "%queryText%"}}, {"match": {"content": "%SearchText%"}}]}}}';
       const searchText = 'test';
 
       const result = processQuery(query, searchText);
@@ -43,7 +43,7 @@ describe('query_processor', () => {
     });
 
     it('should handle empty search text', () => {
-      const query = '{"query": {"match": {"title": "%SearchText%"}}}';
+      const query = '{"query": {"match": {"title": "%queryText%"}}}';
       const searchText = '';
 
       const result = processQuery(query, searchText);

--- a/public/components/search_configuration/__tests__/search_configuration_form.test.tsx
+++ b/public/components/search_configuration/__tests__/search_configuration_form.test.tsx
@@ -224,7 +224,7 @@ describe('SearchConfigurationForm', () => {
           query: {
             bool: {
               must: [
-                { match: { title: '%SearchText%' } },
+                { match: { title: '%queryText%' } },
                 { range: { date: { gte: '2023-01-01' } } },
               ],
               filter: [{ term: { status: 'published' } }],

--- a/public/components/search_configuration/components/search_configuration_form.tsx
+++ b/public/components/search_configuration/components/search_configuration_form.tsx
@@ -88,7 +88,7 @@ export const SearchConfigurationForm: React.FC<SearchConfigurationFormProps> = m
         label="Query"
         error={queryError}
         isInvalid={Boolean(queryError)}
-        helpText="Define the query in JSON format. Use %SearchText% to represent the specific query text."
+        helpText="Define the query in JSON format. Use %queryText% to represent the specific query text."
         fullWidth
       >
         <EuiCodeEditor

--- a/public/components/search_configuration/components/validation_panel.tsx
+++ b/public/components/search_configuration/components/validation_panel.tsx
@@ -28,7 +28,7 @@ export const ValidationPanel: React.FC<ValidationPanelProps> = memo(
     return (
       <EuiFlexItem>
         <EuiFieldText
-          placeholder="Enter a user query to replace %SearchText% placeholder to validate the search configuration..."
+          placeholder="Enter a user query to replace %queryText% placeholder to validate the search configuration..."
           value={testSearchText}
           onChange={(e) => setTestSearchText(e.target.value)}
           fullWidth

--- a/public/components/search_configuration/utils/query_processor.ts
+++ b/public/components/search_configuration/utils/query_processor.ts
@@ -10,7 +10,7 @@
  * @returns The processed query with placeholders replaced
  */
 export const processQuery = (query: string, searchText: string = ''): string => {
-  return query.replace(/%SearchText%/g, searchText);
+  return query.replace(/%SearchText%|%queryText%/g, searchText);
 };
 
 /**


### PR DESCRIPTION
### Description

This PR renames the `%SearchText%` variable placeholder to `%queryText%` across the user interface and configuration templates to better align with the nomenclature used in the Search Configuration indices. 

The query processors have been updated to support both `%queryText%` and `%SearchText%` to ensure backward compatibility for any existing scripts or deep links using the older variable.

### Issues Resolved

Resolves #698

### Check List

- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
