### PR TITLE
Fix generic error message for invalid NDJSON query sets #688

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * Fix text alignment and excessive spacing in Single Query Comparison results view. ([#752](https://github.com/opensearch-project/dashboards-search-relevance/pull/752))
 * Allow a single query setup to be executed in the search comparison UI. ([#746](https://github.com/opensearch-project/dashboards-search-relevance/pull/746))
 * Fix error when deleting judgment ratings by ensuring the judgments list refreshes correctly and removes deleted entries from UI state. ([#751](https://github.com/opensearch-project/dashboards-search-relevance/pull/751))
+* Fix generic error message when uploading malformed NDJSON query sets by surfacing detailed parsing error with line numbers. ([#776](https://github.com/opensearch-project/dashboards-search-relevance/pull/776))
 
 ### Infrastructure
 

--- a/public/components/query_set/__tests__/file_processor.test.ts
+++ b/public/components/query_set/__tests__/file_processor.test.ts
@@ -83,7 +83,7 @@ describe('file_processor', () => {
     expect(result.queries).toHaveLength(0);
   });
 
-  it('should handle malformed JSON gracefully', async () => {
+  it('should return error for malformed JSON', async () => {
     const fileContent = `{"queryText": "valid query"}
 {invalid json}
 {"queryText": "another valid query"}`;
@@ -94,10 +94,8 @@ describe('file_processor', () => {
 
     const result = await processQueryFile(mockFile);
 
-    expect(result.error).toBeUndefined();
-    expect(result.queries).toHaveLength(2);
-    expect(result.queries[0].queryText).toBe('valid query');
-    expect(result.queries[1].queryText).toBe('another valid query');
+    expect(result.error).toMatch(/^Invalid JSON format at line 2: /);
+    expect(result.queries).toHaveLength(0);
   });
 
   it('should handle file read errors', async () => {

--- a/public/components/query_set/utils/file_processor.ts
+++ b/public/components/query_set/utils/file_processor.ts
@@ -124,9 +124,12 @@ export const processQueryFile = async (file: File): Promise<FileProcessResult> =
     const lines = text.trim().split('\n');
     const queryList: QueryItem[] = [];
 
-    for (const line of lines) {
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i].trim();
+      if (line.length === 0) continue;
+
       try {
-        const parsed = JSON.parse(line.trim());
+        const parsed = JSON.parse(line);
         if (parsed.queryText) {
           queryList.push({
             queryText: String(parsed.queryText).trim(),
@@ -137,7 +140,10 @@ export const processQueryFile = async (file: File): Promise<FileProcessResult> =
           });
         }
       } catch (e) {
-        // console.error('Error parsing line:', line, e);
+        return {
+          queries: [],
+          error: `Invalid JSON format at line ${i + 1}: ${(e as Error).message}`,
+        };
       }
     }
 


### PR DESCRIPTION
### Description

This PR improves the error messaging when uploading malformed NDJSON query sets. Previously, if a file contained invalid JSON (e.g., unescaped quotes or invalid syntax), the system would catch the exception silently and display a generic "No valid queries found in file" error. 

This change modifies the [processQueryFile](cci:1://file:///Users/venkateshwaran/repos/OpenSearch-Dashboards/plugins/dashboards-search-relevance/public/components/query_set/utils/file_processor.ts:120:0-162:2) utility to capture and surface the specific `JSON.parse` error along with the exact line number where the parsing failed. This provides users with actionable feedback to help them fix their input files.

### Issues Resolved

Resolves #688

### Check List

- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
