### PR TITLE
Force to use node18 for testing

### DIFF
--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -63,11 +63,19 @@ jobs:
       - name: Move Search Relevance to Plugins Dir
         run: mv dashboards-search-relevance OpenSearch-Dashboards/plugins/dashboards-search-relevance
 
+      - name: Setup Node
+        run: |
+          source $NVM_DIR/nvm.sh
+          nvm install 18
+          nvm use 18
+          YARN_VERSION=$(node -p "require('./OpenSearch-Dashboards/package.json').engines.yarn")
+          npm install -g yarn@$YARN_VERSION
+
       - name: Plugin Bootstrap / test
         run: |
           chown -R 1000:1000 `pwd`
           cd ./OpenSearch-Dashboards/
-          su `id -un 1000` -c "source $NVM_DIR/nvm.sh && nvm use && node -v && yarn -v &&
+          su `id -un 1000` -c "source $NVM_DIR/nvm.sh && nvm use 18 && node -v && yarn -v &&
                                cd ./plugins/dashboards-search-relevance &&
                                whoami && yarn osd bootstrap && yarn test --coverage"
 
@@ -82,7 +90,7 @@ jobs:
         run: |
           chown -R 1000:1000 `pwd`
           cd ./OpenSearch-Dashboards/
-          su `id -un 1000` -c "source $NVM_DIR/nvm.sh && nvm use && node -v && yarn -v &&
+          su `id -un 1000` -c "source $NVM_DIR/nvm.sh && nvm use 18 && node -v && yarn -v &&
                                cd ./plugins/dashboards-search-relevance &&
                                whoami && yarn build && mv -v ./build/*.zip ./build/${{ env.PLUGIN_NAME }}-${{ env.OPENSEARCH_PLUGIN_VERSION }}.zip"
 


### PR DESCRIPTION
### Description

Force to use node18 for testing

### Issues Resolved

N/A

### Check List

- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test
- [ ] New functionality has been documented.
- [X] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
