### PR TITLE
add mandatory step to check integ tests

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,6 +10,7 @@
 
 - [ ] New functionality includes testing.
   - [ ] All tests pass, including unit test, integration test
+  - [ ] Integration tests pass: `yarn cypress:run-without-security --config "baseUrl=http://localhost:5601" --spec "cypress/integration/plugins/search-relevance-dashboards/*.js"` (see [Developer Guide](DEVELOPER_GUIDE.md#integration-tests))
 - [ ] New functionality has been documented.
 - [ ] Commits are signed per the DCO using `--signoff`
 

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -32,6 +32,21 @@ Cd back to `OpenSearch-Dashboards` directory and run `yarn start` to start OpenS
 
 See [CONTRIBUTING](CONTRIBUTING.md).
 
+### Integration Tests
+
+Integration tests live in the [opensearch-dashboards-functional-test](https://github.com/opensearch-project/opensearch-dashboards-functional-test) repo under `cypress/integration/plugins/search-relevance-dashboards/`. These are the same tests triggered by the CI workflow in [`.github/workflows/remote-integ-tests-workflow.yml`](.github/workflows/remote-integ-tests-workflow.yml).
+
+Before submitting a PR, ensure all integration tests pass locally:
+
+1. Start OpenSearch and OpenSearch Dashboards (with the plugin installed) on `localhost:5601`.
+2. From the `opensearch-dashboards-functional-test` repo, run:
+
+```bash
+yarn cypress:run-without-security --config "baseUrl=http://localhost:5601" --spec "cypress/integration/plugins/search-relevance-dashboards/*.js"
+```
+
+All tests must pass before merging.
+
 ### Backports
 
 The Github workflow in [`backport.yml`](.github/workflows/backport.yml) creates backport PRs automatically when the original PR


### PR DESCRIPTION
### Description
Add a checker to make sure e2e integration tests will have to pass before raising the PR.
- issues fixed: https://github.com/opensearch-project/opensearch-dashboards-functional-test/pull/1940

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
