### PR TITLE
[FEATURE] Add name and description fields to Experiment creation form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Features
 
+- Add optional name and description to the Experiment creation flow (all experiment types and scheduled creation where applicable), with shared validation and payloads that omit empty values. ([#770](https://github.com/opensearch-project/dashboards-search-relevance/issues/770), [#827](https://github.com/opensearch-project/dashboards-search-relevance/pull/827))
+
 ### Enhancements
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * Add optional description field to Search Configuration create form, detail view, and listing ([#798](https://github.com/opensearch-project/dashboards-search-relevance/issues/798))
 * Add /search-relevance slash command for chatbot with welcome message and AI-assisted search relevance tuning ([#843](https://github.com/opensearch-project/dashboards-search-relevance/pull/843))
 
+- Add optional name and description to the Experiment creation flow (all experiment types and scheduled creation where applicable), with shared validation and payloads that omit empty values. ([#770](https://github.com/opensearch-project/dashboards-search-relevance/issues/770), [#827](https://github.com/opensearch-project/dashboards-search-relevance/pull/827))
+
 ### Enhancements
 * Make Query Set description optional on create ([#758](https://github.com/opensearch-project/dashboards-search-relevance/issues/758))
 

--- a/common/experiment_metadata.test.ts
+++ b/common/experiment_metadata.test.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  EXPERIMENT_DESCRIPTION_MAX_LENGTH,
+  EXPERIMENT_NAME_MAX_LENGTH,
+  validateExperimentMetadataForCreate,
+} from './experiment_metadata';
+
+describe('validateExperimentMetadataForCreate', () => {
+  it('allows empty optional fields', () => {
+    expect(validateExperimentMetadataForCreate('', '')).toEqual({});
+    expect(validateExperimentMetadataForCreate(undefined, undefined)).toEqual({});
+  });
+
+  it('rejects names longer than the maximum length', () => {
+    const name = 'a'.repeat(EXPERIMENT_NAME_MAX_LENGTH + 1);
+    expect(validateExperimentMetadataForCreate(name, '')).toEqual({
+      name: [`Name must be at most ${EXPERIMENT_NAME_MAX_LENGTH} characters.`],
+    });
+  });
+
+  it('rejects descriptions longer than the maximum length', () => {
+    const description = 'b'.repeat(EXPERIMENT_DESCRIPTION_MAX_LENGTH + 1);
+    expect(validateExperimentMetadataForCreate('', description)).toEqual({
+      description: [
+        `Description must be at most ${EXPERIMENT_DESCRIPTION_MAX_LENGTH} characters.`,
+      ],
+    });
+  });
+});

--- a/common/experiment_metadata.ts
+++ b/common/experiment_metadata.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/** Matches backend search-relevance experiment name/description limits. */
+export const EXPERIMENT_NAME_MAX_LENGTH = 50;
+export const EXPERIMENT_DESCRIPTION_MAX_LENGTH = 250;
+
+export type ExperimentMetadataFieldErrors = {
+  name?: string[];
+  description?: string[];
+};
+
+/**
+ * Client-side validation for optional experiment name/description on create.
+ * Backend enforces the same limits; this surfaces issues before the request.
+ */
+export function validateExperimentMetadataForCreate(
+  name: string | undefined,
+  description: string | undefined
+): ExperimentMetadataFieldErrors {
+  const errors: ExperimentMetadataFieldErrors = {};
+  const n = typeof name === 'string' ? name : '';
+  const d = typeof description === 'string' ? description : '';
+
+  if (n.length > EXPERIMENT_NAME_MAX_LENGTH) {
+    errors.name = [`Name must be at most ${EXPERIMENT_NAME_MAX_LENGTH} characters.`];
+  }
+  if (d.length > EXPERIMENT_DESCRIPTION_MAX_LENGTH) {
+    errors.description = [
+      `Description must be at most ${EXPERIMENT_DESCRIPTION_MAX_LENGTH} characters.`,
+    ];
+  }
+  return errors;
+}

--- a/common/index.ts
+++ b/common/index.ts
@@ -100,4 +100,11 @@ export const PRECISION_TOOL_TIP = 'Precision measures the proportion of retrieve
 export const MAP_TOOL_TIP = 'Mean Average Precision (MAP) is a single-figure measure of quality across recall levels. For a single query, Average Precision (AP) is the average of the Precision values calculated at the rank of each relevant document. MAP is the mean of these Average Precision scores across multiple queries.';
 export const COVERAGE_TOOL_TIP = 'Coverage represents the ratio of query-document pairs in the search results for which a relevance judgment exists. It indicates how much of the returned data has been evaluated for relevance.';
 
+export {
+  EXPERIMENT_DESCRIPTION_MAX_LENGTH,
+  EXPERIMENT_NAME_MAX_LENGTH,
+  validateExperimentMetadataForCreate,
+} from './experiment_metadata';
+export type { ExperimentMetadataFieldErrors } from './experiment_metadata';
+
 export { DISABLED_BACKEND_PLUGIN_MESSAGE, extractUserMessageFromError } from './error_handling';

--- a/public/components/experiment/configuration/build_experiment_create_payload.test.ts
+++ b/public/components/experiment/configuration/build_experiment_create_payload.test.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ExperimentType } from '../../../types/index';
+import { buildExperimentCreateRequestBody } from './build_experiment_create_payload';
+
+describe('buildExperimentCreateRequestBody', () => {
+  it('includes optional name and description when non-empty', () => {
+    const body = buildExperimentCreateRequestBody({
+      type: ExperimentType.PAIRWISE_COMPARISON,
+      querySetId: 'qs-1',
+      size: 10,
+      searchConfigurationList: ['a', 'b'],
+      name: '  My experiment  ',
+      description: '  Notes  ',
+    });
+
+    expect(body).toEqual({
+      type: ExperimentType.PAIRWISE_COMPARISON,
+      querySetId: 'qs-1',
+      size: 10,
+      searchConfigurationList: ['a', 'b'],
+      name: 'My experiment',
+      description: 'Notes',
+    });
+  });
+
+  it('omits optional name and description when blank', () => {
+    const body = buildExperimentCreateRequestBody({
+      type: ExperimentType.PAIRWISE_COMPARISON,
+      querySetId: 'qs-1',
+      size: 10,
+      searchConfigurationList: ['a', 'b'],
+      name: '   ',
+      description: '',
+    });
+
+    expect(body).toEqual({
+      type: ExperimentType.PAIRWISE_COMPARISON,
+      querySetId: 'qs-1',
+      size: 10,
+      searchConfigurationList: ['a', 'b'],
+    });
+  });
+
+  it('includes judgment lists for evaluation-style experiments', () => {
+    const body = buildExperimentCreateRequestBody({
+      type: ExperimentType.POINTWISE_EVALUATION,
+      querySetId: 'qs-1',
+      size: 10,
+      searchConfigurationList: ['sc-1'],
+      judgmentList: ['j-1'],
+      name: 'Eval',
+    });
+
+    expect(body).toEqual({
+      type: ExperimentType.POINTWISE_EVALUATION,
+      querySetId: 'qs-1',
+      size: 10,
+      searchConfigurationList: ['sc-1'],
+      judgmentList: ['j-1'],
+      name: 'Eval',
+    });
+  });
+});

--- a/public/components/experiment/configuration/build_experiment_create_payload.ts
+++ b/public/components/experiment/configuration/build_experiment_create_payload.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ConfigurationFormData } from './types';
+
+/**
+ * Builds the JSON body for creating an experiment. Omits empty optional name/description
+ * so the backend can apply its default naming behavior.
+ */
+export function buildExperimentCreateRequestBody(data: ConfigurationFormData): Record<string, unknown> {
+  const payload: Record<string, unknown> = {
+    type: data.type,
+    querySetId: data.querySetId,
+    size: data.size,
+    searchConfigurationList: data.searchConfigurationList,
+  };
+
+  if ('judgmentList' in data && Array.isArray(data.judgmentList) && data.judgmentList.length > 0) {
+    payload.judgmentList = data.judgmentList;
+  }
+
+  const name = typeof data.name === 'string' ? data.name.trim() : '';
+  const description = typeof data.description === 'string' ? data.description.trim() : '';
+
+  if (name) {
+    payload.name = name;
+  }
+  if (description) {
+    payload.description = description;
+  }
+
+  return payload;
+}

--- a/public/components/experiment/configuration/configuration_form.tsx
+++ b/public/components/experiment/configuration/configuration_form.tsx
@@ -176,6 +176,8 @@ const getInitialFormData = (templateType: TemplateType): ConfigurationFormData =
     querySetId: '',
     size: 10,
     searchConfigurationList: [],
+    name: '',
+    description: '',
   };
 
   switch (templateType) {

--- a/public/components/experiment/configuration/experiment_metadata_fields.tsx
+++ b/public/components/experiment/configuration/experiment_metadata_fields.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { EuiFieldText, EuiFormRow, EuiSpacer, EuiTextArea } from '@elastic/eui';
+import {
+  EXPERIMENT_DESCRIPTION_MAX_LENGTH,
+  EXPERIMENT_NAME_MAX_LENGTH,
+} from '../../../../common';
+
+export interface ExperimentMetadataFieldsProps {
+  name: string;
+  description: string;
+  onChange: (field: 'name' | 'description', value: string) => void;
+  nameError?: string[];
+  descriptionError?: string[];
+}
+
+export const ExperimentMetadataFields: React.FC<ExperimentMetadataFieldsProps> = ({
+  name,
+  description,
+  onChange,
+  nameError = [],
+  descriptionError = [],
+}) => (
+  <>
+    <EuiFormRow
+      label="Experiment name"
+      helpText="Optional. If left empty, a name will be auto-generated."
+      isInvalid={nameError.length > 0}
+      error={nameError}
+    >
+      <EuiFieldText
+        name="experimentName"
+        value={name}
+        onChange={(e) => onChange('name', e.target.value)}
+        placeholder="Enter experiment name"
+        maxLength={EXPERIMENT_NAME_MAX_LENGTH}
+        data-test-subj="experimentCreateName"
+        fullWidth
+      />
+    </EuiFormRow>
+    <EuiSpacer size="m" />
+    <EuiFormRow
+      label="Description"
+      helpText={`Optional. Up to ${EXPERIMENT_DESCRIPTION_MAX_LENGTH} characters.`}
+      isInvalid={descriptionError.length > 0}
+      error={descriptionError}
+    >
+      <EuiTextArea
+        name="experimentDescription"
+        value={description}
+        onChange={(e) => onChange('description', e.target.value)}
+        placeholder="Describe the purpose of this experiment (optional)"
+        maxLength={EXPERIMENT_DESCRIPTION_MAX_LENGTH}
+        data-test-subj="experimentCreateDescription"
+        fullWidth
+      />
+    </EuiFormRow>
+    <EuiSpacer size="m" />
+  </>
+);

--- a/public/components/experiment/configuration/form/hybrid_optimizer_experiment_form.tsx
+++ b/public/components/experiment/configuration/form/hybrid_optimizer_experiment_form.tsx
@@ -15,6 +15,8 @@ import {
   mapOptionLabelsToFormData,
   mapQuerySetToOptionLabels,
 } from '../configuration_form';
+import { ExperimentMetadataFields } from '../experiment_metadata_fields';
+import { validateExperimentMetadataForCreate } from '../../../../../common';
 
 export interface HybridOptimizerExperimentFormRef {
   validateAndSetErrors: () => { isValid: boolean; data: HybridOptimizerExperimentFormData };
@@ -41,12 +43,16 @@ export const HybridOptimizerExperimentForm = forwardRef<
   const [kError, setKError] = useState<string[]>([]);
   const [searchConfigError, setSearchConfigError] = useState<string[]>([]);
   const [judgmentError, setJudgmentError] = useState<string[]>([]);
+  const [nameError, setNameError] = useState<string[]>([]);
+  const [descriptionError, setDescriptionError] = useState<string[]>([]);
 
   const clearAllErrors = () => {
     setQuerySetError([]);
     setKError([]);
     setSearchConfigError([]);
     setJudgmentError([]);
+    setNameError([]);
+    setDescriptionError([]);
   };
 
   useEffect(() => {
@@ -72,7 +78,23 @@ export const HybridOptimizerExperimentForm = forwardRef<
       searchConfigurationList: selectedSearchConfigs.map((c) => c.value),
       judgmentList: judgmentOptions.map((j) => j.value),
       type: formData.type, // Preserve the 'type' from the initial formData
+      name: typeof formData.name === 'string' ? formData.name : '',
+      description: typeof formData.description === 'string' ? formData.description : '',
     };
+
+    const metadataErrors = validateExperimentMetadataForCreate(currentData.name, currentData.description);
+    if (metadataErrors.name) {
+      setNameError(metadataErrors.name);
+      isValid = false;
+    } else {
+      setNameError([]);
+    }
+    if (metadataErrors.description) {
+      setDescriptionError(metadataErrors.description);
+      isValid = false;
+    } else {
+      setDescriptionError([]);
+    }
 
     // Validate Query Set
     if (!currentData.querySetId) {
@@ -170,6 +192,15 @@ export const HybridOptimizerExperimentForm = forwardRef<
 
   return (
     <EuiFlexGroup direction="column">
+      <EuiFlexItem>
+        <ExperimentMetadataFields
+          name={typeof formData.name === 'string' ? formData.name : ''}
+          description={typeof formData.description === 'string' ? formData.description : ''}
+          onChange={(field, value) => onChange(field, value)}
+          nameError={nameError}
+          descriptionError={descriptionError}
+        />
+      </EuiFlexItem>
       <EuiFlexItem>
         <EuiFlexGroup gutterSize="m" direction="row" style={{ maxWidth: 600 }}>
           <EuiFlexItem grow={4}>

--- a/public/components/experiment/configuration/form/pointwise_experiment_form.tsx
+++ b/public/components/experiment/configuration/form/pointwise_experiment_form.tsx
@@ -15,6 +15,8 @@ import {
   mapOptionLabelsToFormData,
   mapQuerySetToOptionLabels,
 } from '../configuration_form';
+import { ExperimentMetadataFields } from '../experiment_metadata_fields';
+import { validateExperimentMetadataForCreate } from '../../../../../common';
 
 interface PointwiseExperimentFormProps {
   formData: PointwiseExperimentFormData;
@@ -41,12 +43,16 @@ export const PointwiseExperimentForm = forwardRef<
   const [kError, setKError] = useState<string[]>([]);
   const [searchConfigError, setSearchConfigError] = useState<string[]>([]);
   const [judgmentError, setJudgmentError] = useState<string[]>([]);
+  const [nameError, setNameError] = useState<string[]>([]);
+  const [descriptionError, setDescriptionError] = useState<string[]>([]);
 
   const clearAllErrors = () => {
     setQuerySetError([]);
     setKError([]);
     setSearchConfigError([]);
     setJudgmentError([]);
+    setNameError([]);
+    setDescriptionError([]);
   };
 
   useEffect(() => {
@@ -69,7 +75,23 @@ export const PointwiseExperimentForm = forwardRef<
       searchConfigurationList: selectedSearchConfigs.map((c) => c.value),
       judgmentList: judgmentOptions.map((j) => j.value),
       type: formData.type, // Preserve the type from the initial formData
+      name: typeof formData.name === 'string' ? formData.name : '',
+      description: typeof formData.description === 'string' ? formData.description : '',
     };
+
+    const metadataErrors = validateExperimentMetadataForCreate(currentData.name, currentData.description);
+    if (metadataErrors.name) {
+      setNameError(metadataErrors.name);
+      isValid = false;
+    } else {
+      setNameError([]);
+    }
+    if (metadataErrors.description) {
+      setDescriptionError(metadataErrors.description);
+      isValid = false;
+    } else {
+      setDescriptionError([]);
+    }
 
     // Validate Query Set
     if (!currentData.querySetId) {
@@ -168,6 +190,15 @@ export const PointwiseExperimentForm = forwardRef<
 
   return (
     <EuiFlexGroup direction="column">
+      <EuiFlexItem>
+        <ExperimentMetadataFields
+          name={typeof formData.name === 'string' ? formData.name : ''}
+          description={typeof formData.description === 'string' ? formData.description : ''}
+          onChange={(field, value) => onChange(field, value)}
+          nameError={nameError}
+          descriptionError={descriptionError}
+        />
+      </EuiFlexItem>
       <EuiFlexItem>
         <EuiFlexGroup gutterSize="m" direction="row" style={{ maxWidth: 600 }}>
           <EuiFlexItem grow={4}>

--- a/public/components/experiment/configuration/form/result_list_comparison_form.tsx
+++ b/public/components/experiment/configuration/form/result_list_comparison_form.tsx
@@ -14,6 +14,8 @@ import {
   mapOptionLabelsToFormData,
   mapQuerySetToOptionLabels,
 } from '../configuration_form';
+import { ExperimentMetadataFields } from '../experiment_metadata_fields';
+import { validateExperimentMetadataForCreate } from '../../../../../common';
 
 export interface ResultListComparisonFormRef {
   validateAndSetErrors: () => { isValid: boolean; data: ResultListComparisonFormData };
@@ -38,11 +40,15 @@ export const ResultListComparisonForm = forwardRef<
   const [querySetError, setQuerySetError] = useState<string[]>([]);
   const [kError, setKError] = useState<string[]>([]);
   const [searchConfigError, setSearchConfigError] = useState<string[]>([]);
+  const [nameError, setNameError] = useState<string[]>([]);
+  const [descriptionError, setDescriptionError] = useState<string[]>([]);
 
   const clearAllErrors = () => {
     setQuerySetError([]);
     setKError([]);
     setSearchConfigError([]);
+    setNameError([]);
+    setDescriptionError([]);
   };
 
   useEffect(() => {
@@ -65,7 +71,23 @@ export const ResultListComparisonForm = forwardRef<
       size: k,
       searchConfigurationList: selectedSearchConfigs.map((c) => c.value),
       type: formData.type,
+      name: typeof formData.name === 'string' ? formData.name : '',
+      description: typeof formData.description === 'string' ? formData.description : '',
     };
+
+    const metadataErrors = validateExperimentMetadataForCreate(currentData.name, currentData.description);
+    if (metadataErrors.name) {
+      setNameError(metadataErrors.name);
+      isValid = false;
+    } else {
+      setNameError([]);
+    }
+    if (metadataErrors.description) {
+      setDescriptionError(metadataErrors.description);
+      isValid = false;
+    } else {
+      setDescriptionError([]);
+    }
 
     // Validate Query Set
     if (!currentData.querySetId) {
@@ -146,6 +168,15 @@ export const ResultListComparisonForm = forwardRef<
 
   return (
     <EuiFlexGroup direction="column">
+      <EuiFlexItem>
+        <ExperimentMetadataFields
+          name={typeof formData.name === 'string' ? formData.name : ''}
+          description={typeof formData.description === 'string' ? formData.description : ''}
+          onChange={(field, value) => onChange(field, value)}
+          nameError={nameError}
+          descriptionError={descriptionError}
+        />
+      </EuiFlexItem>
       <EuiFlexItem>
         <EuiFlexGroup gutterSize="m" direction="row" style={{ maxWidth: 600 }}>
           <EuiFlexItem grow={4}>

--- a/public/components/experiment/configuration/template_configuration.tsx
+++ b/public/components/experiment/configuration/template_configuration.tsx
@@ -9,6 +9,7 @@ import { EuiFlexItem, EuiFlexGroup, EuiTitle, EuiSpacer, EuiLoadingSpinner } fro
 import { withRouter } from 'react-router-dom';
 import { EuiPanel } from '@elastic/eui';
 import { ConfigurationForm, ConfigurationFormRef } from './configuration_form';
+import { buildExperimentCreateRequestBody } from './build_experiment_create_payload';
 import { TemplateConfigurationProps } from './types';
 import { Routes } from '../../../../common';
 import { ConfigurationActions } from './configuration_action';
@@ -59,7 +60,10 @@ export const TemplateConfiguration = ({
       // If we reach here, `data` is guaranteed to be valid and not null
       try {
         setIsCreating(true);
-        const response = await experimentService.createExperiment(data, selectedDataSource || undefined);
+        const response = await experimentService.createExperiment(
+          buildExperimentCreateRequestBody(data),
+          selectedDataSource || undefined
+        );
 
         if (response.experiment_id) {
           if (isMountedRef.current) {

--- a/public/components/experiment/configuration/template_configuration.tsx
+++ b/public/components/experiment/configuration/template_configuration.tsx
@@ -9,6 +9,7 @@ import { EuiFlexItem, EuiFlexGroup, EuiTitle, EuiSpacer, EuiLoadingSpinner } fro
 import { withRouter } from 'react-router-dom';
 import { EuiPanel } from '@elastic/eui';
 import { ConfigurationForm, ConfigurationFormRef } from './configuration_form';
+import { buildExperimentCreateRequestBody } from './build_experiment_create_payload';
 import { TemplateConfigurationProps } from './types';
 import { Routes } from '../../../../common';
 import { ConfigurationActions } from './configuration_action';
@@ -55,7 +56,10 @@ export const TemplateConfiguration = ({
       // If we reach here, `data` is guaranteed to be valid and not null
       try {
         setIsCreating(true);
-        const response = await experimentService.createExperiment(data, dataSourceId);
+        const response = await experimentService.createExperiment(
+          buildExperimentCreateRequestBody(data),
+          dataSourceId
+        );
 
         if (response.experiment_id) {
           if (isMountedRef.current) {

--- a/public/components/experiment/configuration/types.ts
+++ b/public/components/experiment/configuration/types.ts
@@ -47,6 +47,10 @@ export interface BaseFormData {
   querySetId: string;
   size: number;
   searchConfigurationList: string[];
+  /** Optional; omitted on create when empty so the backend can auto-generate a name. */
+  name?: string;
+  /** Optional experiment description. */
+  description?: string;
 }
 
 export interface OptionLabel {

--- a/public/components/experiment/configuration/types.ts
+++ b/public/components/experiment/configuration/types.ts
@@ -43,6 +43,10 @@ export interface BaseFormData {
   querySetId: string;
   size: number;
   searchConfigurationList: string[];
+  /** Optional; omitted on create when empty so the backend can auto-generate a name. */
+  name?: string;
+  /** Optional experiment description. */
+  description?: string;
 }
 
 export interface OptionLabel {

--- a/server/routes/search_relevance_route_service.ts
+++ b/server/routes/search_relevance_route_service.ts
@@ -123,6 +123,8 @@ export function registerSearchRelevanceRoutes(router: IRouter, dataSourceEnabled
           searchConfigurationList: schema.arrayOf(schema.string()),
           size: schema.number(),
           type: schema.string(),
+          name: schema.maybe(schema.string()),
+          description: schema.maybe(schema.string()),
           // TODO: make mandatory conditional on experiment type
           judgmentList: schema.maybe(schema.arrayOf(schema.string())),
         }),

--- a/server/routes/search_relevance_route_service.ts
+++ b/server/routes/search_relevance_route_service.ts
@@ -124,6 +124,8 @@ export function registerSearchRelevanceRoutes(router: IRouter, dataSourceEnabled
           searchConfigurationList: schema.arrayOf(schema.string()),
           size: schema.number(),
           type: schema.string(),
+          name: schema.maybe(schema.string()),
+          description: schema.maybe(schema.string()),
           // TODO: make mandatory conditional on experiment type
           judgmentList: schema.maybe(schema.arrayOf(schema.string())),
         }),


### PR DESCRIPTION
**Description**

This PR extends the Search Relevance Workbench **Experiment creation** UI so users can optionally set a **name** and **description** when creating experiments—aligned with Query Sets, Search Configurations, and Judgments, and with the behavior described in the feature request.

**Key improvements include:**

- **Creation forms:** Optional **name** (text) and **description** (textarea) with validation that matches backend limits, shared across experiment templates.
- **All experiment types:** Pairwise comparison, pointwise evaluation, and hybrid optimizer flows include these fields (placement: name and description before type-specific configuration, consistent with the issue).
- **Scheduled experiments:** Name and description are included in the scheduled creation flow where that flow exists in the UI.
- **Payload behavior:** Values are trimmed; empty name/description are omitted from the create request so the backend can keep auto-generating names when omitted.
- **API:** Dashboards proxy POST schema accepts optional `name` / `description` for experiment creation.

**Issues resolved**

Resolves [[FEATURE] Add name and description fields to Experiment creation form #770](https://github.com/opensearch-project/dashboards-search-relevance/issues/770)

**Depends on**

- Backend support for experiment name and description on create (see [search-relevance#305](https://github.com/opensearch-project/search-relevance/issues/305) as noted on the issue).
- Display of name/description in list/detail UIs is tracked separately ([[FEATURE] Display name and description in Experiment UI #769](https://github.com/opensearch-project/dashboards-search-relevance/issues/769)).

**Check list**

- [x] Commits are signed per the DCO using `--signoff`
- By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

For more information on following Developer Certificate of Origin and signing off your commits, please check https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin