### PR TITLE
Align eslint with opensearch-dashboards for osd bootstrap

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {},
   "devDependencies": {
     "@types/enzyme-adapter-react-16": "^1.0.6",
-    "eslint": "^6.8.0"
+    "eslint": "^8.57.1"
   },
   "resolutions": {
     "ansi-regex": "^5.0.1",


### PR DESCRIPTION

### Description

Updates `devDependencies` so **`eslint` is `^8.57.1`**, matching **`opensearch-dashboards`**. This satisfies the monorepo **`single_version_dependencies`** check during `yarn osd bootstrap`, which was failing in CI with conflicting ranges (`^8.57.1` vs `^6.8.0`). No application behavior changes; this is a **dependency alignment** fix for builds and plugin CI that clone OSD and run bootstrap/tests.

### Issues Resolved

- Unblocks CI / local **`yarn osd bootstrap`** when the dashboard root declares **eslint 8.x** and the plugin still declared **eslint 6.x**.

### Check List

- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test
  - [x] Integration tests pass: `yarn cypress:run-without-security --config "baseUrl=http://localhost:5601" --spec "cypress/integration/plugins/search-relevance-dashboards/*.js"` (see [Developer Guide](DEVELOPER_GUIDE.md#integration-tests))
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.  
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).