### PR TITLE
fix: strip metadata from query text before substitution

### DIFF
--- a/public/components/query_compare/search_result/search/query_processor.ts
+++ b/public/components/query_compare/search_result/search/query_processor.ts
@@ -21,7 +21,11 @@ export const validateQuery = (selectedIndex: string, queryString: string, queryE
 export const rewriteQuery = (value: string, queryString: string, queryError: QueryError) => {
   if (queryString.trim().length > 0) {
     try {
-      return JSON.parse(queryString.replace(/%SearchText%/g, value));
+      // Strip metadata from the value if it contains the # delimiter (Issue #822)
+      const hashIndex = value.indexOf('#');
+      const cleanValue = hashIndex !== -1 ? value.substring(0, hashIndex) : value;
+
+      return JSON.parse(queryString.replace(/%SearchText%/g, cleanValue));
     } catch {
       queryError.queryString = QueryStringError.invalid;
       queryError.errorResponse.statusCode = 400;

--- a/public/components/search_configuration/__tests__/query_processor.test.ts
+++ b/public/components/search_configuration/__tests__/query_processor.test.ts
@@ -8,13 +8,28 @@ import {
   prepareQueryBody,
   buildValidationRequestBody,
   processSearchResults,
+  stripMetadata,
 } from '../utils/query_processor';
 
 describe('query_processor', () => {
+  describe('stripMetadata', () => {
+    it('should strip metadata after #', () => {
+      expect(stripMetadata('query#{"ref":""}')).toBe('query');
+    });
+
+    it('should return same text if no # is present', () => {
+      expect(stripMetadata('plain query')).toBe('plain query');
+    });
+
+    it('should handle empty string', () => {
+      expect(stripMetadata('')).toBe('');
+    });
+  });
+
   describe('processQuery', () => {
-    it('should replace placeholder with search text', () => {
+    it('should replace placeholder with clean search text', () => {
       const query = '{"query": {"match": {"title": "%SearchText%"}}}';
-      const searchText = 'test search';
+      const searchText = 'test search#{"referenceAnswer":""}';
 
       const result = processQuery(query, searchText);
 

--- a/public/components/search_configuration/utils/query_processor.ts
+++ b/public/components/search_configuration/utils/query_processor.ts
@@ -4,13 +4,29 @@
  */
 
 /**
+ * Strips metadata from the search text if it contains the # delimiter.
+ * This is used to fix Issue #822 where the backend appends JSON metadata to the query text.
+ * @param searchText The search text that might contain metadata
+ * @returns The search text without metadata
+ */
+export const stripMetadata = (searchText: string): string => {
+  if (!searchText) return '';
+  const hashIndex = searchText.indexOf('#');
+  if (hashIndex !== -1) {
+    return searchText.substring(0, hashIndex);
+  }
+  return searchText;
+};
+
+/**
  * Processes a query by replacing the search text placeholder
  * @param query The original query string
  * @param searchText The search text to replace the placeholder with
  * @returns The processed query with placeholders replaced
  */
 export const processQuery = (query: string, searchText: string = ''): string => {
-  return query.replace(/%SearchText%/g, searchText);
+  const cleanSearchText = stripMetadata(searchText);
+  return query.replace(/%SearchText%/g, cleanSearchText);
 };
 
 /**


### PR DESCRIPTION
## Description
This PR fixes Issue #822 where the Search Relevance Workbench plugin incorrectly appends `#{"referenceAnswer":""}` to `queryText` values when uploading a Query Set via the UI. This metadata was leaking into the `%SearchText%` substitution in Search Configurations, causing JSON parsing errors and failed experiments.

## Changes
- Modified `processQuery` in `public/components/search_configuration/utils/query_processor.ts` to strip any content after the `#` delimiter from the search text.
- Modified `rewriteQuery` in `public/components/query_compare/search_result/search/query_processor.ts` to perform the same stripping logic.
- Added unit tests in `public/components/search_configuration/__tests__/query_processor.test.ts` to verify the fix.

Fixes #822