### PR TITLE
Render RRF variants correctly in VariantDetailsModal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Enhancements
 
 ### Bug Fixes
+* Render RRF variants correctly in VariantDetailsModal ([#836](https://github.com/opensearch-project/dashboards-search-relevance/pull/836))
 
 ### Infrastructure
 

--- a/public/components/experiment/__tests__/variant_details.test.tsx
+++ b/public/components/experiment/__tests__/variant_details.test.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { VariantDetailsModal } from '../metrics/variant_details';
+
+describe('VariantDetailsModal', () => {
+  const onClose = jest.fn();
+
+  afterEach(() => {
+    onClose.mockClear();
+  });
+
+  it('renders RRF variant with rank constant and hides normalization/weights', () => {
+    render(
+      <VariantDetailsModal
+        variantDetails={{
+          parameters: {
+            combination: 'rrf',
+            rank_constant: 10,
+          },
+        }}
+        onClose={onClose}
+      />
+    );
+
+    expect(screen.getByText('Combination')).toBeInTheDocument();
+    expect(screen.getByText('rrf')).toBeInTheDocument();
+    expect(screen.getByText('Rank constant')).toBeInTheDocument();
+    expect(screen.getByText('10')).toBeInTheDocument();
+
+    expect(screen.queryByText('Normalization')).not.toBeInTheDocument();
+    expect(screen.queryByText('Weights')).not.toBeInTheDocument();
+  });
+
+  it('renders arithmetic_mean variant with normalization/weights and hides rank constant', () => {
+    render(
+      <VariantDetailsModal
+        variantDetails={{
+          parameters: {
+            combination: 'arithmetic_mean',
+            normalization: 'min_max',
+            weights: [0.5, 0.5],
+          },
+        }}
+        onClose={onClose}
+      />
+    );
+
+    expect(screen.getByText('Combination')).toBeInTheDocument();
+    expect(screen.getByText('arithmetic_mean')).toBeInTheDocument();
+    expect(screen.getByText('Normalization')).toBeInTheDocument();
+    expect(screen.getByText('min_max')).toBeInTheDocument();
+    expect(screen.getByText('Weights')).toBeInTheDocument();
+    // EuiCodeBlock highlights each JSON token into its own span,
+    // so the two weight values render as two separate "0.5" nodes.
+    expect(screen.getAllByText('0.5')).toHaveLength(2);
+
+    expect(screen.queryByText('Rank constant')).not.toBeInTheDocument();
+  });
+});

--- a/public/components/experiment/metrics/variant_details.tsx
+++ b/public/components/experiment/metrics/variant_details.tsx
@@ -47,7 +47,7 @@ export const VariantDetailsModal: React.FC<VariantDetailsModalProps> = ({
       ? [
           {
             title: 'Rank constant',
-            description: <EuiBadge color="primary">{String(rank_constant)}</EuiBadge>,
+            description: <EuiBadge color="primary">{String(rank_constant ?? 'N/A')}</EuiBadge>,
           },
         ]
       : [

--- a/public/components/experiment/metrics/variant_details.tsx
+++ b/public/components/experiment/metrics/variant_details.tsx
@@ -11,10 +11,7 @@ import {
   EuiModalBody,
   EuiModalFooter,
   EuiButton,
-  EuiFlexGroup,
-  EuiFlexItem,
   EuiPanel,
-  EuiText,
   EuiSpacer,
   EuiDescriptionList,
   EuiCodeBlock,
@@ -25,9 +22,10 @@ import {
 interface VariantDetailsModalProps {
   variantDetails: {
     parameters: {
-      weights: number[];
-      normalization: string;
       combination: string;
+      weights?: number[];
+      normalization?: string;
+      rank_constant?: number;
     };
   };
   onClose: () => void;
@@ -37,23 +35,35 @@ export const VariantDetailsModal: React.FC<VariantDetailsModalProps> = ({
   variantDetails,
   onClose,
 }) => {
+  const { combination, normalization, weights, rank_constant } = variantDetails.parameters;
+  const isRrf = combination === 'rrf';
+
   const parameterItems = [
     {
-      title: 'Weights',
-      description: (
-        <EuiCodeBlock language="json" paddingSize="s" isCopyable>
-          {JSON.stringify(variantDetails.parameters.weights, null, 2)}
-        </EuiCodeBlock>
-      ),
-    },
-    {
-      title: 'Normalization',
-      description: <EuiBadge color="primary">{variantDetails.parameters.normalization}</EuiBadge>,
-    },
-    {
       title: 'Combination',
-      description: <EuiBadge color="success">{variantDetails.parameters.combination}</EuiBadge>,
+      description: <EuiBadge color="success">{combination}</EuiBadge>,
     },
+    ...(isRrf
+      ? [
+          {
+            title: 'Rank constant',
+            description: <EuiBadge color="primary">{String(rank_constant)}</EuiBadge>,
+          },
+        ]
+      : [
+          {
+            title: 'Normalization',
+            description: <EuiBadge color="primary">{normalization}</EuiBadge>,
+          },
+          {
+            title: 'Weights',
+            description: (
+              <EuiCodeBlock language="json" paddingSize="s" isCopyable>
+                {JSON.stringify(weights, null, 2)}
+              </EuiCodeBlock>
+            ),
+          },
+        ]),
   ];
 
   return (


### PR DESCRIPTION
### Description
The hybrid optimizer backend now persists RRF variants with a parameter shape of {combination, rank_constant} only. The previous modal hardcoded reads to parameters.weights and parameters.normalization, rendering undefined/empty fields for RRF variants and never surfacing rank_constant.

This change:
- Widens the props type to mark weights/normalization as optional and adds rank_constant.
- Branches rendering on combination === 'rrf': RRF variants show Combination + Rank constant. NP variants show Combination + Normalization + Weights (unchanged).

### Issues Resolved
https://github.com/opensearch-project/search-relevance/issues/343

### Testing

- Verified locally: started OpenSearch with the backend PR's changes + Dashboards with this plugin change, seeded 2 NP + 2 RRF variants via REST API, confirmed the modal renders correct fields for each shape.
- No existing Cypress tests cover the `VariantDetailsModal` component; the change is purely presentational branching with no new data fetching or state logic.

### Display
Experiment：
<img width="1595" height="744" alt="image" src="https://github.com/user-attachments/assets/05b0ed54-d078-414a-81e7-bc0d28a4f061" />
v-np-1(existing behavior — unchanged by this PR):
<img width="1534" height="639" alt="image" src="https://github.com/user-attachments/assets/03a9edfe-c56f-4825-a628-b1a0ebf7ceb0" />
v-np-2(z_score):
<img width="1602" height="700" alt="image" src="https://github.com/user-attachments/assets/ff0bd2f1-373d-4dce-9528-9d5078a81503" />
v-rrf-60:
<img width="1559" height="674" alt="image" src="https://github.com/user-attachments/assets/8e72e4d9-d9f0-45f7-a234-f2bcbc6c4a5d" />
v-rrf-1:
<img width="1552" height="671" alt="image" src="https://github.com/user-attachments/assets/4760df4d-0b09-48d0-88d9-5d655d117e2f" />



### Check List

- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
