### PR TITLE
[CI] Fix Linux workflow Node.js setup for OpenSearch Dashboards compatibility

### DIFF
--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -64,7 +64,7 @@ jobs:
         run: |
           chown -R 1000:1000 `pwd`
           cd ./OpenSearch-Dashboards/
-          su `id -un 1000` -c "source $NVM_DIR/nvm.sh && nvm use && node -v && yarn -v &&
+          su `id -un 1000` -c "source $NVM_DIR/nvm.sh && nvm install && nvm use && node -v && yarn -v &&
                                cd ./plugins/dashboards-search-relevance &&
                                whoami && yarn osd bootstrap && yarn test --coverage"
 
@@ -79,7 +79,7 @@ jobs:
         run: |
           chown -R 1000:1000 `pwd`
           cd ./OpenSearch-Dashboards/
-          su `id -un 1000` -c "source $NVM_DIR/nvm.sh && nvm use && node -v && yarn -v &&
+          su `id -un 1000` -c "source $NVM_DIR/nvm.sh && nvm install && nvm use && node -v && yarn -v &&
                                cd ./plugins/dashboards-search-relevance &&
                                whoami && yarn build && mv -v ./build/*.zip ./build/${{ env.PLUGIN_NAME }}-${{ env.OPENSEARCH_PLUGIN_VERSION }}.zip"
 


### PR DESCRIPTION
Fixes Linux CI failures caused by newer Node.js versions required by OpenSearch-Dashboards.

The Linux workflow was relying on nvm use, assuming the required Node version already existed in the CI container. After recent .nvmrc updates upstream, the workflow started failing with:

Found '/__w/.../OpenSearch-Dashboards/.nvmrc' with version <22.22.3>
N/A: version "22.22.3 -> N/A" is not yet installed.
You need to run "nvm install 22.22.3"

This change adds nvm install before nvm use in the Linux workflow so the required Node.js version is installed automatically during CI runs.

### Check List

- [x] New functionality includes testing.
- [x] All tests pass, including unit test, integration test
- [x] Integration tests pass: `yarn cypress:run-without-security --config "baseUrl=http://localhost:5601" --spec "cypress/integration/plugins/search-relevance-dashboards/*.js"` (see [Developer Guide](DEVELOPER_GUIDE.md#integration-tests))
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
