### PR TITLE
Add /search-relevance slash command with welcome message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Features
 * Add UI support for uploading Judgment Sets via CSV, including parsing and preview before creating the judgment list. ([#715](https://github.com/opensearch-project/dashboards-search-relevance/pull/715))
 * Support manually creating a Query Set using plain text, key-value, or NDJSON input directly in the UI. ([#754](https://github.com/opensearch-project/dashboards-search-relevance/pull/754))
+* Add /search-relevance slash command for chatbot to navigate to Search Relevance page ([#843](https://github.com/opensearch-project/dashboards-search-relevance/pull/843))
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Features
 * Add optional description field to Search Configuration create form, detail view, and listing ([#798](https://github.com/opensearch-project/dashboards-search-relevance/issues/798))
+* Add /search-relevance slash command for chatbot with welcome message and AI-assisted search relevance tuning ([#843](https://github.com/opensearch-project/dashboards-search-relevance/pull/843))
 
 ### Enhancements
 * Make Query Set description optional on create ([#758](https://github.com/opensearch-project/dashboards-search-relevance/issues/758))

--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -13,7 +13,8 @@
     "dataSource",
     "dataSourceManagement",
     "contentManagement",
-    "home"
+    "home",
+    "chat"
   ],
   "supportedOSDataSourceVersions": ">=2.8.0"
 }

--- a/public/chat/__tests__/search_relevance_command.test.ts
+++ b/public/chat/__tests__/search_relevance_command.test.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { registerSearchRelevanceCommand } from '../search_relevance_command';
+import { ChatPluginSetup } from '../../../../../src/plugins/chat/public';
+import { CoreSetup } from '../../../../../src/core/public';
+
+describe('registerSearchRelevanceCommand', () => {
+  let mockRegisterCommand: jest.Mock;
+  let mockChatSetup: ChatPluginSetup;
+  let mockCoreSetup: any;
+  let mockNavigateToApp: jest.Mock;
+  let mockAddInfo: jest.Mock;
+
+  beforeEach(() => {
+    mockRegisterCommand = jest.fn();
+    mockNavigateToApp = jest.fn();
+    mockAddInfo = jest.fn();
+
+    mockChatSetup = {
+      commandRegistry: { registerCommand: mockRegisterCommand },
+    } as unknown as ChatPluginSetup;
+
+    mockCoreSetup = {
+      workspaces: {
+        currentWorkspace$: { getValue: jest.fn() },
+      },
+      getStartServices: jest.fn().mockResolvedValue([
+        {
+          application: { navigateToApp: mockNavigateToApp },
+          notifications: { toasts: { addInfo: mockAddInfo } },
+        },
+        {},
+        {},
+      ]),
+    };
+
+    mockRegisterCommand.mockReturnValue(jest.fn());
+  });
+
+  it('registers the command', () => {
+    registerSearchRelevanceCommand(mockCoreSetup, mockChatSetup);
+    expect(mockRegisterCommand).toHaveBeenCalledWith(
+      expect.objectContaining({ command: 'search-relevance' })
+    );
+  });
+
+  it('shows toast when not in Search workspace', async () => {
+    mockCoreSetup.workspaces.currentWorkspace$.getValue.mockReturnValue({ name: 'Analytics' });
+    registerSearchRelevanceCommand(mockCoreSetup, mockChatSetup);
+
+    const handler = mockRegisterCommand.mock.calls[0][0].handler;
+    const result = await handler('');
+
+    expect(mockAddInfo).toHaveBeenCalledWith(
+      'Please switch to the "Search" workspace to use Search Relevance.'
+    );
+    expect(mockNavigateToApp).not.toHaveBeenCalled();
+    expect(result).toBe('');
+  });
+
+  it('shows toast when no workspace is active', async () => {
+    mockCoreSetup.workspaces.currentWorkspace$.getValue.mockReturnValue(null);
+    registerSearchRelevanceCommand(mockCoreSetup, mockChatSetup);
+
+    const handler = mockRegisterCommand.mock.calls[0][0].handler;
+    await handler('');
+
+    expect(mockAddInfo).toHaveBeenCalled();
+    expect(mockNavigateToApp).not.toHaveBeenCalled();
+  });
+
+  it('navigates to searchRelevance when in Search workspace', async () => {
+    mockCoreSetup.workspaces.currentWorkspace$.getValue.mockReturnValue({ name: 'Search' });
+    registerSearchRelevanceCommand(mockCoreSetup, mockChatSetup);
+
+    const handler = mockRegisterCommand.mock.calls[0][0].handler;
+    const result = await handler('');
+
+    expect(mockNavigateToApp).toHaveBeenCalledWith('searchRelevance');
+    expect(mockAddInfo).not.toHaveBeenCalled();
+    expect(result).toBe('');
+  });
+
+  it('returns undefined when chat is not available', () => {
+    const result = registerSearchRelevanceCommand(mockCoreSetup, undefined);
+    expect(result).toBeUndefined();
+  });
+});

--- a/public/chat/__tests__/search_relevance_command.test.ts
+++ b/public/chat/__tests__/search_relevance_command.test.ts
@@ -1,0 +1,137 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { registerSearchRelevanceCommand } from '../search_relevance_command';
+import { ChatPluginSetup } from '../../../../../src/plugins/chat/public';
+import { CoreSetup } from '../../../../../src/core/public';
+
+describe('registerSearchRelevanceCommand', () => {
+  let mockRegisterCommand: jest.Mock;
+  let mockChatSetup: ChatPluginSetup;
+  let mockCoreSetup: any;
+  let mockNavigateToApp: jest.Mock;
+  let mockSendMessageWithWindow: jest.Mock;
+
+  beforeEach(() => {
+    mockRegisterCommand = jest.fn().mockReturnValue(jest.fn());
+    mockNavigateToApp = jest.fn();
+    mockSendMessageWithWindow = jest.fn();
+
+    mockChatSetup = ({
+      commandRegistry: { registerCommand: mockRegisterCommand },
+    } as unknown) as ChatPluginSetup;
+
+    mockCoreSetup = {
+      workspaces: {
+        currentWorkspace$: { getValue: jest.fn() },
+        workspaceList$: { getValue: jest.fn().mockReturnValue([]) },
+      },
+      getStartServices: jest.fn().mockResolvedValue([
+        {
+          application: { navigateToApp: mockNavigateToApp },
+          chat: { sendMessageWithWindow: mockSendMessageWithWindow },
+        },
+        {},
+        {},
+      ]),
+    };
+  });
+
+  it('registers /search-relevance command', () => {
+    registerSearchRelevanceCommand(mockCoreSetup, mockChatSetup);
+    expect(mockRegisterCommand).toHaveBeenCalledTimes(1);
+    expect(mockRegisterCommand).toHaveBeenCalledWith(
+      expect.objectContaining({ command: 'search-relevance' })
+    );
+  });
+
+  it('returns localMessage when not in Search workspace', async () => {
+    mockCoreSetup.workspaces.currentWorkspace$.getValue.mockReturnValue({
+      name: 'Analytics',
+      features: ['use-case-observability'],
+    });
+    registerSearchRelevanceCommand(mockCoreSetup, mockChatSetup);
+
+    const handler = mockRegisterCommand.mock.calls[0][0].handler;
+    const result = await handler('');
+
+    expect(result).toEqual({
+      localMessage: expect.stringContaining('only works in Search or Analytics (all) workspaces'),
+      title: 'Incompatible workspace type',
+    });
+    expect(mockNavigateToApp).not.toHaveBeenCalled();
+    expect(mockSendMessageWithWindow).not.toHaveBeenCalled();
+  });
+
+  it('returns localMessage when no workspace is set', async () => {
+    mockCoreSetup.workspaces.currentWorkspace$.getValue.mockReturnValue(null);
+    mockCoreSetup.workspaces.workspaceList$.getValue.mockReturnValue([]);
+    registerSearchRelevanceCommand(mockCoreSetup, mockChatSetup);
+
+    const handler = mockRegisterCommand.mock.calls[0][0].handler;
+    const result = await handler('');
+
+    expect(result).toEqual({
+      localMessage: expect.stringContaining('only works in Search or Analytics (all) workspaces'),
+      title: 'Incompatible workspace type',
+    });
+    expect(mockNavigateToApp).not.toHaveBeenCalled();
+  });
+
+  it('navigates and shows welcome message when no args provided', async () => {
+    mockCoreSetup.workspaces.currentWorkspace$.getValue.mockReturnValue({
+      name: 'My Search',
+      features: ['use-case-search'],
+    });
+    registerSearchRelevanceCommand(mockCoreSetup, mockChatSetup);
+
+    const handler = mockRegisterCommand.mock.calls[0][0].handler;
+    const result = await handler('');
+
+    expect(mockNavigateToApp).toHaveBeenCalledWith('searchRelevance');
+    expect(mockSendMessageWithWindow).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      localMessage: expect.stringContaining('Welcome to the OpenSearch Relevance Agent'),
+      role: 'assistant',
+    });
+  });
+
+  it('navigates and forwards user input', async () => {
+    mockCoreSetup.workspaces.currentWorkspace$.getValue.mockReturnValue({
+      name: 'My Search',
+      features: ['use-case-search'],
+    });
+    registerSearchRelevanceCommand(mockCoreSetup, mockChatSetup);
+
+    const handler = mockRegisterCommand.mock.calls[0][0].handler;
+    const result = await handler('check on cluster xxx');
+
+    expect(mockNavigateToApp).toHaveBeenCalledWith('searchRelevance');
+    expect(mockSendMessageWithWindow).toHaveBeenCalledWith('check on cluster xxx', [], {
+      clearConversation: true,
+    });
+    expect(result).toBe('');
+  });
+
+  it('navigates when in All use-case workspace', async () => {
+    mockCoreSetup.workspaces.currentWorkspace$.getValue.mockReturnValue({
+      name: 'Everything',
+      features: ['use-case-all'],
+    });
+    registerSearchRelevanceCommand(mockCoreSetup, mockChatSetup);
+
+    const handler = mockRegisterCommand.mock.calls[0][0].handler;
+    const result = await handler('');
+
+    expect(mockNavigateToApp).toHaveBeenCalledWith('searchRelevance');
+    expect(mockSendMessageWithWindow).not.toHaveBeenCalled();
+    expect(result).toEqual(expect.objectContaining({ role: 'assistant' }));
+  });
+
+  it('returns undefined when chat is not available', () => {
+    const result = registerSearchRelevanceCommand(mockCoreSetup, undefined);
+    expect(result).toBeUndefined();
+  });
+});

--- a/public/chat/__tests__/search_relevance_command.test.ts
+++ b/public/chat/__tests__/search_relevance_command.test.ts
@@ -48,14 +48,14 @@ describe('registerSearchRelevanceCommand', () => {
   });
 
   it('shows toast when not in Search workspace', async () => {
-    mockCoreSetup.workspaces.currentWorkspace$.getValue.mockReturnValue({ name: 'Analytics' });
+    mockCoreSetup.workspaces.currentWorkspace$.getValue.mockReturnValue({ name: 'Analytics', features: ['use-case-observability'] });
     registerSearchRelevanceCommand(mockCoreSetup, mockChatSetup);
 
     const handler = mockRegisterCommand.mock.calls[0][0].handler;
     const result = await handler('');
 
     expect(mockAddInfo).toHaveBeenCalledWith(
-      'Please switch to the "Search" workspace to use Search Relevance.'
+      'Please switch to a workspace with the Search use case to use Search Relevance.'
     );
     expect(mockNavigateToApp).not.toHaveBeenCalled();
     expect(result).toBe('');
@@ -73,7 +73,7 @@ describe('registerSearchRelevanceCommand', () => {
   });
 
   it('navigates to searchRelevance when in Search workspace', async () => {
-    mockCoreSetup.workspaces.currentWorkspace$.getValue.mockReturnValue({ name: 'Search' });
+    mockCoreSetup.workspaces.currentWorkspace$.getValue.mockReturnValue({ name: 'My Search', features: ['use-case-search'] });
     registerSearchRelevanceCommand(mockCoreSetup, mockChatSetup);
 
     const handler = mockRegisterCommand.mock.calls[0][0].handler;
@@ -81,6 +81,17 @@ describe('registerSearchRelevanceCommand', () => {
 
     expect(mockNavigateToApp).toHaveBeenCalledWith('searchRelevance');
     expect(mockAddInfo).not.toHaveBeenCalled();
+    expect(result).toBe('');
+  });
+
+  it('navigates when in All use-case workspace', async () => {
+    mockCoreSetup.workspaces.currentWorkspace$.getValue.mockReturnValue({ name: 'Everything', features: ['use-case-all'] });
+    registerSearchRelevanceCommand(mockCoreSetup, mockChatSetup);
+
+    const handler = mockRegisterCommand.mock.calls[0][0].handler;
+    const result = await handler('');
+
+    expect(mockNavigateToApp).toHaveBeenCalledWith('searchRelevance');
     expect(result).toBe('');
   });
 

--- a/public/chat/search_relevance_command.ts
+++ b/public/chat/search_relevance_command.ts
@@ -3,7 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { CoreSetup } from '../../../../src/core/public';
+import {
+  CoreSetup,
+  ALL_USE_CASE_ID,
+  SEARCH_USE_CASE_ID,
+  isNavGroupInFeatureConfigs,
+} from '../../../../src/core/public';
 import { ChatPluginSetup } from '../../../../src/plugins/chat/public';
 import { PLUGIN_ID } from '../../common';
 
@@ -16,18 +21,20 @@ export const registerSearchRelevanceCommand = (
     description: 'Navigate to Search Relevance page',
     usage: '/search-relevance',
     handler: async (): Promise<string> => {
+      const [coreStart] = await core.getStartServices();
       const currentWorkspace = core.workspaces.currentWorkspace$.getValue();
-      const workspaceName = currentWorkspace?.name ?? '';
+      const features = currentWorkspace?.features ?? [];
+      const hasSearchFeature =
+        isNavGroupInFeatureConfigs(SEARCH_USE_CASE_ID, features) ||
+        isNavGroupInFeatureConfigs(ALL_USE_CASE_ID, features);
 
-      if (workspaceName !== 'Search') {
-        const [coreStart] = await core.getStartServices();
+      if (!hasSearchFeature) {
         coreStart.notifications.toasts.addInfo(
-          'Please switch to the "Search" workspace to use Search Relevance.'
+          'Please switch to a workspace with the Search use case to use Search Relevance.'
         );
         return '';
       }
 
-      const [coreStart] = await core.getStartServices();
       coreStart.application.navigateToApp(PLUGIN_ID);
       return '';
     },

--- a/public/chat/search_relevance_command.ts
+++ b/public/chat/search_relevance_command.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { i18n } from '@osd/i18n';
+import {
+  CoreSetup,
+  ALL_USE_CASE_ID,
+  SEARCH_USE_CASE_ID,
+  isNavGroupInFeatureConfigs,
+} from '../../../../src/core/public';
+import { ChatPluginSetup } from '../../../../src/plugins/chat/public';
+import { SlashCommandResult } from '../../../../src/plugins/chat/public/services/slash_commands';
+import { PLUGIN_ID } from '../../common';
+
+const getWelcomeMessage = () =>
+  i18n.translate('searchRelevance.command.welcomeMessage', {
+    defaultMessage: `Welcome to the OpenSearch Relevance Agent!
+
+I'm your AI-powered search relevance tuning assistant. I help you identify relevance issues, generate data-driven tuning hypotheses, and validate improvements through automated experiments -- all through natural conversation. Whether you have UBI data or just want to optimize your search configurations, I can accelerate your relevance workflow from weeks to hours. I work alongside you as a human-in-the-loop system -- you stay in control while I handle the heavy lifting.
+
+Here are some things you can ask me:
+- "Analyze my most common queries"
+- "What is my current search configurations"
+- "Create a hypothesis to improve relevance for product searches and run an experiment to validate it"
+- "Compare my current search configuration against a boosted-title variant using NDCG@10"
+- "Help me set up a query set and judgment list for my e-commerce catalog"`,
+  });
+
+const hasSearchUseCase = (features: string[]): boolean =>
+  isNavGroupInFeatureConfigs(SEARCH_USE_CASE_ID, features) ||
+  isNavGroupInFeatureConfigs(ALL_USE_CASE_ID, features);
+
+const createHandler = (core: CoreSetup) => async (args: string): Promise<SlashCommandResult> => {
+  const currentWorkspace = core.workspaces.currentWorkspace$.getValue();
+  const features = currentWorkspace?.features ?? [];
+
+  if (!hasSearchUseCase(features)) {
+    return {
+      title: i18n.translate('searchRelevance.command.incompatibleWorkspaceTitle', {
+        defaultMessage: 'Incompatible workspace type',
+      }),
+      localMessage: i18n.translate('searchRelevance.command.incompatibleWorkspaceMessage', {
+        defaultMessage:
+          'The /search-relevance command only works in Search or Analytics (all) workspaces. Please navigate to one and try again.',
+      }),
+    };
+  }
+
+  const [coreStart] = await core.getStartServices();
+  coreStart.application.navigateToApp(PLUGIN_ID);
+
+  const question = args.trim();
+  if (question) {
+    coreStart.chat.sendMessageWithWindow(question, [], { clearConversation: true });
+    return '';
+  }
+
+  return { localMessage: getWelcomeMessage(), role: 'assistant' };
+};
+
+export const registerSearchRelevanceCommand = (
+  core: CoreSetup,
+  chatSetup?: ChatPluginSetup
+): (() => void) | undefined => {
+  if (!chatSetup?.commandRegistry) return undefined;
+
+  const handler = createHandler(core);
+
+  const unregister = chatSetup.commandRegistry.registerCommand({
+    command: 'search-relevance',
+    description: i18n.translate('searchRelevance.command.description', {
+      defaultMessage: 'Tune search configurations in Search Relevance Workbench',
+    }),
+    usage: '/search-relevance <optional question>',
+    hint: i18n.translate('searchRelevance.command.hint', {
+      defaultMessage: 'Tune search configurations in Search Relevance Workbench',
+    }),
+    handler,
+  });
+
+  return () => {
+    unregister?.();
+  };
+};

--- a/public/chat/search_relevance_command.ts
+++ b/public/chat/search_relevance_command.ts
@@ -1,0 +1,35 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { CoreSetup } from '../../../../src/core/public';
+import { ChatPluginSetup } from '../../../../src/plugins/chat/public';
+import { PLUGIN_ID } from '../../common';
+
+export const registerSearchRelevanceCommand = (
+  core: CoreSetup,
+  chatSetup?: ChatPluginSetup
+): (() => void) | undefined => {
+  return chatSetup?.commandRegistry?.registerCommand({
+    command: 'search-relevance',
+    description: 'Navigate to Search Relevance page',
+    usage: '/search-relevance',
+    handler: async (): Promise<string> => {
+      const currentWorkspace = core.workspaces.currentWorkspace$.getValue();
+      const workspaceName = currentWorkspace?.name ?? '';
+
+      if (workspaceName !== 'Search') {
+        const [coreStart] = await core.getStartServices();
+        coreStart.notifications.toasts.addInfo(
+          'Please switch to the "Search" workspace to use Search Relevance.'
+        );
+        return '';
+      }
+
+      const [coreStart] = await core.getStartServices();
+      coreStart.application.navigateToApp(PLUGIN_ID);
+      return '';
+    },
+  });
+};

--- a/public/components/experiment/views/experiment_listing.tsx
+++ b/public/components/experiment/views/experiment_listing.tsx
@@ -86,6 +86,17 @@ export const ExperimentListing: React.FC<ExperimentListingProps> = ({
   const { services } = useOpenSearchDashboards();
   const share = services.share;
 
+  const [isChatWindowOpen, setIsChatWindowOpen] = useState(
+    () => services.chat?.isWindowOpen() ?? false
+  );
+
+  useEffect(() => {
+    const sub = services.chat?.getWindowState$()?.subscribe((state) => {
+      setIsChatWindowOpen(state.isWindowOpen);
+    });
+    return () => sub?.unsubscribe();
+  }, [services.chat]);
+
   // Clear cached table data when data source changes so findExperiments re-fetches
   useEffect(() => {
     setTableData([]);
@@ -579,7 +590,7 @@ export const ExperimentListing: React.FC<ExperimentListingProps> = ({
 
       <EuiSpacer size="m" />
 
-      {onAskAI && !isAICalloutDismissed && (
+      {onAskAI && !isAICalloutDismissed && !isChatWindowOpen && (
         <>
           <EuiCallOut
             title={

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -19,10 +19,13 @@ import {
 import { registerAllPluginNavGroups } from './plugin_nav';
 import { ContentManagementPluginStart } from '../../../src/plugins/content_management/public';
 import { registerCompareQueryCard } from './components/service_card/compare_query_card';
+import { ChatPluginSetup } from '../../../src/plugins/chat/public';
+import { registerSearchRelevanceCommand } from './chat/search_relevance_command';
 
 export interface SearchRelevancePluginSetupDependencies {
   dataSource: DataSourcePluginSetup;
   dataSourceManagement: DataSourceManagementPluginSetup;
+  chat?: ChatPluginSetup;
 }
 
 export interface SearchRelevanceStartDependencies {
@@ -32,9 +35,11 @@ export interface SearchRelevanceStartDependencies {
 
 export class SearchRelevancePlugin
   implements Plugin<SearchRelevancePluginSetup, SearchRelevancePluginStart> {
+  private unregisterSearchRelevanceCommand?: () => void;
+
   public setup(
     core: CoreSetup,
-    { dataSource, dataSourceManagement }: SearchRelevancePluginSetupDependencies
+    { dataSource, dataSourceManagement, chat }: SearchRelevancePluginSetupDependencies
   ): SearchRelevancePluginSetup {
     // Register an application into the side navigation menu
     core.application.register({
@@ -52,11 +57,9 @@ export class SearchRelevancePlugin
         const [coreStart, depsStart] = await core.getStartServices();
         const onAskAI = coreStart.chat.isAvailable()
           ? () =>
-              coreStart.chat.sendMessageWithWindow(
-                'Help me improve search relevance',
-                [],
-                { clearConversation: true }
-              )
+              coreStart.chat.sendMessageWithWindow('Help me improve search relevance', [], {
+                clearConversation: true,
+              })
           : undefined;
         // Render the application
         return renderApp(
@@ -68,6 +71,7 @@ export class SearchRelevancePlugin
       },
     });
     registerAllPluginNavGroups(core);
+    this.unregisterSearchRelevanceCommand = registerSearchRelevanceCommand(core, chat);
     // Return methods that should be available to other plugins
     return {
       getGreeting() {
@@ -91,5 +95,7 @@ export class SearchRelevancePlugin
     return {};
   }
 
-  public stop() {}
+  public stop() {
+    this.unregisterSearchRelevanceCommand?.();
+  }
 }

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -19,10 +19,13 @@ import {
 import { registerAllPluginNavGroups } from './plugin_nav';
 import { ContentManagementPluginStart } from '../../../src/plugins/content_management/public';
 import { registerCompareQueryCard } from './components/service_card/compare_query_card';
+import { ChatPluginSetup } from '../../../src/plugins/chat/public';
+import { registerSearchRelevanceCommand } from './chat/search_relevance_command';
 
 export interface SearchRelevancePluginSetupDependencies {
   dataSource: DataSourcePluginSetup;
   dataSourceManagement: DataSourceManagementPluginSetup;
+  chat?: ChatPluginSetup;
 }
 
 export interface SearchRelevanceStartDependencies {
@@ -32,9 +35,11 @@ export interface SearchRelevanceStartDependencies {
 
 export class SearchRelevancePlugin
   implements Plugin<SearchRelevancePluginSetup, SearchRelevancePluginStart> {
+  private unregisterSearchRelevanceCommand?: () => void;
+
   public setup(
     core: CoreSetup,
-    { dataSource, dataSourceManagement }: SearchRelevancePluginSetupDependencies
+    { dataSource, dataSourceManagement, chat }: SearchRelevancePluginSetupDependencies
   ): SearchRelevancePluginSetup {
     // Register an application into the side navigation menu
     core.application.register({
@@ -68,6 +73,7 @@ export class SearchRelevancePlugin
       },
     });
     registerAllPluginNavGroups(core);
+    this.unregisterSearchRelevanceCommand = registerSearchRelevanceCommand(core, chat);
     // Return methods that should be available to other plugins
     return {
       getGreeting() {
@@ -91,5 +97,7 @@ export class SearchRelevancePlugin
     return {};
   }
 
-  public stop() {}
+  public stop() {
+    this.unregisterSearchRelevanceCommand?.();
+  }
 }

--- a/test/setup.jest.ts
+++ b/test/setup.jest.ts
@@ -10,6 +10,20 @@ configure({ testIdAttribute: 'data-test-subj' });
 
 window.URL.createObjectURL = () => '';
 HTMLCanvasElement.prototype.getContext = () => '';
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: jest.fn().mockImplementation((query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  })),
+});
 window.IntersectionObserver = class IntersectionObserver {
   constructor() {}
 


### PR DESCRIPTION
### Description

Add a `/search-relevance` slash command to the chatbot that navigates users to the Search Relevance Workbench for AI-assisted search relevance tuning.

**Behavior:**
- `/search-relevance` (no args): navigates to `/app/searchRelevance` and shows a welcome message with sample questions as an assistant bubble (no agent call)
- `/search-relevance <question>`: navigates to `/app/searchRelevance` and sends the question directly to the agent
- In any non-Search workspace: shows a local "Incompatible workspace type" error explaining the command requires a Search or Analytics (all) workspace
- Hides the "Ask AI" callout on the experiment listing page when the chat window is already open

Uses `isNavGroupInFeatureConfigs` from core to detect workspace use case via features. All user-facing strings are i18n-wrapped.

Depends on:
- https://github.com/opensearch-project/OpenSearch-Dashboards/pull/12148 (merged)
- https://github.com/opensearch-project/OpenSearch-Dashboards/pull/12197 (draft — adds role field to SlashCommandResult)

### Issues Resolved

N/A - New feature

### Demo

**Welcome message (no args — navigates + shows assistant bubble):**

[srw-welcome-message.webm](https://github.com/user-attachments/assets/8f6ab203-5d11-4120-ba08-879e132de4bc)

**With question (navigates + sends to agent):**

[srw-with-question.webm](https://github.com/user-attachments/assets/89ea7aeb-ea41-4e1f-a155-9526d8667ab4)

**Wrong workspace (local error message):**

[srw-wrong-workspace.webm](https://github.com/user-attachments/assets/b45d2779-48a3-4e51-84ea-74fc668fa6f7)

**AI callout hides when chat opens:**

[srw-callout-toggle.webm](https://github.com/user-attachments/assets/d63626a0-72ab-4902-a511-e145e7162339)

### Check List

- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test
  - [x] Integration tests pass
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
