### PR TITLE
fix: hide AnalyticEngine data sources from DSL-dependent dropdowns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Enhancements
 
 ### Bug Fixes
+* Hide AnalyticEngine data sources from DSL-dependent data source dropdowns ([#846](https://github.com/opensearch-project/dashboards-search-relevance/pull/846))
 
 ### Infrastructure
 

--- a/public/components/common/__test__/datasource_utils.test.ts
+++ b/public/components/common/__test__/datasource_utils.test.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { renderHook } from '@testing-library/react';
+import { useDataSourceFilter } from '../datasource_utils';
+
+const createMockDataSource = (version: string, engineType?: string) => ({
+  id: 'test-ds',
+  type: 'data-source',
+  attributes: {
+    title: 'Test',
+    endpoint: 'http://localhost:9200',
+    dataSourceVersion: version,
+    dataSourceEngineType: engineType,
+    auth: { type: 'no_auth', credentials: undefined },
+  },
+  references: [],
+});
+
+describe('useDataSourceFilter', () => {
+  describe('without excludeEngineTypes', () => {
+    it('returns true for OpenSearch data source with supported version', () => {
+      const { result } = renderHook(() => useDataSourceFilter());
+      const filter = result.current;
+      expect(filter(createMockDataSource('2.12.0', 'OpenSearch') as any)).toBe(true);
+    });
+
+    it('returns true for AnalyticEngine data source with supported version', () => {
+      const { result } = renderHook(() => useDataSourceFilter());
+      const filter = result.current;
+      expect(filter(createMockDataSource('2.12.0', 'AnalyticEngine') as any)).toBe(true);
+    });
+
+    it('returns false for data source with unsupported version', () => {
+      const { result } = renderHook(() => useDataSourceFilter());
+      const filter = result.current;
+      expect(filter(createMockDataSource('2.6.0', 'OpenSearch') as any)).toBe(false);
+    });
+  });
+
+  describe('with excludeEngineTypes', () => {
+    it('returns false for AnalyticEngine when excluded', () => {
+      const { result } = renderHook(() => useDataSourceFilter(['AnalyticEngine']));
+      const filter = result.current;
+      expect(filter(createMockDataSource('2.12.0', 'AnalyticEngine') as any)).toBe(false);
+    });
+
+    it('returns true for OpenSearch when AnalyticEngine is excluded', () => {
+      const { result } = renderHook(() => useDataSourceFilter(['AnalyticEngine']));
+      const filter = result.current;
+      expect(filter(createMockDataSource('2.12.0', 'OpenSearch') as any)).toBe(true);
+    });
+
+    it('returns false for unsupported version even when engine type is allowed', () => {
+      const { result } = renderHook(() => useDataSourceFilter(['AnalyticEngine']));
+      const filter = result.current;
+      expect(filter(createMockDataSource('2.6.0', 'OpenSearch') as any)).toBe(false);
+    });
+
+    it('returns true for data source with no engine type set', () => {
+      const { result } = renderHook(() => useDataSourceFilter(['AnalyticEngine']));
+      const filter = result.current;
+      expect(filter(createMockDataSource('2.12.0') as any)).toBe(true);
+    });
+  });
+});

--- a/public/components/common/datasource_selector.tsx
+++ b/public/components/common/datasource_selector.tsx
@@ -23,6 +23,7 @@ interface DataSourceSelectorProps {
   disabled?: boolean;
   fullWidth?: boolean;
   removePrepend?: boolean;
+  excludeEngineTypes?: string[];
 }
 
 export const DataSourceSelector: React.FC<DataSourceSelectorProps> = ({
@@ -37,7 +38,8 @@ export const DataSourceSelector: React.FC<DataSourceSelectorProps> = ({
   notifications,
   disabled = false,
   fullWidth = false,
-  removePrepend = true
+  removePrepend = true,
+  excludeEngineTypes
 }) => {
   const { services } = useOpenSearchDashboards();
   const onSelectedDataSource = useCallback((dataSources) => {
@@ -45,7 +47,7 @@ export const DataSourceSelector: React.FC<DataSourceSelectorProps> = ({
     setSelectedDataSource(dataConnectionId);
     onChange?.();
   }, [setSelectedDataSource, onChange]);
-  const dataSourceFilter = useDataSourceFilter();
+  const dataSourceFilter = useDataSourceFilter(excludeEngineTypes);
 
   if (!dataSourceEnabled || !dataSourceManagement?.ui?.DataSourceSelector) {
     return null;

--- a/public/components/common/datasource_utils.ts
+++ b/public/components/common/datasource_utils.ts
@@ -50,9 +50,19 @@ export const useDataSourceSelection = (setSelectedDataSource: (id: string) => vo
 /**
  * Hook for datasource filter function
  */
-export const useDataSourceFilter = () => {
-  return useCallback((dataSource: SavedObject<DataSourceAttributes>) => {
-    const dataSourceVersion = dataSource?.attributes?.dataSourceVersion || '';
-    return semver.satisfies(dataSourceVersion, pluginManifest.supportedOSDataSourceVersions);
-  }, []);
+export const useDataSourceFilter = (excludeEngineTypes?: string[]) => {
+  return useCallback(
+    (dataSource: SavedObject<DataSourceAttributes>) => {
+      if (
+        excludeEngineTypes?.length &&
+        dataSource?.attributes?.dataSourceEngineType &&
+        excludeEngineTypes.includes(dataSource.attributes.dataSourceEngineType)
+      ) {
+        return false;
+      }
+      const dataSourceVersion = dataSource?.attributes?.dataSourceVersion || '';
+      return semver.satisfies(dataSourceVersion, pluginManifest.supportedOSDataSourceVersions);
+    },
+    [excludeEngineTypes]
+  );
 };

--- a/public/components/experiment/configuration/template_configuration.tsx
+++ b/public/components/experiment/configuration/template_configuration.tsx
@@ -111,6 +111,7 @@ export const TemplateConfiguration = ({
               savedObjects={savedObjects}
               selectedDataSource={selectedDataSource}
               setSelectedDataSource={setSelectedDataSource}
+              excludeEngineTypes={['AnalyticEngine']}
             />
           )}
           <EuiSpacer size="m" />

--- a/public/components/experiment/views/experiment_listing.tsx
+++ b/public/components/experiment/views/experiment_listing.tsx
@@ -593,6 +593,7 @@ export const ExperimentListing: React.FC<ExperimentListingProps> = ({
           savedObjects={savedObjects}
           selectedDataSource={selectedDataSource}
           setSelectedDataSource={setSelectedDataSource}
+          excludeEngineTypes={['AnalyticEngine']}
         />
       )}
 

--- a/public/components/query_compare/search_result/search_components/search_configs/search_config.tsx
+++ b/public/components/query_compare/search_result/search_components/search_configs/search_config.tsx
@@ -257,6 +257,9 @@ export const SearchConfig: FunctionComponent<SearchConfigProps> = ({
     DataSourceSelector = dataSourceManagement.ui.DataSourceSelector;
   }
   const dataSourceFilterFn = (dataSource: SavedObject<DataSourceAttributes>) => {
+    if (dataSource?.attributes?.dataSourceEngineType === 'AnalyticEngine') {
+      return false;
+    }
     const dataSourceVersion = dataSource?.attributes?.dataSourceVersion || '';
     return semver.satisfies(dataSourceVersion, pluginManifest.supportedOSDataSourceVersions);
   };

--- a/public/components/search_configuration/views/search_configuration_create.tsx
+++ b/public/components/search_configuration/views/search_configuration_create.tsx
@@ -121,6 +121,7 @@ export const SearchConfigurationCreate: React.FC<SearchConfigurationCreateProps>
                 savedObjects={savedObjects}
                 selectedDataSource={selectedDataSource}
                 setSelectedDataSource={setSelectedDataSource}
+                excludeEngineTypes={['AnalyticEngine']}
               />
             )}
             <SearchConfigurationForm

--- a/public/components/search_configuration/views/search_configuration_listing.tsx
+++ b/public/components/search_configuration/views/search_configuration_listing.tsx
@@ -178,6 +178,7 @@ export const SearchConfigurationListing: React.FC<SearchConfigurationListingProp
           savedObjects={savedObjects}
           selectedDataSource={selectedDataSource}
           setSelectedDataSource={setSelectedDataSource}
+          excludeEngineTypes={['AnalyticEngine']}
         />
       )}
 


### PR DESCRIPTION

### Description

AnalyticEngine only supports PPL queries, not DSL. This excludes AnalyticEngine data sources from the data source selector in features that execute DSL queries (search configs, experiments, query compare) while keeping them available for metadata-only features (judgments, query sets).

similar PR made by dashboard assistant plugin: https://github.com/opensearch-project/dashboards-assistant/pull/689
### Issues Resolved

campaign for mustang

### Check List

- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test
  - [ ] Integration tests pass: `yarn cypress:run-without-security --config "baseUrl=http://localhost:5601" --spec "cypress/integration/plugins/search-relevance-dashboards/*.js"` (see [Developer Guide](DEVELOPER_GUIDE.md#integration-tests))
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
