### PR TITLE
Fix failed queries being treated as zero search results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Enhancements
 
 ### Bug Fixes
+* Fix Search Evaluation experiment view treating failed OpenSearch queries as zero search results (ZSR); show per-query status and separate notifications for failed, ZSR, and not-evaluated queries ([#733](https://github.com/opensearch-project/dashboards-search-relevance/pull/849))
 * Hide AnalyticEngine data sources from DSL-dependent data source dropdowns ([#846](https://github.com/opensearch-project/dashboards-search-relevance/pull/846))
 
 ### Infrastructure

--- a/public/components/experiment/utils/__tests__/query_evaluation_builder.test.ts
+++ b/public/components/experiment/utils/__tests__/query_evaluation_builder.test.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  buildQueryEvaluationRows,
+  countQueryOutcomes,
+  getQueryExecutionOrder,
+  getQueryTextsFromQuerySet,
+  mapQueryStatusesFromVariants,
+} from '../query_evaluation_builder';
+
+describe('query_evaluation_builder', () => {
+  it('extracts query texts from array and object query sets', () => {
+    expect(
+      getQueryTextsFromQuerySet([
+        { queryText: 'laptop', category: 'tech' },
+        { queryText: 'phone', category: 'tech' },
+      ])
+    ).toEqual(['laptop', 'phone']);
+
+    expect(getQueryTextsFromQuerySet({ a: 'laptop', b: 'phone' })).toEqual(['laptop', 'phone']);
+  });
+
+  it('maps variant statuses to queries when counts align', () => {
+    const statuses = mapQueryStatusesFromVariants(
+      ['query-a', 'query-b'],
+      [
+        { timestamp: '2026-01-01T00:00:00Z', status: 'ERROR', results: { error: 'boom' } },
+        {
+          timestamp: '2026-01-01T00:00:01Z',
+          status: 'COMPLETED',
+          results: { details: 'no search hits found' },
+        },
+      ]
+    );
+
+    expect(statuses.get('query-a')).toBe('failed');
+    expect(statuses.get('query-b')).toBe('zero_results');
+  });
+
+  it('builds rows for successful, failed, and missing queries', () => {
+    const rows = buildQueryEvaluationRows({
+      queryTexts: ['success-query', 'failed-query', 'missing-query'],
+      evaluationByQueryText: new Map([
+        [
+          'success-query',
+          {
+            queryText: 'success-query',
+            metrics: { ndcg: 0.5 },
+            documentIds: ['doc-1'],
+          },
+        ],
+      ]),
+      experimentResults: [{ queryText: 'failed-query' }],
+      variantStatusByQueryText: new Map(),
+    });
+
+    expect(rows).toHaveLength(3);
+    expect(rows[0].status).toBe('success');
+    expect(rows[1].status).toBe('failed');
+    expect(rows[2].status).toBe('not_run');
+  });
+
+  it('uses variant status for zero-results queries', () => {
+    const rows = buildQueryEvaluationRows({
+      queryTexts: ['zsr-query'],
+      evaluationByQueryText: new Map(),
+      experimentResults: [{ queryText: 'zsr-query' }],
+      variantStatusByQueryText: new Map([['zsr-query', 'zero_results']]),
+    });
+
+    expect(rows[0].status).toBe('zero_results');
+    expect(rows[0].statusMessage).toContain('zero search results');
+  });
+
+  it('counts outcomes for notifications', () => {
+    const counts = countQueryOutcomes([
+      { queryText: 'a', metrics: {}, documentIds: [], status: 'success' },
+      { queryText: 'b', metrics: {}, documentIds: [], status: 'failed' },
+      { queryText: 'c', metrics: {}, documentIds: [], status: 'zero_results' },
+      { queryText: 'd', metrics: {}, documentIds: [], status: 'not_run' },
+    ]);
+
+    expect(counts).toEqual({ success: 1, failed: 1, zeroResults: 1, notRun: 1 });
+  });
+
+  it('preserves query execution order from experiment results', () => {
+    expect(
+      getQueryExecutionOrder([
+        { queryText: 'second' },
+        { queryText: 'first' },
+        { queryText: 'second' },
+      ])
+    ).toEqual(['second', 'first']);
+  });
+});

--- a/public/components/experiment/utils/query_evaluation_builder.ts
+++ b/public/components/experiment/utils/query_evaluation_builder.ts
@@ -1,0 +1,236 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { QueryEvaluation } from '../../../types/index';
+
+export type QueryEvaluationStatus = 'success' | 'zero_results' | 'failed' | 'not_run';
+
+export interface QueryEvaluationRow extends QueryEvaluation {
+  status: QueryEvaluationStatus;
+  statusMessage?: string;
+}
+
+export interface ExperimentResultEntry {
+  queryText?: string;
+  evaluationId?: string;
+}
+
+export interface ExperimentVariantSource {
+  timestamp?: string;
+  status?: string;
+  results?: {
+    error?: string;
+    details?: string;
+    evaluationResultId?: string;
+  };
+}
+
+export interface QueryOutcomeCounts {
+  success: number;
+  zeroResults: number;
+  failed: number;
+  notRun: number;
+}
+
+const NO_HITS_DETAIL = 'no search hits found';
+
+export const getQueryTextsFromQuerySet = (querySetQueries: unknown): string[] => {
+  if (!querySetQueries) {
+    return [];
+  }
+
+  if (Array.isArray(querySetQueries)) {
+    return querySetQueries
+      .map((entry) => {
+        if (typeof entry === 'string') {
+          return entry;
+        }
+        if (entry && typeof entry === 'object' && 'queryText' in entry) {
+          return String((entry as { queryText: string }).queryText);
+        }
+        return null;
+      })
+      .filter((text): text is string => Boolean(text));
+  }
+
+  if (typeof querySetQueries === 'object') {
+    return Object.values(querySetQueries as Record<string, string>).filter(
+      (text) => typeof text === 'string' && text.length > 0
+    );
+  }
+
+  return [];
+};
+
+export const getQueryExecutionOrder = (experimentResults: ExperimentResultEntry[]): string[] => {
+  const order: string[] = [];
+  const seen = new Set<string>();
+
+  for (const result of experimentResults) {
+    const queryText = result?.queryText;
+    if (queryText && !seen.has(queryText)) {
+      seen.add(queryText);
+      order.push(queryText);
+    }
+  }
+
+  return order;
+};
+
+const classifyVariant = (variant: ExperimentVariantSource): QueryEvaluationStatus | null => {
+  const results = variant.results ?? {};
+  const details = typeof results.details === 'string' ? results.details : '';
+
+  if (variant.status === 'ERROR' || results.error) {
+    return 'failed';
+  }
+
+  if (details.toLowerCase().includes(NO_HITS_DETAIL)) {
+    return 'zero_results';
+  }
+
+  if (results.evaluationResultId) {
+    return 'success';
+  }
+
+  return null;
+};
+
+export const mapQueryStatusesFromVariants = (
+  queryExecutionOrder: string[],
+  variants: ExperimentVariantSource[]
+): Map<string, QueryEvaluationStatus> => {
+  const statusByQuery = new Map<string, QueryEvaluationStatus>();
+
+  if (queryExecutionOrder.length === 0 || variants.length !== queryExecutionOrder.length) {
+    return statusByQuery;
+  }
+
+  const sortedVariants = [...variants].sort((a, b) =>
+    String(a.timestamp ?? '').localeCompare(String(b.timestamp ?? ''))
+  );
+
+  queryExecutionOrder.forEach((queryText, index) => {
+    const variantStatus = classifyVariant(sortedVariants[index]);
+    if (variantStatus && variantStatus !== 'success') {
+      statusByQuery.set(queryText, variantStatus);
+    }
+  });
+
+  return statusByQuery;
+};
+
+const getStatusMessage = (status: QueryEvaluationStatus, errorMessage?: string): string | undefined => {
+  switch (status) {
+    case 'failed':
+      return errorMessage || 'Query failed to execute';
+    case 'zero_results':
+      return 'Query succeeded but returned zero search results';
+    case 'not_run':
+      return 'Query was not evaluated';
+    default:
+      return undefined;
+  }
+};
+
+export const buildQueryEvaluationRows = ({
+  queryTexts,
+  evaluationByQueryText,
+  experimentResults,
+  variantStatusByQueryText,
+}: {
+  queryTexts: string[];
+  evaluationByQueryText: Map<string, QueryEvaluation>;
+  experimentResults: ExperimentResultEntry[];
+  variantStatusByQueryText: Map<string, QueryEvaluationStatus>;
+}): QueryEvaluationRow[] => {
+  const experimentResultsByQuery = new Map<string, ExperimentResultEntry[]>();
+
+  for (const result of experimentResults) {
+    const queryText = result?.queryText;
+    if (!queryText) {
+      continue;
+    }
+    const existing = experimentResultsByQuery.get(queryText) ?? [];
+    existing.push(result);
+    experimentResultsByQuery.set(queryText, existing);
+  }
+
+  return queryTexts.map((queryText) => {
+    const evaluation = evaluationByQueryText.get(queryText);
+    if (evaluation) {
+      return {
+        ...evaluation,
+        status: 'success',
+      };
+    }
+
+    const variantStatus = variantStatusByQueryText.get(queryText);
+    const experimentEntries = experimentResultsByQuery.get(queryText) ?? [];
+    const hasEvaluationId = experimentEntries.some((entry) => Boolean(entry.evaluationId));
+
+    if (hasEvaluationId) {
+      return {
+        queryText,
+        metrics: {},
+        documentIds: [],
+        status: 'success',
+      };
+    }
+
+    if (variantStatus) {
+      return {
+        queryText,
+        metrics: {},
+        documentIds: [],
+        status: variantStatus,
+        statusMessage: getStatusMessage(variantStatus),
+      };
+    }
+
+    if (experimentEntries.length > 0) {
+      return {
+        queryText,
+        metrics: {},
+        documentIds: [],
+        status: 'failed',
+        statusMessage: getStatusMessage('failed'),
+      };
+    }
+
+    return {
+      queryText,
+      metrics: {},
+      documentIds: [],
+      status: 'not_run',
+      statusMessage: getStatusMessage('not_run'),
+    };
+  });
+};
+
+export const countQueryOutcomes = (rows: QueryEvaluationRow[]): QueryOutcomeCounts => {
+  return rows.reduce(
+    (counts, row) => {
+      switch (row.status) {
+        case 'zero_results':
+          counts.zeroResults++;
+          break;
+        case 'failed':
+          counts.failed++;
+          break;
+        case 'not_run':
+          counts.notRun++;
+          break;
+        default:
+          counts.success++;
+      }
+      return counts;
+    },
+    { success: 0, zeroResults: 0, failed: 0, notRun: 0 }
+  );
+};
+
+export const parseVariantSources = (hits: Array<{ _source?: ExperimentVariantSource }>): ExperimentVariantSource[] =>
+  hits.map((hit) => hit._source).filter((source): source is ExperimentVariantSource => Boolean(source));

--- a/public/components/experiment/views/evaluation_experiment_view.tsx
+++ b/public/components/experiment/views/evaluation_experiment_view.tsx
@@ -4,6 +4,7 @@
  */
 
 import {
+  EuiBadge,
   EuiButtonEmpty,
   EuiCallOut,
   EuiPanel,
@@ -46,6 +47,16 @@ import {
   MAP_TOOL_TIP,
   COVERAGE_TOOL_TIP,
 } from '../../../../common';
+import {
+  buildQueryEvaluationRows,
+  countQueryOutcomes,
+  getQueryExecutionOrder,
+  getQueryTextsFromQuerySet,
+  mapQueryStatusesFromVariants,
+  parseVariantSources,
+  QueryEvaluationRow,
+  QueryEvaluationStatus,
+} from '../utils/query_evaluation_builder';
 
 interface EvaluationExperimentViewProps extends RouteComponentProps<{ id: string }> {
   http: CoreStart['http'];
@@ -70,7 +81,7 @@ export const EvaluationExperimentView: React.FC<EvaluationExperimentViewProps> =
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
 
-  const [queryEvaluations, setQueryEvaluations] = useState<QueryEvaluation[]>([]);
+  const [queryEvaluations, setQueryEvaluations] = useState<QueryEvaluationRow[]>([]);
 
   const [tableColumns, setTableColumns] = useState<any[]>([]);
 
@@ -86,6 +97,14 @@ export const EvaluationExperimentView: React.FC<EvaluationExperimentViewProps> =
       try {
         // Find the evaluation from already fetched queryEvaluations
         const evaluation = queryEvaluations.find((q) => q.queryText === queryText);
+
+        if (evaluation?.status && evaluation.status !== 'success') {
+          notifications.toasts.addWarning({
+            title: 'Query not evaluated',
+            text: evaluation.statusMessage || 'This query does not have evaluation results',
+          });
+          return;
+        }
 
         if (!evaluation?.documentIds?.length) {
           notifications.toasts.addWarning({
@@ -160,29 +179,45 @@ export const EvaluationExperimentView: React.FC<EvaluationExperimentViewProps> =
             )
             .then(sanitizeResponse));
 
-        const querySetSize = _querySet && Object.keys(_querySet.querySetQueries).length;
-        const query = {
+        const queryTexts = getQueryTextsFromQuerySet(_querySet?.querySetQueries);
+        const querySetSize = queryTexts.length;
+        const evaluationQuery = {
           index: 'search-relevance-evaluation-result',
           query: {
             match: {
               experimentId: _experiment.id,
             },
           },
-          size: querySetSize,
+          size: Math.max(querySetSize, 1),
         };
-        
-        const requestBody = {
-          query1: query,
-          ...(dataSourceId && { dataSourceId1: dataSourceId })
+
+        const variantQuery = {
+          index: 'search-relevance-experiment-variant',
+          query: {
+            match: {
+              experimentId: _experiment.id,
+            },
+          },
+          size: Math.max(querySetSize, 1),
         };
-        
-        const result = await http.post(ServiceEndpoints.GetSearchResults, {
-          body: JSON.stringify(requestBody)
-        });
+
+        const requestBase = dataSourceId ? { dataSourceId1: dataSourceId } : {};
+
+        const [evaluationSearchResult, variantSearchResult] = await Promise.all([
+          http.post(ServiceEndpoints.GetSearchResults, {
+            body: JSON.stringify({ query1: evaluationQuery, ...requestBase }),
+          }),
+          http.post(ServiceEndpoints.GetSearchResults, {
+            body: JSON.stringify({ query1: variantQuery, ...requestBase }),
+          }),
+        ]);
+
         const parseResults =
-          result &&
-          result.result1?.hits?.hits &&
-          combineResults(...result.result1.hits.hits.map((x: any) => toQueryEvaluation(x._source)));
+          evaluationSearchResult?.result1?.hits?.hits &&
+          combineResults(
+            ...evaluationSearchResult.result1.hits.hits.map((x: any) => toQueryEvaluation(x._source))
+          );
+
         if (_experiment && _searchConfiguration && _querySet && _judgmentSet) {
           setExperiment(parsedExperiment.data);
           setSearchConfiguration(_searchConfiguration);
@@ -190,14 +225,54 @@ export const EvaluationExperimentView: React.FC<EvaluationExperimentViewProps> =
           setJudgmentSet(_judgmentSet);
           setScheduledExperimentJob(_scheduledExperimentJob);
           if (parseResults.success) {
-            setQueryEvaluations(parseResults.data);
-            // Check if there are ZSR queries by comparing resultIds count with query set count
-            if (_querySet && _querySet.querySetQueries && querySetSize > parseResults.data.length) {
-              const zsrCount = querySetSize - parseResults.data.length;
+            const evaluationByQueryText = new Map<string, QueryEvaluation>();
+            for (const evaluation of parseResults.data as QueryEvaluation[]) {
+              evaluationByQueryText.set(evaluation.queryText, evaluation);
+            }
+
+            const experimentResults = Array.isArray(_experiment.results) ? _experiment.results : [];
+            const variantSources = parseVariantSources(variantSearchResult?.result1?.hits?.hits ?? []);
+            const variantStatusByQueryText = mapQueryStatusesFromVariants(
+              getQueryExecutionOrder(experimentResults),
+              variantSources
+            );
+
+            const queryRows = buildQueryEvaluationRows({
+              queryTexts,
+              evaluationByQueryText,
+              experimentResults,
+              variantStatusByQueryText,
+            });
+            setQueryEvaluations(queryRows);
+
+            const outcomeCounts = countQueryOutcomes(queryRows);
+            if (outcomeCounts.failed > 0) {
+              notifications.toasts.addDanger({
+                title: 'Some queries failed',
+                text: `${outcomeCounts.failed} ${
+                  outcomeCounts.failed === 1 ? 'query' : 'queries'
+                } failed to execute`,
+                'data-test-subj': 'failedQueriesWarningToast',
+                toastLifeTimeMs: 10000,
+              });
+            }
+            if (outcomeCounts.zeroResults > 0) {
               notifications.toasts.addWarning({
                 title: 'You have some ZSR queries',
-                text: `${zsrCount} queries returned Zero Search Results`,
+                text: `${outcomeCounts.zeroResults} ${
+                  outcomeCounts.zeroResults === 1 ? 'query' : 'queries'
+                } returned Zero Search Results`,
                 'data-test-subj': 'zsrQueriesWarningToast',
+                toastLifeTimeMs: 10000,
+              });
+            }
+            if (outcomeCounts.notRun > 0) {
+              notifications.toasts.addWarning({
+                title: 'Some queries were not evaluated',
+                text: `${outcomeCounts.notRun} ${
+                  outcomeCounts.notRun === 1 ? 'query was' : 'queries were'
+                } not evaluated`,
+                'data-test-subj': 'notRunQueriesWarningToast',
                 toastLifeTimeMs: 10000,
               });
             }
@@ -221,9 +296,37 @@ export const EvaluationExperimentView: React.FC<EvaluationExperimentViewProps> =
     fetchExperiment();
   }, [http, inputExperiment, dataSourceId]);
 
-  function extractMetricNames(queryEvaluations: any): string[] {
-    if (queryEvaluations.length > 0) {
-      return Object.keys(queryEvaluations[0].metrics);
+  const getStatusBadge = (status: QueryEvaluationStatus, statusMessage?: string) => {
+    const badgeConfig: Record<
+      QueryEvaluationStatus,
+      { color: 'success' | 'warning' | 'danger' | 'default'; label: string }
+    > = {
+      success: { color: 'success', label: 'Evaluated' },
+      zero_results: { color: 'warning', label: 'Zero results' },
+      failed: { color: 'danger', label: 'Failed' },
+      not_run: { color: 'default', label: 'Not run' },
+    };
+    const config = badgeConfig[status];
+
+    const badge = (
+      <EuiBadge color={config.color} data-test-subj={`queryStatus-${status}`}>
+        {config.label}
+      </EuiBadge>
+    );
+
+    if (statusMessage) {
+      return <EuiToolTip content={statusMessage}>{badge}</EuiToolTip>;
+    }
+
+    return badge;
+  };
+
+  function extractMetricNames(evaluations: QueryEvaluationRow[]): string[] {
+    const successfulEvaluation = evaluations.find(
+      (evaluation) => evaluation.status === 'success' && Object.keys(evaluation.metrics).length > 0
+    );
+    if (successfulEvaluation) {
+      return Object.keys(successfulEvaluation.metrics);
     }
     return [];
   }
@@ -256,6 +359,14 @@ export const EvaluationExperimentView: React.FC<EvaluationExperimentViewProps> =
             </EuiButtonEmpty>
           ),
         },
+        {
+          field: 'status',
+          name: 'Status',
+          dataType: 'string',
+          sortable: true,
+          render: (_status: QueryEvaluationStatus, row: QueryEvaluationRow) =>
+            getStatusBadge(row.status, row.statusMessage),
+        },
       ];
       metricNames.forEach((metricName) => {
         // Extract base name for tooltip lookup
@@ -273,14 +384,17 @@ export const EvaluationExperimentView: React.FC<EvaluationExperimentViewProps> =
           ),
           dataType: 'number',
           sortable: true,
-          render: (value: any) => {
+          render: (value: any, row: QueryEvaluationRow) => {
+            if (row.status !== 'success') {
+              return '—';
+            }
             if (typeof value === 'number') {
               return new Intl.NumberFormat(undefined, {
                 minimumFractionDigits: 2,
                 maximumFractionDigits: 2,
               }).format(value);
             }
-            return '-';
+            return '—';
           },
         });
       });
@@ -397,7 +511,11 @@ export const EvaluationExperimentView: React.FC<EvaluationExperimentViewProps> =
     <>
       {experimentDetails}
       <EuiSpacer size="m" />
-      <MetricsSummaryPanel metrics={queryEvaluations.map((q) => q.metrics)} />
+      <MetricsSummaryPanel
+        metrics={queryEvaluations
+          .filter((query) => query.status === 'success')
+          .map((query) => query.metrics)}
+      />
       <EuiSpacer size="m" />
       {resultsPane}
     </>

--- a/public/components/experiment/views/evaluation_experiment_view.tsx
+++ b/public/components/experiment/views/evaluation_experiment_view.tsx
@@ -4,7 +4,6 @@
  */
 
 import {
-  EuiBadge,
   EuiButtonEmpty,
   EuiCallOut,
   EuiPanel,
@@ -12,6 +11,7 @@ import {
   EuiDescriptionList,
   EuiDescriptionListTitle,
   EuiDescriptionListDescription,
+  EuiHealth,
   EuiSpacer,
   EuiToolTip,
 } from '@elastic/eui';
@@ -296,29 +296,30 @@ export const EvaluationExperimentView: React.FC<EvaluationExperimentViewProps> =
     fetchExperiment();
   }, [http, inputExperiment, dataSourceId]);
 
-  const getStatusBadge = (status: QueryEvaluationStatus, statusMessage?: string) => {
-    const badgeConfig: Record<
+  const getStatusIndicator = (status: QueryEvaluationStatus, statusMessage?: string) => {
+    // EuiHealth matches experiment listing status styling (see common_utils/status.ts).
+    const statusConfig: Record<
       QueryEvaluationStatus,
-      { color: 'success' | 'warning' | 'danger' | 'default'; label: string }
+      { color: 'success' | 'warning' | 'danger' | 'subdued'; label: string }
     > = {
       success: { color: 'success', label: 'Evaluated' },
       zero_results: { color: 'warning', label: 'Zero results' },
       failed: { color: 'danger', label: 'Failed' },
-      not_run: { color: 'default', label: 'Not run' },
+      not_run: { color: 'subdued', label: 'Not run' },
     };
-    const config = badgeConfig[status];
+    const config = statusConfig[status];
 
-    const badge = (
-      <EuiBadge color={config.color} data-test-subj={`queryStatus-${status}`}>
-        {config.label}
-      </EuiBadge>
+    const indicator = (
+      <span data-test-subj={`queryStatus-${status}`}>
+        <EuiHealth color={config.color}>{config.label}</EuiHealth>
+      </span>
     );
 
     if (statusMessage) {
-      return <EuiToolTip content={statusMessage}>{badge}</EuiToolTip>;
+      return <EuiToolTip content={statusMessage}>{indicator}</EuiToolTip>;
     }
 
-    return badge;
+    return indicator;
   };
 
   function extractMetricNames(evaluations: QueryEvaluationRow[]): string[] {
@@ -365,7 +366,7 @@ export const EvaluationExperimentView: React.FC<EvaluationExperimentViewProps> =
           dataType: 'string',
           sortable: true,
           render: (_status: QueryEvaluationStatus, row: QueryEvaluationRow) =>
-            getStatusBadge(row.status, row.statusMessage),
+            getStatusIndicator(row.status, row.statusMessage),
         },
       ];
       metricNames.forEach((metricName) => {


### PR DESCRIPTION
## Description

Fixes #733.

Previously, queries that failed to execute in OpenSearch were treated as Zero Search Results (ZSR) in the Search Evaluation view. Since failed queries do not generate evaluation results, the UI incorrectly counted them as missing rows and displayed a misleading ZSR warning.

This change introduces explicit query statuses and displays all queries from the query set in the results table.

### Changes

* Added query statuses: **Evaluated**, **Failed**, **Zero results**, and **Not run**
* Added a Status column with visual badges
* Distinguished failed queries from true ZSR queries using experiment variant data
* Added separate notifications for failed, ZSR, and not-evaluated queries
* Prevented drill-down into evaluation details for non-successful queries
* Updated metrics summaries to only include successfully evaluated queries
* Added unit tests for query status classification and row generation

### Testing

* Added unit tests for the new query evaluation builder utilities
* Verified manually using a failing search configuration:

  * Failed queries are shown as **Failed**
  * "Some queries failed" toast is displayed
  * Queries are no longer reported as ZSR
* Verified successful experiments continue to display metrics and drill-down results correctly


screenshots:
before:
<img width="1728" height="1117" alt="Screenshot 2026-06-04 at 11 42 46 AM" src="https://github.com/user-attachments/assets/d43533a5-48c6-41f6-a400-61cd65f7d5ea" />


after:
<img width="1626" height="1020" alt="Screenshot 2026-06-04 at 11 51 38 AM" src="https://github.com/user-attachments/assets/f42fbfa2-8aee-4ffa-a677-b530f22313f0" />



