### PR TITLE
refactor: replace per-page data source selectors with global menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,3 +20,4 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Maintenance
 
 ### Refactoring
+* Replace per-page data source selectors with a single global data source menu in the OSD chrome header, backed by URL-synced state ([#850](https://github.com/opensearch-project/dashboards-search-relevance/pull/850))

--- a/public/components/app.tsx
+++ b/public/components/app.tsx
@@ -5,7 +5,7 @@
 
 import { EuiGlobalToastList } from '@elastic/eui';
 import { I18nProvider } from '@osd/i18n/react';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { HashRouter, Route, Switch, withRouter, useLocation } from 'react-router-dom';
 import {
   EuiPageSideBar,
@@ -41,7 +41,8 @@ import { QuerySetView } from './query_set';
 import { QuerySetCreate } from './query_set';
 import { TemplateType, routeToTemplateType } from './experiment/configuration/types';
 import { TemplateConfigurationWithRouter } from './experiment/configuration/template_configuration';
-import { parseEntityParams } from './common/datasource_utils';
+import { parseEntityParams, useDataSourceUrlSync } from './common/datasource_utils';
+import { DataSourceMenu } from './common/data_source_menu';
 
 enum Navigation {
   SRW = 'Search Relevance Workbench',
@@ -90,6 +91,12 @@ const SearchRelevancePage = ({
 }: SearchRelevancePageProps) => {
   const location = useLocation();
   const { http: osDashboardsHttp } = useOpenSearchDashboards().services;
+
+  const [dataSourceId, setDataSourceId] = useDataSourceUrlSync(
+    dataSourceEnabled,
+    history,
+    location
+  );
 
   const getNavGroupEnabled = chrome.navGroup.getNavGroupEnabled();
   const parentBreadCrumbs = getNavGroupEnabled
@@ -188,6 +195,15 @@ const SearchRelevancePage = ({
 
   return (
     <EuiPage restrictWidth={'100%'}>
+      <DataSourceMenu
+        dataSourceEnabled={dataSourceEnabled}
+        dataSourceManagement={dataSourceManagement}
+        savedObjects={savedObjects}
+        notifications={notifications}
+        setActionMenu={setActionMenu}
+        dataSourceId={dataSourceId}
+        setDataSourceId={setDataSourceId}
+      />
       <EuiPageSideBar style={{ minWidth: 200 }}>
         <EuiSideNav style={{ width: 200 }} items={sideNavItems} />
       </EuiPageSideBar>
@@ -220,9 +236,7 @@ const SearchRelevancePage = ({
                 // No config parameter, show experiment listing
                 return <ExperimentListingWithRoute
                   http={http}
-                  savedObjects={savedObjects}
-                  dataSourceEnabled={dataSourceEnabled}
-                  dataSourceManagement={dataSourceManagement}
+                  dataSourceId={dataSourceId}
                   onAskAI={onAskAI}
                 />;
               }
@@ -234,9 +248,7 @@ const SearchRelevancePage = ({
             render={() => {
               return <ExperimentListingWithRoute
                 http={http}
-                savedObjects={savedObjects}
-                dataSourceEnabled={dataSourceEnabled}
-                dataSourceManagement={dataSourceManagement}
+                dataSourceId={dataSourceId}
                 onAskAI={onAskAI}
               />;
             }}
@@ -245,36 +257,21 @@ const SearchRelevancePage = ({
             path={Routes.QuerySetListing}
             exact
             render={() => {
-              return <QuerySetListing
-                http={http}
-                savedObjects={savedObjects}
-                dataSourceEnabled={dataSourceEnabled}
-                dataSourceManagement={dataSourceManagement}
-              />;
+              return <QuerySetListing http={http} dataSourceId={dataSourceId} />;
             }}
           />
           <Route
             path={Routes.SearchConfigurationListing}
             exact
             render={() => {
-              return <SearchConfigurationListing
-                http={http}
-                savedObjects={savedObjects}
-                dataSourceEnabled={dataSourceEnabled}
-                dataSourceManagement={dataSourceManagement}
-              />;
+              return <SearchConfigurationListing http={http} dataSourceId={dataSourceId} />;
             }}
           />
           <Route
             path={Routes.JudgmentListing}
             exact
             render={() => {
-              return <JudgmentListing
-                http={http}
-                savedObjects={savedObjects}
-                dataSourceEnabled={dataSourceEnabled}
-                dataSourceManagement={dataSourceManagement}
-              />;
+              return <JudgmentListing http={http} dataSourceId={dataSourceId} />;
             }}
           />
           <Route
@@ -361,9 +358,7 @@ const SearchRelevancePage = ({
                       history.goBack();
                     }}
                     onClose={() => { }}
-                    savedObjects={savedObjects}
-                    dataSourceEnabled={dataSourceEnabled}
-                    dataSourceManagement={dataSourceManagement}
+                    dataSourceId={dataSourceId}
                   />
                 );
               }
@@ -376,9 +371,7 @@ const SearchRelevancePage = ({
               return <QuerySetCreate
                 http={http}
                 notifications={notifications}
-                savedObjects={savedObjects}
-                dataSourceEnabled={dataSourceEnabled}
-                dataSourceManagement={dataSourceManagement}
+                dataSourceId={dataSourceId}
               />;
             }}
           />
@@ -389,9 +382,7 @@ const SearchRelevancePage = ({
               return <SearchConfigurationCreate
                 http={http}
                 notifications={notifications}
-                savedObjects={savedObjects}
-                dataSourceEnabled={dataSourceEnabled}
-                dataSourceManagement={dataSourceManagement}
+                dataSourceId={dataSourceId}
               />;
             }}
           />
@@ -403,9 +394,7 @@ const SearchRelevancePage = ({
                 http={http}
                 notifications={notifications}
                 history={history}
-                savedObjects={savedObjects}
-                dataSourceEnabled={dataSourceEnabled}
-                dataSourceManagement={dataSourceManagement}
+                dataSourceId={dataSourceId}
               />;
             }}
           />

--- a/public/components/common/__test__/data_source_menu.test.tsx
+++ b/public/components/common/__test__/data_source_menu.test.tsx
@@ -1,0 +1,177 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { DataSourceMenu } from '../data_source_menu';
+
+// OSD's getDataSourceMenu() returns a component class; spy on it so we can
+// inspect the props we hand to OSD and drive `onSelectedDataSources` from the
+// test.
+const renderedMenu = jest.fn<React.ReactElement | null, [any]>();
+
+const makeDataSourceManagement = () => ({
+  ui: {
+    getDataSourceMenu: jest.fn(() => (props: any) => {
+      renderedMenu(props);
+      return (
+        <div data-test-subj="osd-data-source-menu">
+          <button
+            type="button"
+            data-test-subj="osd-pick-foo"
+            onClick={() => props.componentConfig.onSelectedDataSources([{ id: 'foo-ds' }])}
+          >
+            pick foo
+          </button>
+          <button
+            type="button"
+            data-test-subj="osd-pick-undefined"
+            onClick={() => props.componentConfig.onSelectedDataSources([{ id: undefined }])}
+          >
+            pick undefined
+          </button>
+          <button
+            type="button"
+            data-test-subj="osd-pick-empty-list"
+            onClick={() => props.componentConfig.onSelectedDataSources([])}
+          >
+            pick empty
+          </button>
+        </div>
+      );
+    }),
+    DataSourceSelector: () => null,
+  } as any,
+});
+
+const baseProps = () => ({
+  dataSourceEnabled: true,
+  dataSourceManagement: makeDataSourceManagement(),
+  savedObjects: { client: { find: jest.fn() } } as any,
+  notifications: {
+    toasts: { addDanger: jest.fn(), addSuccess: jest.fn(), addError: jest.fn() },
+  } as any,
+  setActionMenu: jest.fn(),
+  dataSourceId: undefined as string | undefined,
+  setDataSourceId: jest.fn(),
+});
+
+describe('DataSourceMenu', () => {
+  beforeEach(() => {
+    renderedMenu.mockClear();
+  });
+
+  it('renders nothing when multi-data-source is disabled', () => {
+    const { container } = render(
+      <DataSourceMenu {...baseProps()} dataSourceEnabled={false} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing when the dataSourceManagement plugin is absent', () => {
+    const { container } = render(
+      <DataSourceMenu {...baseProps()} dataSourceManagement={undefined} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('mounts the OSD DataSourceMenu with DataSourceSelectable and no active option when no id is supplied', () => {
+    const props = baseProps();
+    const { getByTestId } = render(<DataSourceMenu {...props} />);
+
+    expect(getByTestId('osd-data-source-menu')).toBeInTheDocument();
+    expect(props.dataSourceManagement!.ui.getDataSourceMenu).toHaveBeenCalledTimes(1);
+
+    const menuProps = renderedMenu.mock.calls[0][0];
+    expect(menuProps.componentType).toBe('DataSourceSelectable');
+    expect(menuProps.setMenuMountPoint).toBe(props.setActionMenu);
+    expect(menuProps.componentConfig.activeOption).toBeUndefined();
+    expect(menuProps.componentConfig.savedObjects).toBe(props.savedObjects.client);
+    expect(menuProps.componentConfig.notifications).toBe(props.notifications);
+  });
+
+  it('seeds activeOption from the supplied dataSourceId', () => {
+    render(<DataSourceMenu {...baseProps()} dataSourceId="foo-ds" />);
+    const menuProps = renderedMenu.mock.calls[0][0];
+    expect(menuProps.componentConfig.activeOption).toEqual([{ id: 'foo-ds' }]);
+  });
+
+  it('forwards a chosen data source id via setDataSourceId', () => {
+    const props = baseProps();
+    const { getByTestId } = render(<DataSourceMenu {...props} />);
+
+    fireEvent.click(getByTestId('osd-pick-foo'));
+
+    expect(props.setDataSourceId).toHaveBeenCalledWith('foo-ds');
+    expect(props.notifications.toasts.addDanger).not.toHaveBeenCalled();
+  });
+
+  it('shows a danger toast and does not update state when the picker yields an undefined id', () => {
+    const props = baseProps();
+    const { getByTestId } = render(<DataSourceMenu {...props} />);
+
+    fireEvent.click(getByTestId('osd-pick-undefined'));
+
+    expect(props.setDataSourceId).not.toHaveBeenCalled();
+    expect(props.notifications.toasts.addDanger).toHaveBeenCalledWith(
+      'Unable to set data source.'
+    );
+  });
+
+  it('shows a danger toast when the picker yields no event at all', () => {
+    const props = baseProps();
+    const { getByTestId } = render(<DataSourceMenu {...props} />);
+
+    fireEvent.click(getByTestId('osd-pick-empty-list'));
+
+    expect(props.setDataSourceId).not.toHaveBeenCalled();
+    expect(props.notifications.toasts.addDanger).toHaveBeenCalledWith(
+      'Unable to set data source.'
+    );
+  });
+
+  it('passes a dataSourceFilter that rejects AnalyticEngine and unsupported versions', () => {
+    render(<DataSourceMenu {...baseProps()} />);
+    const menuProps = renderedMenu.mock.calls[0][0];
+    const filter = menuProps.componentConfig.dataSourceFilter;
+
+    const ds = (version: string, engineType?: string) => ({
+      attributes: { dataSourceVersion: version, dataSourceEngineType: engineType },
+    });
+
+    expect(filter(ds('2.12.0', 'OpenSearch'))).toBe(true);
+    expect(filter(ds('2.12.0', 'AnalyticEngine'))).toBe(false);
+    expect(filter(ds('2.6.0', 'OpenSearch'))).toBe(false);
+  });
+
+  it('does not remount OSD on parent re-renders when stable props are unchanged (dataSourceId changes only update internal state)', () => {
+    // The wrapper memoizes its output so OSD's menu keeps its loaded options
+    // across navigation. Re-rendering with a different dataSourceId must NOT
+    // trigger another getDataSourceMenu() factory call.
+    const props = baseProps();
+    const { rerender } = render(<DataSourceMenu {...props} />);
+
+    expect(props.dataSourceManagement!.ui.getDataSourceMenu).toHaveBeenCalledTimes(1);
+
+    rerender(<DataSourceMenu {...props} dataSourceId="foo-ds" />);
+    rerender(<DataSourceMenu {...props} dataSourceId="bar-ds" />);
+
+    expect(props.dataSourceManagement!.ui.getDataSourceMenu).toHaveBeenCalledTimes(1);
+    // And OSD's menu is rendered exactly once — the cached element is reused.
+    expect(renderedMenu).toHaveBeenCalledTimes(1);
+  });
+
+  it('rebuilds the menu when stable identity props change (e.g. dataSourceManagement swapped)', () => {
+    const first = baseProps();
+    const { rerender } = render(<DataSourceMenu {...first} />);
+    expect(first.dataSourceManagement!.ui.getDataSourceMenu).toHaveBeenCalledTimes(1);
+
+    const second = { ...first, dataSourceManagement: makeDataSourceManagement() };
+    rerender(<DataSourceMenu {...second} />);
+
+    expect(second.dataSourceManagement!.ui.getDataSourceMenu).toHaveBeenCalledTimes(1);
+    expect(renderedMenu).toHaveBeenCalledTimes(2);
+  });
+});

--- a/public/components/common/__test__/use_data_source_url_sync.test.ts
+++ b/public/components/common/__test__/use_data_source_url_sync.test.ts
@@ -1,0 +1,185 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { renderHook, act } from '@testing-library/react';
+import { useDataSourceUrlSync } from '../datasource_utils';
+
+const makeHistory = () => ({ replace: jest.fn() });
+
+const loc = (pathname: string, search = '') => ({ pathname, search, hash: '' });
+
+describe('useDataSourceUrlSync', () => {
+  describe('seeding from the URL', () => {
+    it('reads dataSourceId from the URL on mount when MDS is enabled', () => {
+      const history = makeHistory();
+      const { result } = renderHook(() =>
+        useDataSourceUrlSync(true, history, loc('/querySet', '?dataSourceId=foo-ds'))
+      );
+      expect(result.current[0]).toBe('foo-ds');
+    });
+
+    it('returns undefined when no dataSourceId is in the URL', () => {
+      const history = makeHistory();
+      const { result } = renderHook(() =>
+        useDataSourceUrlSync(true, history, loc('/querySet'))
+      );
+      expect(result.current[0]).toBeUndefined();
+    });
+
+    it('ignores a stale ?dataSourceId=… from a prior session when MDS is disabled', () => {
+      // The server-side dataSource plugin isn't loaded to route the id in
+      // single-cluster mode, so we must not seed state with it.
+      const history = makeHistory();
+      const { result } = renderHook(() =>
+        useDataSourceUrlSync(false, history, loc('/querySet', '?dataSourceId=foo-ds'))
+      );
+      expect(result.current[0]).toBeUndefined();
+    });
+  });
+
+  describe('writing back to the URL', () => {
+    it('does not call history.replace on initial mount when state already matches the URL', () => {
+      const history = makeHistory();
+      renderHook(() =>
+        useDataSourceUrlSync(true, history, loc('/querySet', '?dataSourceId=foo-ds'))
+      );
+      expect(history.replace).not.toHaveBeenCalled();
+    });
+
+    it('writes ?dataSourceId=… when the user picks a new source', () => {
+      const history = makeHistory();
+      const location = loc('/querySet');
+      const { result } = renderHook(() =>
+        useDataSourceUrlSync(true, history, location)
+      );
+
+      act(() => {
+        result.current[1]('foo-ds');
+      });
+
+      expect(history.replace).toHaveBeenCalledWith({
+        pathname: '/querySet',
+        search: '?dataSourceId=foo-ds',
+        hash: '',
+      });
+    });
+
+    it('removes the param when the user clears the selection', () => {
+      const history = makeHistory();
+      const location = loc('/querySet', '?dataSourceId=foo-ds');
+      const { result } = renderHook(() =>
+        useDataSourceUrlSync(true, history, location)
+      );
+
+      act(() => {
+        result.current[1](undefined);
+      });
+
+      expect(history.replace).toHaveBeenCalledWith({
+        pathname: '/querySet',
+        search: '',
+        hash: '',
+      });
+    });
+
+    it('preserves other query params when stamping dataSourceId', () => {
+      const history = makeHistory();
+      const location = loc('/querySet', '?foo=bar');
+      const { result } = renderHook(() =>
+        useDataSourceUrlSync(true, history, location)
+      );
+
+      act(() => {
+        result.current[1]('foo-ds');
+      });
+
+      const call = history.replace.mock.calls[0][0];
+      const params = new URLSearchParams(call.search);
+      expect(params.get('foo')).toBe('bar');
+      expect(params.get('dataSourceId')).toBe('foo-ds');
+    });
+
+    it('does not write to the URL when MDS is disabled', () => {
+      const history = makeHistory();
+      const { result } = renderHook(() =>
+        useDataSourceUrlSync(false, history, loc('/querySet'))
+      );
+
+      act(() => {
+        // Even if something tries to set an id, the effect must short-circuit.
+        result.current[1]('foo-ds');
+      });
+
+      expect(history.replace).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('navigation behavior', () => {
+    it('re-stamps the URL after a tab click drops the dataSourceId param', () => {
+      // Tab clicks call history.push(pathname) with a bare string, which
+      // react-router treats as { pathname, search: '', hash: '' } — dropping
+      // the param. The effect must re-stamp it onto the new URL because we
+      // include `location` in the deps.
+      const history = makeHistory();
+
+      const { result, rerender } = renderHook(
+        ({ location }: { location: any }) =>
+          useDataSourceUrlSync(true, history, location),
+        { initialProps: { location: loc('/querySet', '?dataSourceId=foo-ds') } }
+      );
+      expect(result.current[0]).toBe('foo-ds');
+      expect(history.replace).not.toHaveBeenCalled();
+
+      // Simulate `history.push(Routes.JudgmentListing)` — same hook tree, new
+      // location with the param stripped.
+      rerender({ location: loc('/judgment') });
+
+      expect(history.replace).toHaveBeenCalledTimes(1);
+      expect(history.replace).toHaveBeenCalledWith({
+        pathname: '/judgment',
+        search: '?dataSourceId=foo-ds',
+        hash: '',
+      });
+    });
+
+    it('does not re-stamp when navigating to a URL that already has the right param', () => {
+      const history = makeHistory();
+
+      const { rerender } = renderHook(
+        ({ location }: { location: any }) =>
+          useDataSourceUrlSync(true, history, location),
+        { initialProps: { location: loc('/querySet', '?dataSourceId=foo-ds') } }
+      );
+
+      rerender({ location: loc('/judgment', '?dataSourceId=foo-ds') });
+
+      expect(history.replace).not.toHaveBeenCalled();
+    });
+
+    it('does not loop after writing — the effect short-circuits once the URL is in sync', () => {
+      const history = makeHistory();
+      let location = loc('/querySet');
+
+      const { result, rerender } = renderHook(
+        ({ location: l }: { location: any }) =>
+          useDataSourceUrlSync(true, history, l),
+        { initialProps: { location } }
+      );
+
+      // User picks a source — effect writes to the URL.
+      act(() => {
+        result.current[1]('foo-ds');
+      });
+      expect(history.replace).toHaveBeenCalledTimes(1);
+
+      // Simulate the URL change propagating back into the hook.
+      location = history.replace.mock.calls[0][0];
+      rerender({ location });
+
+      // The effect must NOT fire again — current === dataSourceId now.
+      expect(history.replace).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/public/components/common/data_source_menu.tsx
+++ b/public/components/common/data_source_menu.tsx
@@ -1,0 +1,76 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useMemo } from 'react';
+import semver from 'semver';
+import { CoreStart, MountPoint, SavedObject } from '../../../../../src/core/public';
+import {
+  DataSourceManagementPluginSetup,
+  DataSourceSelectableConfig,
+} from '../../../../../src/plugins/data_source_management/public';
+import { DataSourceOption } from '../../../../../src/plugins/data_source_management/public/components/data_source_menu/types';
+import { DataSourceAttributes } from '../../../../../src/plugins/data_source/common/data_sources';
+import * as pluginManifest from '../../../opensearch_dashboards.json';
+
+interface DataSourceMenuProps {
+  dataSourceEnabled: boolean;
+  dataSourceManagement?: DataSourceManagementPluginSetup;
+  savedObjects: CoreStart['savedObjects'];
+  notifications: CoreStart['notifications'];
+  setActionMenu: (menuMount: MountPoint | undefined) => void;
+  dataSourceId: string | undefined;
+  setDataSourceId: (id: string | undefined) => void;
+}
+
+const dataSourceFilterFn = (dataSource: SavedObject<DataSourceAttributes>) => {
+  if (dataSource?.attributes?.dataSourceEngineType === 'AnalyticEngine') {
+    return false;
+  }
+  const dataSourceVersion = dataSource?.attributes?.dataSourceVersion || '';
+  return semver.satisfies(dataSourceVersion, pluginManifest.supportedOSDataSourceVersions);
+};
+
+export const DataSourceMenu: React.FC<DataSourceMenuProps> = ({
+  dataSourceEnabled,
+  dataSourceManagement,
+  savedObjects,
+  notifications,
+  setActionMenu,
+  dataSourceId,
+  setDataSourceId,
+}) => {
+  // Cache the menu element so OSD's DataSourceMenu mounts once and keeps
+  // its internal state (loaded options, selection) across parent re-renders.
+  // dataSourceId is intentionally NOT a dep — the menu owns its own UI state
+  // after mount; the activeOption prop is only the initial seed.
+  return useMemo(() => {
+    if (!dataSourceEnabled || !dataSourceManagement) {
+      return null;
+    }
+    const Menu = dataSourceManagement.ui.getDataSourceMenu<DataSourceSelectableConfig>();
+    return (
+      <Menu
+        setMenuMountPoint={setActionMenu}
+        componentType={'DataSourceSelectable'}
+        componentConfig={{
+          fullWidth: false,
+          activeOption: dataSourceId === undefined ? undefined : [{ id: dataSourceId }],
+          savedObjects: savedObjects.client,
+          notifications,
+          onSelectedDataSources: ([event]: DataSourceOption[]) => {
+            const id = event?.id;
+            if (id === undefined) {
+              notifications.toasts.addDanger('Unable to set data source.');
+              return;
+            }
+            setDataSourceId(id);
+          },
+          dataSourceFilter: dataSourceFilterFn,
+        }}
+      />
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dataSourceEnabled, dataSourceManagement, savedObjects, notifications, setActionMenu, setDataSourceId]);
+};

--- a/public/components/common/datasource_utils.ts
+++ b/public/components/common/datasource_utils.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { useCallback } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { SavedObject } from '../../../../../src/core/public';
 import { DataSourceAttributes } from '../../../../../src/plugins/data_source/common/data_sources';
 import semver from 'semver';
@@ -45,6 +45,39 @@ export const useDataSourceSelection = (setSelectedDataSource: (id: string) => vo
     const dataConnectionId = dataSources[0] ? dataSources[0].id : '';
     setSelectedDataSource(dataConnectionId);
   }, [setSelectedDataSource]);
+};
+
+/**
+ * Hook that owns the active dataSourceId and keeps it in sync with the URL
+ * `?dataSourceId=…` query param. Seeded from the URL on mount (only when MDS
+ * is enabled, so a stale param from a prior session is ignored when the
+ * dataSource plugin isn't loaded), then re-stamped on every navigation so
+ * tab clicks via `history.push(pathname)` don't drop the param.
+ */
+export const useDataSourceUrlSync = (
+  dataSourceEnabled: boolean,
+  history: { replace: (location: any) => void },
+  location: { search?: string; pathname?: string; hash?: string }
+): [string | undefined, (id: string | undefined) => void] => {
+  const [dataSourceId, setDataSourceId] = useState<string | undefined>(() =>
+    dataSourceEnabled ? parseDataSourceIdFromUrl(location) : undefined
+  );
+
+  useEffect(() => {
+    if (!dataSourceEnabled) return;
+    const params = new URLSearchParams(location.search);
+    const current = params.get('dataSourceId') || undefined;
+    if (current === dataSourceId) return;
+    if (dataSourceId === undefined) {
+      params.delete('dataSourceId');
+    } else {
+      params.set('dataSourceId', dataSourceId);
+    }
+    const search = params.toString();
+    history.replace({ ...location, search: search ? `?${search}` : '' });
+  }, [dataSourceId, dataSourceEnabled, location, history]);
+
+  return [dataSourceId, setDataSourceId];
 };
 
 /**

--- a/public/components/common/index.ts
+++ b/public/components/common/index.ts
@@ -5,5 +5,6 @@
 
 export * from './datasource_utils';
 export { DataSourceSelector } from './datasource_selector';
+export { DataSourceMenu } from './data_source_menu';
 export { DeleteModal } from './DeleteModal';
 export { DashboardInstallModal } from './dashboard_install_modal';

--- a/public/components/experiment/configuration/template_configuration.tsx
+++ b/public/components/experiment/configuration/template_configuration.tsx
@@ -14,22 +14,18 @@ import { Routes } from '../../../../common';
 import { ConfigurationActions } from './configuration_action';
 import { ExperimentService } from '../services/experiment_service';
 import { useOpenSearchDashboards } from '../../../../../../src/plugins/opensearch_dashboards_react/public';
-import { DataSourceSelector } from '../../common/datasource_selector';
 
 export const TemplateConfiguration = ({
   templateType,
   onBack,
   onClose,
   history,
-  savedObjects,
-  dataSourceEnabled = false,
-  dataSourceManagement,
+  dataSourceId,
 }: TemplateConfigurationProps) => {
   const [experimentId, setExperimentId] = useState<string | null>(null);
   const [isCreating, setIsCreating] = useState<boolean>(false);
   const [showEvaluation, setShowEvaluation] = useState(false);
   const [showTemplateConfigError, setShowTemplateConfigError] = useState<boolean>(false);
-  const [selectedDataSource, setSelectedDataSource] = useState<string>('');
 
   const configurationFormRef = useRef<ConfigurationFormRef>(null);
   const isMountedRef = useRef(true);
@@ -59,7 +55,7 @@ export const TemplateConfiguration = ({
       // If we reach here, `data` is guaranteed to be valid and not null
       try {
         setIsCreating(true);
-        const response = await experimentService.createExperiment(data, selectedDataSource || undefined);
+        const response = await experimentService.createExperiment(data, dataSourceId);
 
         if (response.experiment_id) {
           if (isMountedRef.current) {
@@ -104,18 +100,7 @@ export const TemplateConfiguration = ({
             <h2>{templateType} Experiment</h2>
           </EuiTitle>
           <EuiSpacer size="m" />
-          {dataSourceEnabled && dataSourceManagement && savedObjects && (
-            <DataSourceSelector
-              dataSourceEnabled={dataSourceEnabled}
-              dataSourceManagement={dataSourceManagement}
-              savedObjects={savedObjects}
-              selectedDataSource={selectedDataSource}
-              setSelectedDataSource={setSelectedDataSource}
-              excludeEngineTypes={['AnalyticEngine']}
-            />
-          )}
-          <EuiSpacer size="m" />
-          <ConfigurationForm templateType={templateType} dataSourceId={selectedDataSource || undefined} ref={configurationFormRef} />
+          <ConfigurationForm templateType={templateType} dataSourceId={dataSourceId} ref={configurationFormRef} />
         </EuiFlexItem>
 
         <EuiFlexItem>

--- a/public/components/experiment/configuration/types.ts
+++ b/public/components/experiment/configuration/types.ts
@@ -5,8 +5,6 @@
 
 import { RouteComponentProps } from 'react-router-dom';
 import { RouteTemplateType } from '../../../../common';
-import { CoreStart } from '../../../../../../src/core/public';
-import { DataSourceManagementPluginSetup } from '../../../../../../src/plugins/data_source_management/public';
 
 export enum TemplateType {
   QueryAnalysis = 'Query Analysis',
@@ -32,9 +30,7 @@ export interface TemplateConfigurationProps extends RouteComponentProps {
   templateType: string;
   onBack: () => void;
   onClose: () => void;
-  savedObjects?: CoreStart['savedObjects'];
-  dataSourceEnabled?: boolean;
-  dataSourceManagement?: DataSourceManagementPluginSetup;
+  dataSourceId?: string;
 }
 
 export interface ConfigurationFormProps {

--- a/public/components/experiment/views/experiment_listing.tsx
+++ b/public/components/experiment/views/experiment_listing.tsx
@@ -29,11 +29,9 @@ import {
   useOpenSearchDashboards,
 } from '../../../../../../src/plugins/opensearch_dashboards_react/public';
 import { CoreStart } from '../../../../../../src/core/public';
-import { DataSourceManagementPluginSetup } from '../../../../../../src/plugins/data_source_management/public';
 import { Routes, SavedObjectIds, extractUserMessageFromError } from '../../../../common';
 import { DeleteModal } from '../../common/DeleteModal';
 import { DashboardInstallModal } from '../../common/dashboard_install_modal';
-import { DataSourceSelector } from '../../common/datasource_selector';
 import { useConfig } from '../../../contexts/date_format_context';
 import { printType } from '../../../types/index';
 import { ExperimentService } from '../services/experiment_service';
@@ -52,24 +50,19 @@ import './experiment_listing.scss';
 
 interface ExperimentListingProps extends RouteComponentProps {
   http: CoreStart['http'];
-  savedObjects?: CoreStart['savedObjects'];
-  dataSourceEnabled?: boolean;
-  dataSourceManagement?: DataSourceManagementPluginSetup;
+  dataSourceId?: string;
   onAskAI?: () => void;
 }
 
 export const ExperimentListing: React.FC<ExperimentListingProps> = ({
   http,
   history,
-  savedObjects,
-  dataSourceEnabled = false,
-  dataSourceManagement,
+  dataSourceId,
   onAskAI,
 }) => {
   const { dateFormat } = useConfig();
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [selectedDataSource, setSelectedDataSource] = useState<string>('');
   const experimentService = new ExperimentService(http);
 
   const [showDeleteExperimentModal, setShowDeleteExperimentModal] = useState(false);
@@ -97,7 +90,7 @@ export const ExperimentListing: React.FC<ExperimentListingProps> = ({
   useEffect(() => {
     setTableData([]);
     setRefreshKey((prev) => prev + 1);
-  }, [selectedDataSource]);
+  }, [dataSourceId]);
 
   // Custom hook for experiment polling
   const useExperimentPolling = () => {
@@ -130,7 +123,7 @@ export const ExperimentListing: React.FC<ExperimentListingProps> = ({
 
         setIsBackgroundRefreshing(true);
         try {
-          const parseResults = await experimentService.getExperiments(selectedDataSource || undefined);
+          const parseResults = await experimentService.getExperiments(dataSourceId);
 
           if (parseResults.success) {
             const updatedList = parseResults.data;
@@ -261,7 +254,7 @@ export const ExperimentListing: React.FC<ExperimentListingProps> = ({
 
     setIsLoading(true);
     try {
-      await experimentService.deleteExperiment(experimentToDelete.id, selectedDataSource || undefined);
+      await experimentService.deleteExperiment(experimentToDelete.id, dataSourceId);
 
       // Close modal and clear state first
       setShowDeleteExperimentModal(false);
@@ -289,7 +282,7 @@ export const ExperimentListing: React.FC<ExperimentListingProps> = ({
 
     setIsLoading(true);
     try {
-      await experimentService.deleteScheduledExperiment(scheduledForExperiment.id, selectedDataSource || undefined);
+      await experimentService.deleteScheduledExperiment(scheduledForExperiment.id, dataSourceId);
 
       // Close modal and clear state first
       setShowDeleteScheduleModal(false);
@@ -319,7 +312,7 @@ export const ExperimentListing: React.FC<ExperimentListingProps> = ({
       await experimentService.createScheduledExperiment(JSON.stringify({
         experimentId: experimentToSchedule.id,
         cronExpression: `${cronExpression.trim()}`
-      }), selectedDataSource || undefined);
+      }), dataSourceId);
 
       setShowScheduleExperimentModal(false);
       setExperimentToSchedule(null);
@@ -342,7 +335,7 @@ export const ExperimentListing: React.FC<ExperimentListingProps> = ({
   const getScheduledExperiment = async (experimentId: string) => {
     setIsLoading(true);
     try {
-      const scheduledExperiment = (await experimentService.getScheduledExperiment(experimentId, selectedDataSource || undefined));
+      const scheduledExperiment = (await experimentService.getScheduledExperiment(experimentId, dataSourceId));
       return scheduledExperiment.data;
     } catch (err) {
       console.error('Failed to retrieve schedule', err);
@@ -367,7 +360,7 @@ export const ExperimentListing: React.FC<ExperimentListingProps> = ({
       ) => (
         <EuiButtonEmpty
           size="xs"
-          {...reactRouterNavigate(history, `${Routes.ExperimentViewPrefix}/${experiment.id}${selectedDataSource ? `?dataSourceId=${selectedDataSource}` : ''}`)}
+          {...reactRouterNavigate(history, `${Routes.ExperimentViewPrefix}/${experiment.id}${dataSourceId ? `?dataSourceId=${dataSourceId}` : ''}`)}
         >
           {printType(type)}
         </EuiButtonEmpty>
@@ -515,7 +508,7 @@ export const ExperimentListing: React.FC<ExperimentListingProps> = ({
     setIsLoading(true);
     setError(null);
     try {
-      const parseResults = await experimentService.getExperiments(selectedDataSource || undefined);
+      const parseResults = await experimentService.getExperiments(dataSourceId);
 
       if (!parseResults.success) {
         console.error(parseResults.errors);
@@ -586,19 +579,6 @@ export const ExperimentListing: React.FC<ExperimentListingProps> = ({
 
       <EuiSpacer size="m" />
 
-      {dataSourceEnabled && dataSourceManagement && savedObjects && (
-        <DataSourceSelector
-          dataSourceEnabled={dataSourceEnabled}
-          dataSourceManagement={dataSourceManagement}
-          savedObjects={savedObjects}
-          selectedDataSource={selectedDataSource}
-          setSelectedDataSource={setSelectedDataSource}
-          excludeEngineTypes={['AnalyticEngine']}
-        />
-      )}
-
-      <EuiSpacer size="m" />
-
       {onAskAI && !isAICalloutDismissed && (
         <>
           <EuiCallOut
@@ -642,7 +622,7 @@ export const ExperimentListing: React.FC<ExperimentListingProps> = ({
         )}
         {!error && (
           <TableListView
-            key={`${refreshKey}-${selectedDataSource}`}
+            key={`${refreshKey}-${dataSourceId ?? ''}`}
             headingId="experimentListingHeading"
             entityName="Experiment"
             entityNamePlural="Experiments"

--- a/public/components/judgment/__tests__/judgment_create.test.tsx
+++ b/public/components/judgment/__tests__/judgment_create.test.tsx
@@ -111,20 +111,46 @@ describe('JudgmentCreate', () => {
     expect(mockHistory.push).toHaveBeenCalledWith('/judgment');
   });
 
-  it('should render with data source enabled', () => {
+  it('forwards dataSourceId to the form hook', () => {
+    const captured: any[] = [];
+    const useJudgmentFormMock = jest.requireMock('../hooks/use_judgment_form');
+    useJudgmentFormMock.useJudgmentForm = jest.fn((...args: any[]) => {
+      captured.push(args);
+      return {
+        formData: { name: '', type: 'LLM_JUDGMENT', ignoreFailure: false, contextFields: [] },
+        updateFormData: jest.fn(),
+        selectedQuerySet: [],
+        setSelectedQuerySet: jest.fn(),
+        selectedSearchConfigs: [],
+        setSelectedSearchConfigs: jest.fn(),
+        selectedModel: [],
+        setSelectedModel: jest.fn(),
+        querySetOptions: [],
+        searchConfigOptions: [],
+        modelOptions: [],
+        isLoadingQuerySets: false,
+        isLoadingSearchConfigs: false,
+        isLoadingModels: false,
+        nameError: '',
+        newContextField: '',
+        setNewContextField: jest.fn(),
+        addContextField: jest.fn(),
+        removeContextField: jest.fn(),
+        validateAndSubmit: jest.fn(),
+      };
+    });
+
     render(
-      <JudgmentCreate 
-        http={mockHttp} 
-        notifications={mockNotifications} 
+      <JudgmentCreate
+        http={mockHttp}
+        notifications={mockNotifications}
         history={mockHistory}
-        dataSourceEnabled={true}
-        dataSourceManagement={{ ui: { DataSourceSelector: () => <div>DataSourceSelector</div> } } as any}
-        savedObjects={{ client: {} } as any}
-        navigation={{} as any}
-        setActionMenu={jest.fn()}
+        dataSourceId="foo-ds"
       />
     );
 
-    expect(screen.getByText('DataSourceSelector')).toBeInTheDocument();
+    // Signature: (http, notifications, dataSourceId)
+    const lastCall = captured[captured.length - 1];
+    expect(lastCall[2]).toBe('foo-ds');
   });
 });

--- a/public/components/judgment/__tests__/use_judgment_form.test.ts
+++ b/public/components/judgment/__tests__/use_judgment_form.test.ts
@@ -390,5 +390,37 @@ describe('useJudgmentForm', () => {
     expect(result.current.parsedJudgments).toEqual([]);
     expect(result.current.importedRatings).toEqual([]);
   });
+
+  describe('dataSourceId propagation', () => {
+    it('runs the initial fetch with no dataSourceId when none is supplied', async () => {
+      renderHook(() => useJudgmentForm(mockHttp, mockNotifications));
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      expect(mockService.fetchUbiIndexes).toHaveBeenCalledWith(undefined);
+    });
+
+    it('refetches when dataSourceId changes', async () => {
+      const { rerender } = renderHook(
+        ({ dataSourceId }: { dataSourceId: string | undefined }) =>
+          useJudgmentForm(mockHttp, mockNotifications, dataSourceId),
+        { initialProps: { dataSourceId: undefined as string | undefined } }
+      );
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      rerender({ dataSourceId: 'foo-ds' });
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      expect(mockService.fetchUbiIndexes).toHaveBeenCalledWith('foo-ds');
+    });
+  });
 });
 

--- a/public/components/judgment/hooks/use_judgment_form.ts
+++ b/public/components/judgment/hooks/use_judgment_form.ts
@@ -11,7 +11,11 @@ import { buildJudgmentPayload } from '../utils/form_processor';
 import { processJudgmentFile } from '../utils/judgment_file_processor';
 import moment from 'moment';
 
-export const useJudgmentForm = (http: any, notifications: any, dataSourceId?: string, dataSourceEnabled = false) => {
+export const useJudgmentForm = (
+  http: any,
+  notifications: any,
+  dataSourceId?: string
+) => {
   // Form data
   const [formData, setFormData] = useState<JudgmentFormData>({
     name: '',
@@ -107,7 +111,7 @@ export const useJudgmentForm = (http: any, notifications: any, dataSourceId?: st
         setModelOptions([]);
       }).finally(() => setIsLoadingModels(false)),
     ]);
-  }, [formData.type, http, notifications.toasts, dataSourceId, dataSourceEnabled]);
+  }, [formData.type, http, notifications.toasts, dataSourceId]);
 
   useEffect(() => {
     fetchData();

--- a/public/components/judgment/types.ts
+++ b/public/components/judgment/types.ts
@@ -43,9 +43,7 @@ export interface JudgmentCreateProps {
   http: any;
   notifications: any;
   history: any;
-  savedObjects?: any;
-  dataSourceEnabled?: boolean;
-  dataSourceManagement?: any;
+  dataSourceId?: string;
 }
 
 // Re-export prompt template types

--- a/public/components/judgment/views/judgment_create.tsx
+++ b/public/components/judgment/views/judgment_create.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useCallback, useState } from 'react';
+import React, { useCallback } from 'react';
 import { withRouter } from 'react-router-dom';
 import {
   EuiButton,
@@ -17,17 +17,13 @@ import { JudgmentCreateProps, JudgmentType } from '../types';
 import { useJudgmentForm } from '../hooks/use_judgment_form';
 import { JudgmentPreview } from '../components/judgment_preview';
 import { JudgmentForm } from '../components/judgment_form';
-import { DataSourceSelector } from '../../common/datasource_selector';
 
 export const JudgmentCreate: React.FC<JudgmentCreateProps> = ({
   http,
   notifications,
   history,
-  savedObjects,
-  dataSourceEnabled = false,
-  dataSourceManagement,
+  dataSourceId,
 }) => {
-  const [selectedDataSource, setSelectedDataSource] = useState<string>('');
   const {
     formData,
     updateFormData,
@@ -55,7 +51,11 @@ export const JudgmentCreate: React.FC<JudgmentCreateProps> = ({
     dateRangeError,
     parsedJudgments,
     parseSummary,
-  } = useJudgmentForm(http, notifications, selectedDataSource || undefined, dataSourceEnabled);
+  } = useJudgmentForm(
+    http,
+    notifications,
+    dataSourceId
+  );
 
   const handleSubmit = useCallback(() => {
     validateAndSubmit(() => {
@@ -96,15 +96,6 @@ export const JudgmentCreate: React.FC<JudgmentCreateProps> = ({
 
       <EuiPanel hasBorder={true}>
         <EuiFlexItem>
-          {dataSourceEnabled && dataSourceManagement && savedObjects && (
-            <DataSourceSelector
-              dataSourceEnabled={dataSourceEnabled}
-              dataSourceManagement={dataSourceManagement}
-              savedObjects={savedObjects}
-              selectedDataSource={selectedDataSource}
-              setSelectedDataSource={setSelectedDataSource}
-            />
-          )}
           <JudgmentForm
             formData={formData}
             updateFormData={updateFormData}

--- a/public/components/judgment/views/judgment_listing.tsx
+++ b/public/components/judgment/views/judgment_listing.tsx
@@ -19,13 +19,11 @@ import {
 } from '@elastic/eui';
 import moment from 'moment';
 import { CoreStart } from '../../../../../../src/core/public';
-import { DataSourceManagementPluginSetup } from '../../../../../../src/plugins/data_source_management/public';
 import {
   reactRouterNavigate,
   TableListView,
 } from '../../../../../../src/plugins/opensearch_dashboards_react/public';
 import { DeleteModal } from '../../common/DeleteModal';
-import { DataSourceSelector } from '../../common/datasource_selector';
 import { useConfig } from '../../../contexts/date_format_context';
 import { Routes } from '../../../../common';
 import { useJudgmentList } from '../hooks/use_judgment_list';
@@ -33,20 +31,15 @@ import { getStatusColor } from '../../common_utils/status';
 
 interface JudgmentListingProps extends RouteComponentProps {
   http: CoreStart['http'];
-  savedObjects?: CoreStart['savedObjects'];
-  dataSourceEnabled?: boolean;
-  dataSourceManagement?: DataSourceManagementPluginSetup;
+  dataSourceId?: string;
 }
 
 export const JudgmentListing: React.FC<JudgmentListingProps> = ({
   http,
   history,
-  savedObjects,
-  dataSourceEnabled = false,
-  dataSourceManagement,
+  dataSourceId,
 }) => {
   const { dateFormat } = useConfig();
-  const [selectedDataSource, setSelectedDataSource] = useState<string>('');
   const {
     isLoading,
     error,
@@ -55,7 +48,7 @@ export const JudgmentListing: React.FC<JudgmentListingProps> = ({
     refreshKey,
     findJudgments,
     deleteJudgment,
-  } = useJudgmentList(http, selectedDataSource || undefined);
+  } = useJudgmentList(http, dataSourceId);
 
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [judgmentToDelete, setJudgmentToDelete] = useState<any>(null);
@@ -84,7 +77,7 @@ export const JudgmentListing: React.FC<JudgmentListingProps> = ({
         <>
           <EuiButtonEmpty
             size="xs"
-            {...reactRouterNavigate(history, `${Routes.JudgmentViewPrefix}/${judgment.id}${selectedDataSource ? `?dataSourceId=${selectedDataSource}` : ''}`)}
+            {...reactRouterNavigate(history, `${Routes.JudgmentViewPrefix}/${judgment.id}${dataSourceId ? `?dataSourceId=${dataSourceId}` : ''}`)}
           >
             {name}
           </EuiButtonEmpty>
@@ -155,16 +148,6 @@ export const JudgmentListing: React.FC<JudgmentListingProps> = ({
         ]}
       />
 
-      {dataSourceEnabled && dataSourceManagement && savedObjects && (
-        <DataSourceSelector
-          dataSourceEnabled={dataSourceEnabled}
-          dataSourceManagement={dataSourceManagement}
-          savedObjects={savedObjects}
-          selectedDataSource={selectedDataSource}
-          setSelectedDataSource={setSelectedDataSource}
-        />
-      )}
-
       <EuiFlexItem>
         {error ? (
           <EuiCallOut title="Error" color="danger">
@@ -172,7 +155,7 @@ export const JudgmentListing: React.FC<JudgmentListingProps> = ({
           </EuiCallOut>
         ) : (
           <TableListView
-            key={`${refreshKey}-${selectedDataSource}`}
+            key={`${refreshKey}-${dataSourceId ?? ''}`}
             headingId="judgmentListingHeading"
             entityName="Judgment"
             entityNamePlural="Judgments"

--- a/public/components/query_set/__tests__/query_set_create.test.tsx
+++ b/public/components/query_set/__tests__/query_set_create.test.tsx
@@ -28,7 +28,6 @@ jest.mock('../components/query_preview', () => ({
     <div data-test-subj="query-preview">{parsedQueries.length} queries</div>
   ),
 }));
-
 const mockFormState = {
   name: 'Test Query Set',
   setName: jest.fn(),
@@ -68,6 +67,7 @@ const mockFormState = {
 
 const mockQuerySetServiceInstance = {
   createQuerySet: jest.fn(),
+  fetchUbiIndexes: jest.fn(),
 };
 
 describe('QuerySetCreate', () => {
@@ -88,6 +88,7 @@ describe('QuerySetCreate', () => {
 
     // Reset mocks
     jest.clearAllMocks();
+    mockQuerySetServiceInstance.fetchUbiIndexes.mockResolvedValue([]);
 
     // Mock the hook return value
     (require('../hooks/use_query_set_form').useQuerySetForm as jest.Mock).mockReturnValue(
@@ -192,5 +193,38 @@ describe('QuerySetCreate', () => {
 
     expect(screen.getByTestId('query-preview')).toBeInTheDocument();
     expect(screen.getByText('2 queries')).toBeInTheDocument();
+  });
+
+  describe('UBI index fetch with dataSourceId prop', () => {
+    const renderWithDataSourceId = (dataSourceId?: string) =>
+      render(
+        <Router history={history}>
+          <QuerySetCreate
+            http={mockHttp}
+            notifications={mockNotifications}
+            history={history}
+            location={history.location}
+            match={{ params: {}, isExact: true, path: '', url: '' }}
+            dataSourceId={dataSourceId}
+          />
+        </Router>
+      );
+
+    it('fetches UBI indexes against the local cluster when no dataSourceId is supplied', async () => {
+      renderWithDataSourceId(undefined);
+
+      await waitFor(() => {
+        expect(mockQuerySetServiceInstance.fetchUbiIndexes).toHaveBeenCalledTimes(1);
+      });
+      expect(mockQuerySetServiceInstance.fetchUbiIndexes).toHaveBeenCalledWith(undefined);
+    });
+
+    it('forwards dataSourceId to fetchUbiIndexes', async () => {
+      renderWithDataSourceId('foo-ds');
+
+      await waitFor(() => {
+        expect(mockQuerySetServiceInstance.fetchUbiIndexes).toHaveBeenCalledWith('foo-ds');
+      });
+    });
   });
 });

--- a/public/components/query_set/views/query_set_create.tsx
+++ b/public/components/query_set/views/query_set_create.tsx
@@ -14,34 +14,27 @@ import {
 import React, { useCallback, useMemo, useState, useEffect } from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { CoreStart, NotificationsStart } from '../../../../../../core/public';
-import { DataSourceManagementPluginSetup } from '../../../../../../src/plugins/data_source_management/public';
 import { QuerySetService } from '../services/query_set_service';
 import { useQuerySetForm } from '../hooks/use_query_set_form';
 import { QuerySetForm } from '../components/query_set_form';
 import { QueryPreview } from '../components/query_preview';
-import { DataSourceSelector } from '../../common/datasource_selector';
 
 interface QuerySetCreateProps extends RouteComponentProps {
   http: CoreStart['http'];
   notifications: NotificationsStart;
-  savedObjects?: CoreStart['savedObjects'];
-  dataSourceEnabled?: boolean;
-  dataSourceManagement?: DataSourceManagementPluginSetup;
+  dataSourceId?: string;
 }
 
 export const QuerySetCreate: React.FC<QuerySetCreateProps> = ({
   http,
   notifications,
   history,
-  savedObjects,
-  dataSourceEnabled = false,
-  dataSourceManagement,
+  dataSourceId,
 }) => {
   const formState = useQuerySetForm();
   const querySetService = useMemo(() => new QuerySetService(http), [http]);
   const filePickerId = useMemo(() => `filePicker-${Math.random().toString(36).substr(2, 9)}`, []);
-  const [selectedDataSource, setSelectedDataSource] = useState<string>('');
-  
+
   const [indexOptions, setIndexOptions] = useState<Array<{ label: string; value: string }>>([]);
   const [isLoadingIndexes, setIsLoadingIndexes] = useState(false);
 
@@ -49,7 +42,7 @@ export const QuerySetCreate: React.FC<QuerySetCreateProps> = ({
     const fetchIndexes = async () => {
       setIsLoadingIndexes(true);
       try {
-        const indexes = await querySetService.fetchUbiIndexes(selectedDataSource || undefined);
+        const indexes = await querySetService.fetchUbiIndexes(dataSourceId);
         setIndexOptions(indexes);
       } catch (error) {
         notifications.toasts.addDanger('Failed to fetch UBI indexes');
@@ -62,7 +55,7 @@ export const QuerySetCreate: React.FC<QuerySetCreateProps> = ({
     fetchIndexes();
     formState.setUbiQueriesIndex('');
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [querySetService, selectedDataSource]);
+  }, [querySetService, dataSourceId]);
 
   const createQuerySet = useCallback(async () => {
     if (!formState.isFormValid()) {
@@ -79,7 +72,7 @@ export const QuerySetCreate: React.FC<QuerySetCreateProps> = ({
         ...(formState.ubiQueriesIndex && { ubiQueriesIndex: formState.ubiQueriesIndex }),
       };
 
-      await querySetService.createQuerySet(querySetData, formState.isManualInput, selectedDataSource || undefined);
+      await querySetService.createQuerySet(querySetData, formState.isManualInput, dataSourceId);
       notifications.toasts.addSuccess(`Query set "${formState.name}" created successfully`);
       history.push('/querySet');
     } catch (err) {
@@ -135,16 +128,7 @@ export const QuerySetCreate: React.FC<QuerySetCreateProps> = ({
 
       <EuiPanel hasBorder={true}>
         <EuiFlexItem>
-          {dataSourceEnabled && dataSourceManagement && savedObjects && (
-            <DataSourceSelector
-              dataSourceEnabled={dataSourceEnabled}
-              dataSourceManagement={dataSourceManagement}
-              savedObjects={savedObjects}
-              selectedDataSource={selectedDataSource}
-              setSelectedDataSource={setSelectedDataSource}
-            />
-          )}
-          <QuerySetForm 
+          <QuerySetForm
             formState={formState} 
             filePickerId={filePickerId}
             indexOptions={indexOptions}

--- a/public/components/query_set/views/query_set_listing.tsx
+++ b/public/components/query_set/views/query_set_listing.tsx
@@ -7,31 +7,24 @@ import React, { useState } from 'react';
 import { EuiFlexItem, EuiCallOut, EuiPageTemplate, EuiPageHeader, EuiButton } from '@elastic/eui';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { CoreStart } from '../../../../../../src/core/public';
-import { DataSourceManagementPluginSetup } from '../../../../../../src/plugins/data_source_management/public';
 import { Routes } from '../../../../common';
 import { DeleteModal } from '../../common/DeleteModal';
-import { DataSourceSelector } from '../../common/datasource_selector';
 import { QuerySetTable } from '../components/query_set_table';
 import { useQuerySetList } from '../hooks/use_query_set_list';
 
 interface QuerySetListingProps extends RouteComponentProps {
   http: CoreStart['http'];
-  savedObjects?: CoreStart['savedObjects'];
-  dataSourceEnabled?: boolean;
-  dataSourceManagement?: DataSourceManagementPluginSetup;
+  dataSourceId?: string;
 }
 
 export const QuerySetListing: React.FC<QuerySetListingProps> = ({
   http,
   history,
-  savedObjects,
-  dataSourceEnabled = false,
-  dataSourceManagement,
+  dataSourceId,
 }) => {
-  const [selectedDataSource, setSelectedDataSource] = useState<string>('');
   const { isLoading, error, refreshKey, findQuerySets, deleteQuerySet, setError } = useQuerySetList(
     http,
-    selectedDataSource || undefined
+    dataSourceId
   );
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [querySetToDelete, setQuerySetToDelete] = useState<any>(null);
@@ -71,16 +64,6 @@ export const QuerySetListing: React.FC<QuerySetListingProps> = ({
         ]}
       />
 
-      {dataSourceEnabled && dataSourceManagement && savedObjects && (
-        <DataSourceSelector
-          dataSourceEnabled={dataSourceEnabled}
-          dataSourceManagement={dataSourceManagement}
-          savedObjects={savedObjects}
-          selectedDataSource={selectedDataSource}
-          setSelectedDataSource={setSelectedDataSource}
-        />
-      )}
-
       <EuiFlexItem>
         {error ? (
           <EuiCallOut title="Error" color="danger">
@@ -93,7 +76,7 @@ export const QuerySetListing: React.FC<QuerySetListingProps> = ({
             findItems={findQuerySets}
             onDelete={handleDeleteClick}
             history={history}
-            dataSourceId={selectedDataSource || undefined}
+            dataSourceId={dataSourceId}
           />
         )}
       </EuiFlexItem>

--- a/public/components/resource_management_home/resource_management_tabs.tsx
+++ b/public/components/resource_management_home/resource_management_tabs.tsx
@@ -20,8 +20,6 @@ import ExperimentListingWithRoute from '../experiment/views/experiment_listing';
 import { useOpenSearchDashboards } from '../../../../../src/plugins/opensearch_dashboards_react/public';
 import { JudgmentCreateWithRouter } from '../judgment';
 import { JudgmentListing, JudgmentView } from '../judgment';
-import { useContext } from 'react';
-import { ConfigContext } from '../../contexts/date_format_context';
 
 const TAB_STYLES = {
   mainTabs: {
@@ -59,8 +57,7 @@ export const ResourceManagementTabs = ({
   entityAction,
   entityId,
 }: ResourceManagementTabsProps) => {
-  const { http, notifications, savedObjects } = useOpenSearchDashboards().services;
-  const { dataSourceEnabled, dataSourceManagement } = useContext(ConfigContext);
+  const { http, notifications } = useOpenSearchDashboards().services;
 
   const selectedMainTabId = entity ? entity : 'experiment';
   // HACK: we map view to list, because we show the view pane under the list tab
@@ -133,12 +130,9 @@ export const ResourceManagementTabs = ({
               )}
               {entityAction === 'view' ? <QuerySetView http={http} id={entityId} /> : <></>}
               {selectedSubTabs === 'create' ? (
-                <QuerySetCreate 
-                  http={http} 
+                <QuerySetCreate
+                  http={http}
                   notifications={notifications}
-                  savedObjects={savedObjects}
-                  dataSourceEnabled={dataSourceEnabled}
-                  dataSourceManagement={dataSourceManagement}
                 />
               ) : (
                 <></>
@@ -167,12 +161,9 @@ export const ResourceManagementTabs = ({
                 <></>
               )}
               {selectedSubTabs === 'create' ? (
-                <SearchConfigurationCreate 
-                  http={http} 
+                <SearchConfigurationCreate
+                  http={http}
                   notifications={notifications}
-                  savedObjects={savedObjects}
-                  dataSourceEnabled={dataSourceEnabled}
-                  dataSourceManagement={dataSourceManagement}
                 />
               ) : (
                 <></>
@@ -201,9 +192,6 @@ export const ResourceManagementTabs = ({
                   http={http}
                   notifications={notifications}
                   history={history}
-                  savedObjects={savedObjects}
-                  dataSourceEnabled={dataSourceEnabled}
-                  dataSourceManagement={dataSourceManagement}
                 />
               ) : (
                 <></>

--- a/public/components/search_configuration/__tests__/search_configuration_create.test.tsx
+++ b/public/components/search_configuration/__tests__/search_configuration_create.test.tsx
@@ -172,20 +172,24 @@ describe('SearchConfigurationCreate', () => {
     expect(screen.getByTestId('createSearchConfigurationButton')).toBeInTheDocument();
   });
 
-  it('should render with data source enabled', () => {
+  it('forwards dataSourceId to the form hook', () => {
+    const captured: any[] = [];
+    const useFormMock = jest.requireMock('../hooks/use_search_configuration_form');
+    useFormMock.useSearchConfigurationForm = jest.fn((props: any) => {
+      captured.push(props);
+      return mockHookReturn;
+    });
+
     render(
       <SearchConfigurationCreate
         http={mockHttp}
         notifications={mockNotifications}
         history={mockHistory}
-        dataSourceEnabled={true}
-        dataSourceManagement={{ ui: { DataSourceSelector: () => <div>DataSourceSelector</div> } } as any}
-        savedObjects={{ client: {} } as any}
-        navigation={{} as any}
-        setActionMenu={jest.fn()}
+        dataSourceId="foo-ds"
       />
     );
 
-    expect(screen.getByText('DataSourceSelector')).toBeInTheDocument();
+    const lastCall = captured[captured.length - 1];
+    expect(lastCall.dataSourceId).toBe('foo-ds');
   });
 });

--- a/public/components/search_configuration/__tests__/use_search_configuration_form.test.ts
+++ b/public/components/search_configuration/__tests__/use_search_configuration_form.test.ts
@@ -382,4 +382,46 @@ describe('useSearchConfigurationForm', () => {
       searchPipeline: 'pipeline1',
     }, undefined);
   });
+
+  describe('dataSourceId propagation', () => {
+    it('runs the initial fetch with no dataSourceId when none is supplied', async () => {
+      renderHook(() =>
+        useSearchConfigurationForm({ http: mockHttp, notifications: mockNotifications })
+      );
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      expect(mockService.fetchIndexes).toHaveBeenCalledTimes(1);
+      expect(mockService.fetchIndexes).toHaveBeenCalledWith(undefined);
+      expect(mockService.fetchPipelines).toHaveBeenCalledTimes(1);
+      expect(mockService.fetchPipelines).toHaveBeenCalledWith(undefined);
+    });
+
+    it('refetches when dataSourceId changes', async () => {
+      const { rerender } = renderHook(
+        ({ dataSourceId }: { dataSourceId: string | undefined }) =>
+          useSearchConfigurationForm({
+            http: mockHttp,
+            notifications: mockNotifications,
+            dataSourceId,
+          }),
+        { initialProps: { dataSourceId: undefined as string | undefined } }
+      );
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      rerender({ dataSourceId: 'foo-ds' });
+
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      expect(mockService.fetchIndexes).toHaveBeenCalledWith('foo-ds');
+      expect(mockService.fetchPipelines).toHaveBeenCalledWith('foo-ds');
+    });
+  });
 });

--- a/public/components/search_configuration/hooks/use_search_configuration_form.ts
+++ b/public/components/search_configuration/hooks/use_search_configuration_form.ts
@@ -19,7 +19,6 @@ export interface UseSearchConfigurationFormProps {
   notifications: NotificationsStart;
   onSuccess?: () => void;
   dataSourceId?: string;
-  dataSourceEnabled?: boolean;
 }
 
 export interface UseSearchConfigurationFormReturn {
@@ -65,7 +64,6 @@ export const useSearchConfigurationForm = ({
   notifications,
   onSuccess,
   dataSourceId,
-  dataSourceEnabled = false,
 }: UseSearchConfigurationFormProps): UseSearchConfigurationFormReturn => {
   // Form state
   const [name, setName] = useState('');
@@ -112,7 +110,7 @@ export const useSearchConfigurationForm = ({
     };
 
     fetchIndexes();
-  }, [dataSourceId, dataSourceEnabled]);
+  }, [dataSourceId]);
 
   // Fetch pipelines on component mount
   useEffect(() => {
@@ -135,7 +133,7 @@ export const useSearchConfigurationForm = ({
     };
 
     fetchPipelines();
-  }, [dataSourceId, dataSourceEnabled]);
+  }, [dataSourceId]);
 
   // Validate name field on blur
   const validateNameField = useCallback((e: React.FocusEvent<HTMLInputElement>) => {

--- a/public/components/search_configuration/views/search_configuration_create.tsx
+++ b/public/components/search_configuration/views/search_configuration_create.tsx
@@ -12,32 +12,25 @@ import {
   EuiFlexGroup,
   EuiFlexItem,
 } from '@elastic/eui';
-import React, { useCallback, useState } from 'react';
+import React, { useCallback } from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { CoreStart, NotificationsStart } from '../../../../../../src/core/public';
-import { DataSourceManagementPluginSetup } from '../../../../../../src/plugins/data_source_management/public';
 import { SearchConfigurationForm } from '../components/search_configuration_form';
 import { ValidationPanel } from '../components/validation_panel';
 import { useSearchConfigurationForm } from '../hooks/use_search_configuration_form';
-import { DataSourceSelector } from '../../common/datasource_selector';
 
 interface SearchConfigurationCreateProps extends RouteComponentProps {
   http: CoreStart['http'];
   notifications: NotificationsStart;
-  savedObjects?: CoreStart['savedObjects'];
-  dataSourceEnabled?: boolean;
-  dataSourceManagement?: DataSourceManagementPluginSetup;
+  dataSourceId?: string;
 }
 
 export const SearchConfigurationCreate: React.FC<SearchConfigurationCreateProps> = ({
   http,
   notifications,
   history,
-  savedObjects,
-  dataSourceEnabled = false,
-  dataSourceManagement,
+  dataSourceId,
 }) => {
-  const [selectedDataSource, setSelectedDataSource] = useState<string>('');
   const {
     // Form state
     name,
@@ -76,8 +69,7 @@ export const SearchConfigurationCreate: React.FC<SearchConfigurationCreateProps>
     http,
     notifications,
     onSuccess: () => history.push('/searchConfiguration'),
-    dataSourceId: selectedDataSource || undefined,
-    dataSourceEnabled,
+    dataSourceId,
   });
 
   // Handle cancel action
@@ -114,16 +106,6 @@ export const SearchConfigurationCreate: React.FC<SearchConfigurationCreateProps>
       <EuiFlexGroup>
         <EuiFlexItem grow={7}>
           <EuiPanel hasBorder={true}>
-            {dataSourceEnabled && dataSourceManagement && savedObjects && (
-              <DataSourceSelector
-                dataSourceEnabled={dataSourceEnabled}
-                dataSourceManagement={dataSourceManagement}
-                savedObjects={savedObjects}
-                selectedDataSource={selectedDataSource}
-                setSelectedDataSource={setSelectedDataSource}
-                excludeEngineTypes={['AnalyticEngine']}
-              />
-            )}
             <SearchConfigurationForm
               name={name}
               setName={setName}

--- a/public/components/search_configuration/views/search_configuration_listing.tsx
+++ b/public/components/search_configuration/views/search_configuration_listing.tsx
@@ -22,35 +22,28 @@ import {
   TableListView,
 } from '../../../../../../src/plugins/opensearch_dashboards_react/public';
 import { CoreStart } from '../../../../../../src/core/public';
-import { DataSourceManagementPluginSetup } from '../../../../../../src/plugins/data_source_management/public';
 import { Routes } from '../../../../common';
 import { DeleteModal } from '../../common/DeleteModal';
-import { DataSourceSelector } from '../../common/datasource_selector';
 import { useConfig } from '../../../contexts/date_format_context';
 import { useSearchConfigurationList } from '../hooks/use_search_configuration_list';
 
 interface SearchConfigurationListingProps extends RouteComponentProps {
   http: CoreStart['http'];
-  savedObjects?: CoreStart['savedObjects'];
-  dataSourceEnabled?: boolean;
-  dataSourceManagement?: DataSourceManagementPluginSetup;
+  dataSourceId?: string;
 }
 
 export const SearchConfigurationListing: React.FC<SearchConfigurationListingProps> = ({
   http,
   history,
-  savedObjects,
-  dataSourceEnabled = false,
-  dataSourceManagement,
+  dataSourceId,
 }) => {
   const { dateFormat } = useConfig();
-  const [selectedDataSource, setSelectedDataSource] = useState<string>('');
   const {
     isLoading,
     error,
     findSearchConfigurations,
     deleteSearchConfiguration,
-  } = useSearchConfigurationList(http, selectedDataSource || undefined);
+  } = useSearchConfigurationList(http, dataSourceId);
 
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [configToDelete, setConfigToDelete] = useState<any>(null);
@@ -77,7 +70,7 @@ export const SearchConfigurationListing: React.FC<SearchConfigurationListingProp
             size="xs"
             {...reactRouterNavigate(
               history,
-              `${Routes.SearchConfigurationViewPrefix}/${searchConfiguration.id}${selectedDataSource ? `?dataSourceId=${selectedDataSource}` : ''}`
+              `${Routes.SearchConfigurationViewPrefix}/${searchConfiguration.id}${dataSourceId ? `?dataSourceId=${dataSourceId}` : ''}`
             )}
           >
             {name}
@@ -171,17 +164,6 @@ export const SearchConfigurationListing: React.FC<SearchConfigurationListingProp
         ]}
       />
 
-      {dataSourceEnabled && dataSourceManagement && savedObjects && (
-        <DataSourceSelector
-          dataSourceEnabled={dataSourceEnabled}
-          dataSourceManagement={dataSourceManagement}
-          savedObjects={savedObjects}
-          selectedDataSource={selectedDataSource}
-          setSelectedDataSource={setSelectedDataSource}
-          excludeEngineTypes={['AnalyticEngine']}
-        />
-      )}
-
       <EuiFlexItem>
         {error ? (
           <EuiCallOut title="Error" color="danger">
@@ -189,7 +171,7 @@ export const SearchConfigurationListing: React.FC<SearchConfigurationListingProp
           </EuiCallOut>
         ) : (
           <TableListView
-            key={`${refreshKey}-${selectedDataSource}`}
+            key={`${refreshKey}-${dataSourceId ?? ''}`}
             headingId="searchConfigurationListingHeading"
             entityName="Search Configuration"
             entityNamePlural="Search Configurations"


### PR DESCRIPTION


### Description

Mount a single DataSourceSelectable menu in the OSD chrome header from SearchRelevancePage, with the selected dataSourceId tracked in URL query params so it survives reload, navigation, and sharing. Each listing, create, and template-configuration page now receives dataSourceId as a prop instead of rendering its own inline selector and managing its own useState.

The deferred-fetch gating in use_search_configuration_form and use_judgment_form is removed: the global menu mounts before any page, so dataSourceId arrives synchronously on the first render and the init-flag dance is no longer needed.

When MDS is disabled, any stale ?dataSourceId= in the URL is ignored during seeding so requests don't leak through to a server that has no dataSource plugin loaded.



https://github.com/user-attachments/assets/b61e7920-41fd-461f-918a-b36b941d68ba





### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test
  - [ ] Integration tests pass: `yarn cypress:run-without-security --config "baseUrl=http://localhost:5601" --spec "cypress/integration/plugins/search-relevance-dashboards/*.js"` (see [Developer Guide](DEVELOPER_GUIDE.md#integration-tests))
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).




