### PR TITLE
Make Query Set description optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Features
 
 ### Enhancements
+* Make Query Set description optional on create ([#758](https://github.com/opensearch-project/dashboards-search-relevance/issues/758))
 
 ### Bug Fixes
 * Hide AnalyticEngine data sources from DSL-dependent data source dropdowns ([#846](https://github.com/opensearch-project/dashboards-search-relevance/pull/846))

--- a/public/components/query_set/__tests__/query_set_create.test.tsx
+++ b/public/components/query_set/__tests__/query_set_create.test.tsx
@@ -148,6 +148,26 @@ describe('QuerySetCreate', () => {
     expect(history.location.pathname).toBe('/querySet');
   });
 
+  it('should submit when description is empty', async () => {
+    mockFormState.description = '';
+    mockQuerySetServiceInstance.createQuerySet.mockResolvedValue({ success: true });
+
+    renderComponent();
+
+    fireEvent.click(screen.getByTestId('createQuerySetButton'));
+
+    await waitFor(() => {
+      expect(mockQuerySetServiceInstance.createQuerySet).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'Test Query Set',
+          description: '',
+        }),
+        false,
+        undefined
+      );
+    });
+  });
+
   it('should handle form submission errors', async () => {
     const error = new Error('API Error');
     mockQuerySetServiceInstance.createQuerySet.mockRejectedValue(error);

--- a/public/components/query_set/__tests__/query_set_form.test.tsx
+++ b/public/components/query_set/__tests__/query_set_form.test.tsx
@@ -170,6 +170,20 @@ describe('QuerySetForm', () => {
     expect(mockFormState.setIsManualInput).toHaveBeenCalledWith(true);
   });
 
+  it('labels description as optional', () => {
+    render(
+      <QuerySetForm
+        formState={mockFormState}
+        filePickerId={mockFilePickerId}
+        indexOptions={mockIndexOptions}
+        isLoadingIndexes={false}
+      />
+    );
+
+    expect(screen.getByText('Description (optional)')).toBeInTheDocument();
+    expect(screen.getByText('Optionally describe the query set (< 250 characters).')).toBeInTheDocument();
+  });
+
   it('displays validation errors', () => {
     const formStateWithErrors = {
       ...mockFormState,

--- a/public/components/query_set/__tests__/query_set_service.test.ts
+++ b/public/components/query_set/__tests__/query_set_service.test.ts
@@ -174,5 +174,68 @@ describe('QuerySetService', () => {
         query: { dataSourceId: 'test-datasource' }
       });
     });
+
+    it('should omit description from POST body when empty', async () => {
+      const querySetData = {
+        name: 'Test Query Set',
+        description: '',
+        sampling: 'random',
+        querySetSize: 10,
+      };
+
+      mockHttp.post.mockResolvedValue({ success: true });
+
+      await service.createQuerySet(querySetData, false);
+
+      expect(mockHttp.post).toHaveBeenCalledWith('/api/relevancy/query_sets', {
+        body: JSON.stringify({
+          name: 'Test Query Set',
+          sampling: 'random',
+          querySetSize: 10,
+        }),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+    });
+
+    it('should omit description from POST body when whitespace only', async () => {
+      const querySetData = {
+        name: 'Test Query Set',
+        description: '   ',
+        sampling: 'random',
+        querySetSize: 10,
+      };
+
+      mockHttp.post.mockResolvedValue({ success: true });
+
+      await service.createQuerySet(querySetData, false);
+
+      expect(JSON.parse(mockHttp.post.mock.calls[0][1].body)).not.toHaveProperty('description');
+    });
+
+    it('should omit description from PUT body when empty', async () => {
+      const querySetData = {
+        name: 'Test Query Set',
+        description: '',
+        sampling: 'manual',
+        querySetQueries: [{ queryText: 'test query', referenceAnswer: 'test answer' }],
+      };
+
+      mockHttp.put.mockResolvedValue({ success: true });
+
+      await service.createQuerySet(querySetData, true);
+
+      expect(mockHttp.put).toHaveBeenCalledWith('/api/relevancy/query_sets', {
+        body: JSON.stringify({
+          name: 'Test Query Set',
+          sampling: 'manual',
+          querySetQueries: [{ queryText: 'test query', referenceAnswer: 'test answer' }],
+        }),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
+    });
   });
 });

--- a/public/components/query_set/__tests__/use_query_set_form.test.ts
+++ b/public/components/query_set/__tests__/use_query_set_form.test.ts
@@ -129,10 +129,10 @@ describe('useQuerySetForm', () => {
     expect(result.current.errors.nameError).toBe('Name is a required parameter.');
   });
 
-  it('validates description field correctly', () => {
+  it('allows empty description on blur validation', () => {
     (validation.validateForm as jest.Mock).mockReturnValue({
       nameError: '',
-      descriptionError: 'Description is required',
+      descriptionError: '',
       querySizeError: '',
       manualQueriesError: '',
     });
@@ -143,7 +143,7 @@ describe('useQuerySetForm', () => {
       result.current.validateField('description', '');
     });
 
-    expect(result.current.errors.descriptionError).toBe('Description is required');
+    expect(result.current.errors.descriptionError).toBe('');
   });
 
   it('validates form correctly', () => {

--- a/public/components/query_set/__tests__/validation.test.ts
+++ b/public/components/query_set/__tests__/validation.test.ts
@@ -38,7 +38,7 @@ describe('validation utils', () => {
       expect(errors.nameError).toBe('Name is a required parameter.');
     });
 
-    it('should return description error when description is empty', () => {
+    it('should allow empty description', () => {
       const formData = {
         name: 'Test Query Set',
         description: '',
@@ -49,7 +49,22 @@ describe('validation utils', () => {
 
       const errors = validateForm(formData);
 
-      expect(errors.descriptionError).toBe('Description is a required parameter.');
+      expect(errors.descriptionError).toBe('');
+      expect(hasValidationErrors(errors)).toBe(false);
+    });
+
+    it('should return description error when description is too long', () => {
+      const formData = {
+        name: 'Test Query Set',
+        description: 'a'.repeat(251),
+        querySetSize: 10,
+        manualQueries: '',
+        isManualInput: false,
+      };
+
+      const errors = validateForm(formData);
+
+      expect(errors.descriptionError).toBe('Description is too long (> 250 characters).');
     });
 
     it('should return query size error when size is invalid for non-manual input', () => {

--- a/public/components/query_set/components/query_set_form.tsx
+++ b/public/components/query_set/components/query_set_form.tsx
@@ -92,10 +92,10 @@ export const QuerySetForm: React.FC<QuerySetFormProps> = ({ formState, filePicke
       </EuiCompressedFormRow>
 
       <EuiCompressedFormRow
-        label="Description"
+        label="Description (optional)"
         isInvalid={errors.descriptionError.length > 0}
         error={errors.descriptionError}
-        helpText="Describe the query set (< 250 characters)."
+        helpText="Optionally describe the query set (< 250 characters)."
         fullWidth
       >
         <EuiCompressedTextArea

--- a/public/components/query_set/services/query_set_service.ts
+++ b/public/components/query_set/services/query_set_service.ts
@@ -9,7 +9,7 @@ import { DocumentsIndex } from '../../../types';
 
 export interface QuerySetData {
   name: string;
-  description: string;
+  description?: string;
   sampling: string;
   querySetSize?: number;
   querySetQueries?: Array<{ queryText: string; referenceAnswer: string }>;
@@ -33,17 +33,18 @@ export class QuerySetService {
   async createQuerySet(data: QuerySetData, isManualInput: boolean, dataSourceId?: string | null): Promise<any> {
     const endpoint = ServiceEndpoints.QuerySets;
     const method = isManualInput ? 'put' : 'post';
+    const descriptionField = data.description?.trim() ? { description: data.description } : {};
 
     const body = isManualInput
       ? {
           name: data.name,
-          description: data.description,
+          ...descriptionField,
           sampling: 'manual',
           querySetQueries: data.querySetQueries,
         }
       : {
           name: data.name,
-          description: data.description,
+          ...descriptionField,
           sampling: data.sampling,
           querySetSize: data.querySetSize,
           ...(data.ubiQueriesIndex && { ubiQueriesIndex: data.ubiQueriesIndex }),

--- a/public/components/query_set/utils/validation.ts
+++ b/public/components/query_set/utils/validation.ts
@@ -51,9 +51,7 @@ export const validateForm = (data: FormData): ValidationErrors => {
       'Name contains invalid characters (e.g., quotes, backslashes, or HTML tags).';
   }
 
-  if (!data.description.trim()) {
-    errors.descriptionError = 'Description is a required parameter.';
-  } else if (data.description.length > 250) {
+  if (data.description.trim() && data.description.length > 250) {
     errors.descriptionError = 'Description is too long (> 250 characters).';
   } else if (!isValidInputString(data.description)) {
     errors.descriptionError =

--- a/server/routes/search_relevance_route_service.ts
+++ b/server/routes/search_relevance_route_service.ts
@@ -23,7 +23,7 @@ export function registerSearchRelevanceRoutes(router: IRouter, dataSourceEnabled
       validate: {
         body: schema.object({
           name: schema.string(),
-          description: schema.string(),
+          description: schema.maybe(schema.string()),
           sampling: schema.string(),
           querySetSize: schema.number(),
           ubiQueriesIndex: schema.maybe(schema.string()),
@@ -39,7 +39,7 @@ export function registerSearchRelevanceRoutes(router: IRouter, dataSourceEnabled
       validate: {
         body: schema.object({
           name: schema.string(),
-          description: schema.string(),
+          description: schema.maybe(schema.string()),
           sampling: schema.string(),
           querySetQueries: schema.oneOf([
             schema.arrayOf(


### PR DESCRIPTION
## Description

Fixes #758.

The Query Set creation form currently requires a description even though Query Sets can be created without one.
The backend already supports creating Query Sets without a description. This change updates the UI, request payload generation, and route validation to allow omitted descriptions and avoid sending empty description values.

This change makes the Description field optional by:

* Removing frontend validation that required a description
* Omitting empty descriptions from API requests
* Updating route validation to allow missing descriptions
* Updating the UI label and help text to indicate the field is optional
* Adding test coverage for optional description handling

## Testing

* Added unit tests for validation and request payload generation
* Verified Query Sets can be created from the UI with a description
* Verified Query Sets can be created from the UI without a description
* Verified description length validation still works

Fixes #758.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
