### PR TITLE
Display reference answers in Query Set Details view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Enhancements
 
 ### Bug Fixes
+* Display stored reference answers on Query Set Details page ([#855](https://github.com/opensearch-project/dashboards-search-relevance/issues/855))
 * Hide AnalyticEngine data sources from DSL-dependent data source dropdowns ([#846](https://github.com/opensearch-project/dashboards-search-relevance/pull/846))
 
 ### Infrastructure

--- a/public/components/query_set/__tests__/query_set_queries_table.test.tsx
+++ b/public/components/query_set/__tests__/query_set_queries_table.test.tsx
@@ -5,7 +5,11 @@
 
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
-import { QuerySetQueriesTable } from '../components/query_set_queries_table';
+import {
+  QuerySetQueriesTable,
+  getReferenceAnswer,
+  normalizeQuerySetQueries,
+} from '../components/query_set_queries_table';
 
 // Mock TableListView
 let mockFindItems: any;
@@ -35,7 +39,7 @@ describe('QuerySetQueriesTable', () => {
     const { container } = render(<QuerySetQueriesTable queries={mockQueries} />);
 
     expect(container.querySelector('[data-testid="table-list-view"]')).toBeTruthy();
-    expect(container.querySelector('[data-testid="columns-count"]')?.textContent).toBe('1');
+    expect(container.querySelector('[data-testid="columns-count"]')?.textContent).toBe('2');
     expect(container.querySelector('[data-testid="queries-count"]')?.textContent).toBe('3');
   });
 
@@ -64,7 +68,7 @@ describe('QuerySetQueriesTable', () => {
   it('renders correct table column configuration', () => {
     const { container } = render(<QuerySetQueriesTable queries={mockQueries} />);
 
-    expect(container.querySelector('[data-testid="columns-count"]')?.textContent).toBe('1');
+    expect(container.querySelector('[data-testid="columns-count"]')?.textContent).toBe('2');
   });
 
   it('handles undefined queries gracefully', () => {
@@ -93,5 +97,65 @@ describe('QuerySetQueriesTable', () => {
     const result = await mockFindItems('');
     expect(result.total).toBe(3);
     expect(result.hits).toHaveLength(3);
+  });
+
+  it('tests findQueries function filters by reference answer', async () => {
+    const queriesWithReferences = [
+      {
+        queryText: 'What is C#?',
+        customFields: { referenceAnswer: 'Programming language' },
+      },
+      { queryText: 'example1', customFields: { referenceAnswer: '' } },
+    ];
+
+    render(<QuerySetQueriesTable queries={queriesWithReferences} />);
+
+    const result = await mockFindItems('programming');
+    expect(result.total).toBe(1);
+    expect(result.hits[0].queryText).toBe('What is C#?');
+    expect(result.hits[0].referenceAnswer).toBe('Programming language');
+  });
+});
+
+describe('getReferenceAnswer', () => {
+  it('reads referenceAnswer from customFields', () => {
+    expect(
+      getReferenceAnswer({
+        queryText: 'test',
+        customFields: { referenceAnswer: 'stored answer' },
+      })
+    ).toBe('stored answer');
+  });
+
+  it('falls back to top-level referenceAnswer', () => {
+    expect(
+      getReferenceAnswer({
+        queryText: 'test',
+        referenceAnswer: 'legacy answer',
+      })
+    ).toBe('legacy answer');
+  });
+
+  it('returns empty string when no reference answer is present', () => {
+    expect(getReferenceAnswer({ queryText: 'test', customFields: {} })).toBe('');
+  });
+});
+
+describe('normalizeQuerySetQueries', () => {
+  it('normalizes backend query shape for display', () => {
+    expect(
+      normalizeQuerySetQueries([
+        {
+          queryText: 'What is C#?',
+          customFields: { referenceAnswer: 'C# is a programming language' },
+        },
+      ])
+    ).toEqual([
+      {
+        id: '0',
+        queryText: 'What is C#?',
+        referenceAnswer: 'C# is a programming language',
+      },
+    ]);
   });
 });

--- a/public/components/query_set/components/query_set_queries_table.tsx
+++ b/public/components/query_set/components/query_set_queries_table.tsx
@@ -3,30 +3,62 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React from 'react';
+import React, { useMemo } from 'react';
 import { EuiText } from '@elastic/eui';
 import { TableListView } from '../../../../../../src/plugins/opensearch_dashboards_react/public';
 
-interface QueryItem {
+interface StoredQueryItem {
   queryText: string;
+  referenceAnswer?: string;
+  customFields?: {
+    referenceAnswer?: string;
+  };
+}
+
+export interface DisplayQueryItem {
+  id: string;
+  queryText: string;
+  referenceAnswer: string;
 }
 
 interface QuerySetQueriesTableProps {
-  queries: QueryItem[];
+  queries: StoredQueryItem[];
 }
 
-export const QuerySetQueriesTable: React.FC<QuerySetQueriesTableProps> = ({ queries }) => {
-  const findQueries = async (searchTerm: string) => {
-    if (!Array.isArray(queries)) {
-      return {
-        total: 0,
-        hits: [],
-      };
-    }
+export const getReferenceAnswer = (query: StoredQueryItem): string => {
+  const customFieldAnswer = query.customFields?.referenceAnswer;
+  if (customFieldAnswer !== undefined && customFieldAnswer !== null) {
+    return String(customFieldAnswer);
+  }
+  if (query.referenceAnswer !== undefined && query.referenceAnswer !== null) {
+    return String(query.referenceAnswer);
+  }
+  return '';
+};
 
+export const normalizeQuerySetQueries = (queries: StoredQueryItem[]): DisplayQueryItem[] => {
+  return queries.map((query, index) => ({
+    id: String(index),
+    queryText: query.queryText ?? '',
+    referenceAnswer: getReferenceAnswer(query),
+  }));
+};
+
+export const QuerySetQueriesTable: React.FC<QuerySetQueriesTableProps> = ({ queries }) => {
+  const normalizedQueries = useMemo(
+    () => (Array.isArray(queries) ? normalizeQuerySetQueries(queries) : []),
+    [queries]
+  );
+
+  const findQueries = async (searchTerm: string) => {
+    const term = searchTerm.toLowerCase();
     const filteredQueries = searchTerm
-      ? queries.filter((query) => query.queryText.toLowerCase().includes(searchTerm.toLowerCase()))
-      : queries;
+      ? normalizedQueries.filter(
+          (query) =>
+            query.queryText.toLowerCase().includes(term) ||
+            query.referenceAnswer.toLowerCase().includes(term)
+        )
+      : normalizedQueries;
     return {
       total: filteredQueries.length,
       hits: filteredQueries,
@@ -40,11 +72,20 @@ export const QuerySetQueriesTable: React.FC<QuerySetQueriesTableProps> = ({ quer
           field: 'queryText',
           name: 'Query',
           sortable: true,
-          width: '100%',
+          width: '50%',
+        },
+        {
+          field: 'referenceAnswer',
+          name: 'Reference Answer',
+          sortable: true,
+          width: '50%',
+          render: (referenceAnswer: string) => (
+            <EuiText size="s">{referenceAnswer || '—'}</EuiText>
+          ),
         },
       ]}
       tableProps={{
-        itemId: 'queryText',
+        itemId: 'id',
         noItemsMessage: 'No queries found',
       }}
       findItems={findQueries}


### PR DESCRIPTION
Description

Fixes #855.

The Query Set Details page currently displays only query text, even when reference answers are present and successfully stored in the backend.

This change updates the Query Set Details view to:

Display stored reference answers alongside query text
Support both legacy referenceAnswer fields and the newer customFields.referenceAnswer format
Allow searching/filtering by reference answer
Add test coverage for reference answer extraction, normalization, and filtering
Testing
Added unit tests for reference answer extraction and query normalization
Added test coverage for filtering by reference answer
Verified Query Set Details displays stored reference answers
Verified Query Set Details continues to work when no reference answer is present
Verified compatibility with both legacy and current backend response formats

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
