### PR TITLE
Poll judgment detail view while processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Enhancements
 
 ### Bug Fixes
+* Poll judgment detail view while status is PROCESSING so ratings appear when async generation completes ([#857](https://github.com/opensearch-project/dashboards-search-relevance/issues/857))
 * Hide AnalyticEngine data sources from DSL-dependent data source dropdowns ([#846](https://github.com/opensearch-project/dashboards-search-relevance/pull/846))
 
 ### Infrastructure

--- a/public/components/judgment/__tests__/judgment_view.test.tsx
+++ b/public/components/judgment/__tests__/judgment_view.test.tsx
@@ -67,6 +67,31 @@ describe('JudgmentView', () => {
     expect(screen.getByText('Failed to load judgment')).toBeInTheDocument();
   });
 
+  it('renders processing callout when judgment status is PROCESSING', () => {
+    mockUseJudgmentView.mockReturnValue({
+      judgment: {
+        id: '1',
+        name: 'Processing Judgment',
+        type: 'UBI',
+        status: 'PROCESSING',
+        metadata: {},
+        judgmentRatings: [],
+        timestamp: '2023-01-01',
+      },
+      loading: false,
+      error: null,
+    });
+
+    render(
+      <Router history={history}>
+        <JudgmentView {...defaultProps} />
+      </Router>
+    );
+
+    expect(screen.getByTestId('judgmentProcessingCallOut')).toBeInTheDocument();
+    expect(screen.getByText('PROCESSING')).toBeInTheDocument();
+  });
+
   it('renders judgment metadata & flattened ratings table', () => {
     mockUseJudgmentView.mockReturnValue({
       judgment: {

--- a/public/components/judgment/__tests__/use_judgment_view.test.ts
+++ b/public/components/judgment/__tests__/use_judgment_view.test.ts
@@ -156,6 +156,76 @@ describe('useJudgmentView', () => {
     );
   });
 
+  it('should poll while judgment status is PROCESSING and stop when COMPLETED', async () => {
+    jest.useFakeTimers();
+
+    const processingResponse = {
+      hits: {
+        hits: [
+          {
+            _source: {
+              id: '1',
+              name: 'Processing Judgment',
+              type: 'UBI',
+              status: 'PROCESSING',
+              metadata: {},
+              judgmentRatings: [],
+              timestamp: '2023-01-01T00:00:00Z',
+            },
+          },
+        ],
+      },
+    };
+
+    const completedResponse = {
+      hits: {
+        hits: [
+          {
+            _source: {
+              id: '1',
+              name: 'Processing Judgment',
+              type: 'UBI',
+              status: 'COMPLETED',
+              metadata: {},
+              judgmentRatings: [
+                {
+                  query: 'futon frames full size without mattress',
+                  ratings: [{ docId: 'doc-1', rating: '3' }],
+                },
+              ],
+              timestamp: '2023-01-01T00:00:00Z',
+            },
+          },
+        ],
+      },
+    };
+
+    mockHttp.get
+      .mockResolvedValueOnce(processingResponse)
+      .mockResolvedValueOnce(completedResponse);
+
+    const { result } = renderHook(() => useJudgmentView(mockHttp as any, '1'));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.judgment?.status).toBe('PROCESSING');
+    expect(result.current.judgment?.judgmentRatings).toEqual([]);
+
+    jest.advanceTimersByTime(5000);
+
+    await waitFor(() => expect(result.current.judgment?.status).toBe('COMPLETED'));
+
+    expect(result.current.judgment?.judgmentRatings).toEqual([
+      {
+        query: 'futon frames full size without mattress',
+        ratings: [{ docId: 'doc-1', rating: '3' }],
+      },
+    ]);
+    expect(mockHttp.get).toHaveBeenCalledTimes(2);
+
+    jest.useRealTimers();
+  });
+
   it('should omit dataSourceId query param when not provided', async () => {
     const mockResponse = {
       hits: { hits: [{ _source: { id: '1', name: 'Test' } }] },

--- a/public/components/judgment/hooks/use_judgment_view.ts
+++ b/public/components/judgment/hooks/use_judgment_view.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { CoreStart } from '../../../../../../src/core/public';
 import { ServiceEndpoints } from '../../../../common';
 
@@ -17,33 +17,107 @@ export interface JudgmentData {
   timestamp: string;
 }
 
+const POLL_INTERVAL_MS = 5000;
+const MAX_POLLING_DURATION_MS = 10 * 60 * 1000;
+const MAX_POLL_ERRORS = 3;
+
 export const useJudgmentView = (http: CoreStart['http'], id: string, dataSourceId?: string | null) => {
   const [judgment, setJudgment] = useState<JudgmentData | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    const fetchJudgment = async () => {
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const pollingStartTime = useRef<number>(0);
+  const pollErrorCount = useRef<number>(0);
+
+  const stopPolling = useCallback(() => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+  }, []);
+
+  const fetchJudgment = useCallback(
+    async (options?: { showLoading?: boolean }) => {
+      const showLoading = options?.showLoading ?? false;
+
       try {
-        setLoading(true);
-        const queryParams = dataSourceId ? { query: { dataSourceId } } : {};
-        const response = await http.get(`${ServiceEndpoints.Judgments}/${id}`, queryParams);
+        if (showLoading) {
+          setLoading(true);
+          setError(null);
+        }
+
+        const response = await http.get(
+          `${ServiceEndpoints.Judgments}/${id}`,
+          dataSourceId ? { query: { dataSourceId } } : {}
+        );
 
         if (response && response.hits && response.hits.hits && response.hits.hits.length > 0) {
-          setJudgment(response.hits.hits[0]._source);
-        } else {
+          const nextJudgment = response.hits.hits[0]._source as JudgmentData;
+          setJudgment(nextJudgment);
+          setError(null);
+          pollErrorCount.current = 0;
+
+          if (nextJudgment.status !== 'PROCESSING') {
+            stopPolling();
+          }
+        } else if (showLoading) {
+          setJudgment(null);
           setError('No matching judgment found');
+          stopPolling();
         }
       } catch (err) {
         console.error('Failed to load judgment', err);
-        setError('Error loading judgment data');
+        if (showLoading) {
+          setJudgment(null);
+          setError('Error loading judgment data');
+          stopPolling();
+        } else {
+          pollErrorCount.current += 1;
+          if (pollErrorCount.current >= MAX_POLL_ERRORS) {
+            stopPolling();
+          }
+        }
       } finally {
-        setLoading(false);
+        if (showLoading) {
+          setLoading(false);
+        }
       }
-    };
+    },
+    [http, id, dataSourceId, stopPolling]
+  );
 
-    fetchJudgment();
-  }, [http, id, dataSourceId]);
+  useEffect(() => {
+    fetchJudgment({ showLoading: true });
+    return () => {
+      stopPolling();
+    };
+  }, [fetchJudgment, stopPolling]);
+
+  useEffect(() => {
+    if (judgment?.status !== 'PROCESSING') {
+      return undefined;
+    }
+
+    if (intervalRef.current) {
+      return undefined;
+    }
+
+    pollingStartTime.current = Date.now();
+
+    intervalRef.current = setInterval(() => {
+      if (Date.now() - pollingStartTime.current > MAX_POLLING_DURATION_MS) {
+        stopPolling();
+        return;
+      }
+
+      fetchJudgment();
+    }, POLL_INTERVAL_MS);
+
+    return () => {
+      stopPolling();
+    };
+  }, [judgment?.status, fetchJudgment, stopPolling]);
 
   const formatJson = (json: string) => {
     try {

--- a/public/components/judgment/hooks/use_judgment_view.ts
+++ b/public/components/judgment/hooks/use_judgment_view.ts
@@ -18,7 +18,6 @@ export interface JudgmentData {
 }
 
 const POLL_INTERVAL_MS = 5000;
-const MAX_POLLING_DURATION_MS = 10 * 60 * 1000;
 const MAX_POLL_ERRORS = 3;
 
 export const useJudgmentView = (http: CoreStart['http'], id: string, dataSourceId?: string | null) => {
@@ -27,7 +26,6 @@ export const useJudgmentView = (http: CoreStart['http'], id: string, dataSourceI
   const [error, setError] = useState<string | null>(null);
 
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  const pollingStartTime = useRef<number>(0);
   const pollErrorCount = useRef<number>(0);
 
   const stopPolling = useCallback(() => {
@@ -103,14 +101,7 @@ export const useJudgmentView = (http: CoreStart['http'], id: string, dataSourceI
       return undefined;
     }
 
-    pollingStartTime.current = Date.now();
-
     intervalRef.current = setInterval(() => {
-      if (Date.now() - pollingStartTime.current > MAX_POLLING_DURATION_MS) {
-        stopPolling();
-        return;
-      }
-
       fetchJudgment();
     }, POLL_INTERVAL_MS);
 

--- a/public/components/judgment/views/judgment_view.tsx
+++ b/public/components/judgment/views/judgment_view.tsx
@@ -15,6 +15,7 @@ import {
   EuiText,
   EuiFieldSearch,
   EuiBasicTable,
+  EuiCallOut,
 } from '@elastic/eui';
 import { CoreStart } from '../../../../../../src/core/public';
 import { useJudgmentView } from '../hooks/use_judgment_view';
@@ -153,6 +154,24 @@ export const JudgmentView: React.FC<JudgmentViewProps> = ({ http, id, dataSource
         <EuiFormRow label="Type" fullWidth>
           <EuiText>{judgment.type}</EuiText>
         </EuiFormRow>
+
+        <EuiFormRow label="Status" fullWidth>
+          <EuiText>{judgment.status}</EuiText>
+        </EuiFormRow>
+
+        {judgment.status === 'PROCESSING' && (
+          <>
+            <EuiSpacer size="m" />
+            <EuiCallOut
+              title="Judgment processing"
+              color="primary"
+              iconType="clock"
+              data-test-subj="judgmentProcessingCallOut"
+            >
+              <p>Judgment ratings are being generated. This page will update automatically.</p>
+            </EuiCallOut>
+          </>
+        )}
 
         <EuiFormRow label="Metadata" fullWidth>
           <EuiText>


### PR DESCRIPTION
Description

Fixes #857.

UBI judgments are generated asynchronously. If a user opens the Judgment Details page while a judgment is still in the PROCESSING state, the page loads with empty ratings and does not automatically refresh when processing completes.

This change updates the Judgment Details view to:

Poll judgment data while the judgment status is PROCESSING
Automatically stop polling when the judgment reaches a terminal state
Display a callout indicating that judgment ratings are still being generated
Keep the page updated without requiring a manual refresh

This improves the user experience for asynchronous judgment generation and keeps the detail view behavior consistent with the judgment listing page.

Testing
Added unit tests to verify polling starts when status is PROCESSING
Added unit tests to verify polling stops when status becomes COMPLETED
Added test coverage for rendering the processing callout
Verified judgment ratings appear automatically when processing completes
Verified polling cleanup on completion and component unmount

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
