### PR TITLE
Fix infinite re-render loop in useDataSourceUrlSync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * Display stored reference answers on Query Set Details page ([#855](https://github.com/opensearch-project/dashboards-search-relevance/issues/855))
 * Poll judgment detail view while status is PROCESSING so ratings appear when async generation completes ([#857](https://github.com/opensearch-project/dashboards-search-relevance/issues/857))
 * Hide AnalyticEngine data sources from DSL-dependent data source dropdowns ([#846](https://github.com/opensearch-project/dashboards-search-relevance/pull/846))
+* Fix infinite re-render loop in useDataSourceUrlSync caused by unstable location object reference ([#859](https://github.com/opensearch-project/dashboards-search-relevance/pull/859))
 
 ### Infrastructure
 

--- a/public/components/common/datasource_utils.ts
+++ b/public/components/common/datasource_utils.ts
@@ -66,7 +66,7 @@ export const useDataSourceUrlSync = (
   useEffect(() => {
     if (!dataSourceEnabled) return;
     const params = new URLSearchParams(location.search);
-    const current = params.get('dataSourceId') || undefined;
+    const current = params.get('dataSourceId') ?? undefined;
     if (current === dataSourceId) return;
     if (dataSourceId === undefined) {
       params.delete('dataSourceId');
@@ -74,8 +74,12 @@ export const useDataSourceUrlSync = (
       params.set('dataSourceId', dataSourceId);
     }
     const search = params.toString();
-    history.replace({ ...location, search: search ? `?${search}` : '' });
-  }, [dataSourceId, dataSourceEnabled, location, history]);
+    history.replace({
+      pathname: location.pathname,
+      search: search ? `?${search}` : '',
+      hash: location.hash,
+    });
+  }, [dataSourceId, dataSourceEnabled, location.search, location.pathname, location.hash, history]);
 
   return [dataSourceId, setDataSourceId];
 };


### PR DESCRIPTION
### Description

Fix an infinite re-render loop in `useDataSourceUrlSync` that floods the console with "Maximum update depth exceeded" warnings.

**Root cause:**

When `DataSourceMenu` selects the local cluster, it calls `setDataSourceId('')`  (empty string). The hook then:

1. Writes `?dataSourceId=` to the URL via `history.replace`
2. On next effect run, reads it back: `params.get('dataSourceId')` returns `''`
3. But `'' || undefined` coerces to `undefined` (the `||` operator treats empty string as falsy)
4. Guard check: `undefined === ''` → **false** → `history.replace` fires again → infinite loop

The `location` object reference changing on every render (from `useLocation()`) compounds this by causing the effect to re-fire even when the URL has not changed.

**Fix (3 changes):**

1. **`||` → `??`**: Use nullish coalescing so empty string is preserved. Now `'' ?? undefined` → `''`, matching `dataSourceId` state → guard catches it.
2. **Stable deps**: Replace `location` object in dependency array with primitive values (`location.search`, `location.pathname`, `location.hash`) that compare by value.
3. **Explicit replace target**: Construct `history.replace` argument from individual properties instead of spreading the unstable `location` object.

### Before

```
Warning: Maximum update depth exceeded. This can happen when a component calls setState inside
useEffect, but useEffect either doesn't have a dependency array, or one of the dependencies
changes on every render.
    at SearchRelevancePage (searchRelevanceDashboards.chunk.1.js:1864:25)
    at SearchRelevanceContextProvider (searchRelevanceDashboards.chunk.1.js:25941:26)
    at PseudoLocaleWrapper (osd-ui-shared-deps.js:250248:5)
    at IntlProvider (osd-ui-shared-deps.js:185576:5)
    at I18nProvider (osd-ui-shared-deps.js:250151:1)
    at Router (osd-ui-shared-deps.js:187130:30)
    at HashRouter (osd-ui-shared-deps.js:186797:35)
    at SearchRelevanceApp (searchRelevanceDashboards.chunk.1.js:2359:31)
    at ConfigProvider (searchRelevanceDashboards.chunk.1.js:25889:28)
```

### After

No warnings. Page loads cleanly.

### Issues Resolved

N/A - Bug fix

### Check List

- [x] All tests pass (11 unit tests for `useDataSourceUrlSync`)
- [x] No eslint-disable needed
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).