### PR TITLE
Fix ubi sample data in workspace

### DIFF
--- a/server/sample_data/ubi_sample_data.test.ts
+++ b/server/sample_data/ubi_sample_data.test.ts
@@ -3,6 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+jest.mock('../../../../src/core/server', () => ({
+  extractTimelineExpression: jest.fn(),
+  extractVegaSpecFromSavedObject: jest.fn(),
+  updateDataSourceNameInTimeline: jest.fn(),
+  updateDataSourceNameInVegaSpec: jest.fn(),
+}));
+
 import { ubiSpecProvider, getUbiDataIndices } from './ubi_sample_data';
 import { getUbiSavedObjects } from './ubi_saved_objects';
 

--- a/server/sample_data/ubi_sample_data.ts
+++ b/server/sample_data/ubi_sample_data.ts
@@ -11,7 +11,7 @@ import {
   appendDataSourceId,
   getSavedObjectsWithDataSource,
   overwriteSavedObjectsWithWorkspaceId,
-} from '../../../../src/plugins/home/server/services/sample_data/data_sets';
+} from '../../../../src/plugins/home/server/services/sample_data/data_sets/util';
 import { getUbiSavedObjects } from './ubi_saved_objects';
 
 /**

--- a/server/sample_data/ubi_sample_data.ts
+++ b/server/sample_data/ubi_sample_data.ts
@@ -7,9 +7,10 @@ import path from 'path';
 import { i18n } from '@osd/i18n';
 import { SampleDatasetSchema } from '../../../../src/plugins/home/server/services/sample_data';
 import { AppLinkSchema } from '../../../../src/plugins/home/server/services/sample_data/lib/sample_dataset_registry_types';
-import { 
+import {
   appendDataSourceId,
-  getSavedObjectsWithDataSource
+  getSavedObjectsWithDataSource,
+  overwriteSavedObjectsWithWorkspaceId,
 } from '../../../../src/plugins/home/server/services/sample_data/data_sets';
 import { getUbiSavedObjects } from './ubi_saved_objects';
 
@@ -141,6 +142,8 @@ export function ubiSpecProvider(): SampleDatasetSchema {
     savedObjects: getUbiSavedObjects(),
     getDataSourceIntegratedSavedObjects: (dataSourceId?: string, dataSourceTitle?: string) =>
       getSavedObjectsWithDataSource(getUbiSavedObjects(), dataSourceId, dataSourceTitle),
+    getWorkspaceIntegratedSavedObjects: (workspaceId: string) =>
+      overwriteSavedObjectsWithWorkspaceId(getUbiSavedObjects(), workspaceId),
     dataIndices: getUbiDataIndices(),
     status: 'not_installed',
   };


### PR DESCRIPTION
### Description
Fixed UBI sample data cannot be installed to a workspace

#### Getting error when install "Sample UBI data"
<img width="492" height="829" alt="Screenshot 2026-06-12 at 10 14 02" src="https://github.com/user-attachments/assets/abd5aafe-4b37-4fe8-a74a-bc461e1f9f13" />

#### Server side error:
```
server    log   [02:13:56.498] [error][http] TypeError: dataset.getWorkspaceIntegratedSavedObjects is not a function
    at getFinalSavedObjects (/Users/ruanyl/project/OpenSearch-Dashboards copy/src/plugins/home/server/services/sample_data/data_sets/util.ts:202:20)
    at /Users/ruanyl/project/OpenSearch-Dashboards copy/src/plugins/home/server/services/sample_data/routes/install.ts:210:52
    at processTicksAndRejections (node:internal/process/task_queues:105:5)
    at Router.handle (/Users/ruanyl/project/OpenSearch-Dashboards copy/src/core/server/http/router/router.ts:286:44)
    at handler (/Users/ruanyl/project/OpenSearch-Dashboards copy/src/core/server/http/router/router.ts:241:11)
    at exports.Manager.execute (/Users/ruanyl/project/OpenSearch-Dashboards copy/node_modules/@hapi/hapi/lib/toolkit.js:60:28)
    at Object.internals.handler (/Users/ruanyl/project/OpenSearch-Dashboards copy/node_modules/@hapi/hapi/lib/handler.js:46:20)
    at exports.execute (/Users/ruanyl/project/OpenSearch-Dashboards copy/node_modules/@hapi/hapi/lib/handler.js:31:20)
    at Request._lifecycle (/Users/ruanyl/project/OpenSearch-Dashboards copy/node_modules/@hapi/hapi/lib/request.js:384:32)
    at Request._execute (/Users/ruanyl/project/OpenSearch-Dashboards copy/node_modules/@hapi/hapi/lib/request.js:294:9)
```

[Describe what this change achieves]

### Issues Resolved

[List any issues this PR will resolve]

### Check List

- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test
  - [ ] Integration tests pass: `yarn cypress:run-without-security --config "baseUrl=http://localhost:5601" --spec "cypress/integration/plugins/search-relevance-dashboards/*.js"` (see [Developer Guide](DEVELOPER_GUIDE.md#integration-tests))
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
