### PR TITLE
Rename CI job display names to match main branch convention

### DIFF
--- a/.github/workflows/test-and-build.yml
+++ b/.github/workflows/test-and-build.yml
@@ -12,6 +12,7 @@ jobs:
       product: opensearch-dashboards
 
   build-linux:
+    name: Run unit tests (ubuntu-latest)
     needs: Get-CI-Image-Tag
     runs-on: ubuntu-latest
     container:
@@ -93,6 +94,7 @@ jobs:
           path: ./OpenSearch-Dashboards/plugins/dashboards-search-relevance/build
 
   build-macos-windows:
+    name: Run unit tests
     strategy:
       matrix:
         os: [macos-latest, windows-latest]


### PR DESCRIPTION
### Description

Rename CI job display names to match main branch convention

### Issues Resolved

N/A

### Check List

- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test
  - [ ] Integration tests pass: `yarn cypress:run-without-security --config "baseUrl=http://localhost:5601" --spec "cypress/integration/plugins/search-relevance-dashboards/*.js"` (see [Developer Guide](DEVELOPER_GUIDE.md#integration-tests))
- [ ] New functionality has been documented.
- [X] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
