### PR TITLE
Refactor GetSearchResults to single-query endpoint (#784)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,5 +27,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Maintenance
 
 ### Refactoring
+* Refactor `GetSearchResults` to a single-query endpoint; fixes inconsistent query1/query2 validation, wrong error routing for query2, and cross-cluster index rejection ([#784](https://github.com/opensearch-project/dashboards-search-relevance/issues/784))
 * Replace per-page data source selectors with a single global data source menu in the OSD chrome header, backed by URL-synced state ([#850](https://github.com/opensearch-project/dashboards-search-relevance/pull/850))
 * Remove unused `resource_management_home` component directory ([#779](https://github.com/opensearch-project/dashboards-search-relevance/issues/779))

--- a/public/components/experiment/__tests__/pairwise_experiment_view.test.tsx
+++ b/public/components/experiment/__tests__/pairwise_experiment_view.test.tsx
@@ -9,8 +9,7 @@ import { ServiceEndpoints } from '../../../../common';
 
 // Mock the HTTP service
 const mockHttpPost = jest.fn(() => Promise.resolve({
-  result1: { hits: { hits: [] } },
-  result2: { hits: { hits: [] } }
+  result: { hits: { hits: [] } },
 }));
 
 const mockHttp = {
@@ -33,7 +32,7 @@ describe('PairwiseExperimentView', () => {
     /**
      * This test verifies that when creating queries with document IDs,
      * the size parameter is set to match the number of IDs.
-     * 
+     *
      * This directly tests the fix we implemented to ensure all requested
      * documents are returned, not just the default 10.
      */
@@ -61,7 +60,7 @@ describe('PairwiseExperimentView', () => {
           docIds2: Array(25).fill(0).map((_, i) => `doc${i+1}`)   // 25 documents
         }
       ];
-      
+
       testCases.forEach(testCase => {
         // Create queries as they would be created in the component
         const query1 = {
@@ -73,7 +72,7 @@ describe('PairwiseExperimentView', () => {
             }
           }
         };
-        
+
         const query2 = {
           index: 'test-index-2',
           size: testCase.docIds2.length, // This is the line we added in our fix
@@ -83,31 +82,27 @@ describe('PairwiseExperimentView', () => {
             }
           }
         };
-        
+
         // Assert that the size parameters match the document ID arrays length
         expect(query1.size).toBe(testCase.docIds1.length);
         expect(query2.size).toBe(testCase.docIds2.length);
-        
-        // Create the POST request as it would be in the component
-        const requestBody = { query1, query2 };
-        const requestOptions = {
-          body: JSON.stringify(requestBody)
-        };
-        
-        // Call the mock HTTP service
-        mockHttp.post(ServiceEndpoints.GetSearchResults, requestOptions);
-        
-        // Get the last call arguments
-        const lastCallArgs = mockHttpPost.mock.calls[mockHttpPost.mock.calls.length - 1];
-        const sentRequestBody = JSON.parse(lastCallArgs[1].body);
-        
-        // Verify that the size parameters in the sent request match the document ID counts
-        expect(sentRequestBody.query1.size).toBe(testCase.docIds1.length);
-        expect(sentRequestBody.query2.size).toBe(testCase.docIds2.length);
-        
-        // For test cases with document IDs, verify the full query structure
+
+        // Create the POST requests as they would be in the component
+        mockHttp.post(ServiceEndpoints.GetSearchResults, {
+          body: JSON.stringify({ query: query1 }),
+        });
+        mockHttp.post(ServiceEndpoints.GetSearchResults, {
+          body: JSON.stringify({ query: query2 }),
+        });
+
+        const firstCallBody = JSON.parse(mockHttpPost.mock.calls[mockHttpPost.mock.calls.length - 2][1].body);
+        const secondCallBody = JSON.parse(mockHttpPost.mock.calls[mockHttpPost.mock.calls.length - 1][1].body);
+
+        expect(firstCallBody.query.size).toBe(testCase.docIds1.length);
+        expect(secondCallBody.query.size).toBe(testCase.docIds2.length);
+
         if (testCase.docIds1.length > 0) {
-          expect(sentRequestBody.query1).toEqual({
+          expect(firstCallBody.query).toEqual({
             index: 'test-index-1',
             size: testCase.docIds1.length,
             query: {
@@ -117,9 +112,9 @@ describe('PairwiseExperimentView', () => {
             }
           });
         }
-        
+
         if (testCase.docIds2.length > 0) {
-          expect(sentRequestBody.query2).toEqual({
+          expect(secondCallBody.query).toEqual({
             index: 'test-index-2',
             size: testCase.docIds2.length,
             query: {
@@ -131,17 +126,15 @@ describe('PairwiseExperimentView', () => {
         }
       });
     });
-    
+
     /**
      * Integration test to verify that the HTTP request is made with the correct size parameter
      * Simulates the flow in the component's useEffect hook when selectedQuery changes
      */
-    it('should make HTTP request with size parameter equal to document IDs length', async () => {
-      // Create document IDs
+    it('should make HTTP requests with size parameter equal to document IDs length', async () => {
       const documentIds1 = Array(15).fill(0).map((_, i) => `doc${i+1}`);
       const documentIds2 = Array(12).fill(0).map((_, i) => `doc${i+1}`);
-      
-      // Set up query objects as they would be in the component
+
       const query1 = {
         index: 'test-index-1',
         size: documentIds1.length,
@@ -151,7 +144,7 @@ describe('PairwiseExperimentView', () => {
           }
         }
       };
-      
+
       const query2 = {
         index: 'test-index-2',
         size: documentIds2.length,
@@ -161,22 +154,23 @@ describe('PairwiseExperimentView', () => {
           }
         }
       };
-      
-      // Simulate the HTTP request made in the useEffect hook
-      mockHttp.post(ServiceEndpoints.GetSearchResults, {
-        body: JSON.stringify({ query1, query2 })
-      });
-      
-      // Verify the HTTP request was made
-      expect(mockHttpPost).toHaveBeenCalledTimes(1);
-      
-      // Get the arguments from the HTTP request
-      const callArgs = mockHttpPost.mock.calls[0];
-      const requestBody = JSON.parse(callArgs[1].body);
-      
-      // Verify the size parameters in the request match the document ID counts
-      expect(requestBody.query1.size).toBe(documentIds1.length);
-      expect(requestBody.query2.size).toBe(documentIds2.length);
+
+      await Promise.all([
+        mockHttp.post(ServiceEndpoints.GetSearchResults, {
+          body: JSON.stringify({ query: query1 }),
+        }),
+        mockHttp.post(ServiceEndpoints.GetSearchResults, {
+          body: JSON.stringify({ query: query2 }),
+        }),
+      ]);
+
+      expect(mockHttpPost).toHaveBeenCalledTimes(2);
+
+      const firstRequestBody = JSON.parse(mockHttpPost.mock.calls[0][1].body);
+      const secondRequestBody = JSON.parse(mockHttpPost.mock.calls[1][1].body);
+
+      expect(firstRequestBody.query.size).toBe(documentIds1.length);
+      expect(secondRequestBody.query.size).toBe(documentIds2.length);
     });
   });
 });

--- a/public/components/experiment/views/evaluation_experiment_view.tsx
+++ b/public/components/experiment/views/evaluation_experiment_view.tsx
@@ -201,21 +201,21 @@ export const EvaluationExperimentView: React.FC<EvaluationExperimentViewProps> =
           size: Math.max(querySetSize, 1),
         };
 
-        const requestBase = dataSourceId ? { dataSourceId1: dataSourceId } : {};
+        const requestBase = dataSourceId ? { dataSourceId } : {};
 
         const [evaluationSearchResult, variantSearchResult] = await Promise.all([
           http.post(ServiceEndpoints.GetSearchResults, {
-            body: JSON.stringify({ query1: evaluationQuery, ...requestBase }),
+            body: JSON.stringify({ query: evaluationQuery, ...requestBase }),
           }),
           http.post(ServiceEndpoints.GetSearchResults, {
-            body: JSON.stringify({ query1: variantQuery, ...requestBase }),
+            body: JSON.stringify({ query: variantQuery, ...requestBase }),
           }),
         ]);
 
         const parseResults =
-          evaluationSearchResult?.result1?.hits?.hits &&
+          evaluationSearchResult?.result?.hits?.hits &&
           combineResults(
-            ...evaluationSearchResult.result1.hits.hits.map((x: any) => toQueryEvaluation(x._source))
+            ...evaluationSearchResult.result.hits.hits.map((x: any) => toQueryEvaluation(x._source))
           );
 
         if (_experiment && _searchConfiguration && _querySet && _judgmentSet) {
@@ -231,7 +231,7 @@ export const EvaluationExperimentView: React.FC<EvaluationExperimentViewProps> =
             }
 
             const experimentResults = Array.isArray(_experiment.results) ? _experiment.results : [];
-            const variantSources = parseVariantSources(variantSearchResult?.result1?.hits?.hits ?? []);
+            const variantSources = parseVariantSources(variantSearchResult?.result?.hits?.hits ?? []);
             const variantStatusByQueryText = mapQueryStatusesFromVariants(
               getQueryExecutionOrder(experimentResults),
               variantSources

--- a/public/components/experiment/views/hybrid_optimizer_experiment_view.tsx
+++ b/public/components/experiment/views/hybrid_optimizer_experiment_view.tsx
@@ -141,16 +141,16 @@ export const HybridOptimizerExperimentView: React.FC<HybridOptimizerExperimentVi
               };
               console.log(`[DEBUG] Fetching batch: from=${from}, size=${batchSize}`);
               const result = await http.post(ServiceEndpoints.GetSearchResults, {
-                body: JSON.stringify({ query1: query }),
+                body: JSON.stringify({ query }),
               });
               
-              if (result?.result1?.hits?.hits && result.result1.hits.hits.length > 0) {
-                console.log(`[DEBUG] Batch returned ${result.result1.hits.hits.length} results`);
-                allResults = allResults.concat(result.result1.hits.hits);
-                from += result.result1.hits.hits.length;
+              if (result?.result?.hits?.hits && result.result.hits.hits.length > 0) {
+                console.log(`[DEBUG] Batch returned ${result.result.hits.hits.length} results`);
+                allResults = allResults.concat(result.result.hits.hits);
+                from += result.result.hits.hits.length;
                 
                 // Stop if we got less than requested or reached max window
-                if (result.result1.hits.hits.length < batchSize || from >= maxSize) {
+                if (result.result.hits.hits.length < batchSize || from >= maxSize) {
                   hasMore = false;
                   if (from >= maxSize && expectedSize > maxSize) {
                     console.warn(`[WARNING] Reached OpenSearch max_result_window limit (${maxSize}). Cannot fetch remaining ${expectedSize - from} results.`);
@@ -178,11 +178,11 @@ export const HybridOptimizerExperimentView: React.FC<HybridOptimizerExperimentVi
           };
 
           const result = await http.post(ServiceEndpoints.GetSearchResults, {
-            body: JSON.stringify({ query1: query }),
+            body: JSON.stringify({ query }),
           });
 
-          if (result?.result1?.hits?.hits) {
-              allResults = result.result1.hits.hits;
+          if (result?.result?.hits?.hits) {
+              allResults = result.result.hits.hits;
             }
           }
 
@@ -242,10 +242,10 @@ export const HybridOptimizerExperimentView: React.FC<HybridOptimizerExperimentVi
       };
 
       const result = await http.post(ServiceEndpoints.GetSearchResults, {
-        body: JSON.stringify({ query1: query }),
+        body: JSON.stringify({ query }),
       });
 
-      const variantDetails = result?.result1?.hits?.hits?.[0]?._source;
+      const variantDetails = result?.result?.hits?.hits?.[0]?._source;
       if (variantDetails) {
         setSelectedVariantDetails(variantDetails);
         setSelectedVariantId(variantId);

--- a/public/components/experiment/views/pairwise_experiment_view.tsx
+++ b/public/components/experiment/views/pairwise_experiment_view.tsx
@@ -234,13 +234,17 @@ export const PairwiseExperimentView: React.FC<PairwiseExperimentViewProps> = ({
         },
       };
 
-      http
-        .post(ServiceEndpoints.GetSearchResults, {
-          body: JSON.stringify({ query1, query2 }),
-        })
-        .then((res) => {
-          setQueryResult1(resolve_attributes(snapshot1, convertFromSearchResult(res.result1)));
-          setQueryResult2(resolve_attributes(snapshot2, convertFromSearchResult(res.result2)));
+      Promise.all([
+        http.post(ServiceEndpoints.GetSearchResults, {
+          body: JSON.stringify({ query: query1 }),
+        }),
+        http.post(ServiceEndpoints.GetSearchResults, {
+          body: JSON.stringify({ query: query2 }),
+        }),
+      ])
+        .then(([res1, res2]) => {
+          setQueryResult1(resolve_attributes(snapshot1, convertFromSearchResult(res1.result)));
+          setQueryResult2(resolve_attributes(snapshot2, convertFromSearchResult(res2.result)));
         })
         .catch((error: Error) => {
           console.error(error);

--- a/public/components/query_compare/search_result/agent/agent_handler.ts
+++ b/public/components/query_compare/search_result/agent/agent_handler.ts
@@ -21,8 +21,8 @@ export class AgentHandler {
   async performAgenticSearch(requestBody: any, dataSourceId: string): Promise<any> {
     return await this.http.post(ServiceEndpoints.GetSearchResults, {
       body: JSON.stringify({
-        query1: requestBody,
-        dataSourceId1: dataSourceId,
+        query: requestBody,
+        dataSourceId,
       }),
     });
   }

--- a/public/components/query_compare/search_result/index.tsx
+++ b/public/components/query_compare/search_result/index.tsx
@@ -263,38 +263,29 @@ export const SearchResult = ({
     datasource: string,
     setQueryResult: React.Dispatch<React.SetStateAction<SearchResults>>,
     updateComparedResult: (result: SearchResults) => void,
-    setQueryError: React.Dispatch<React.SetStateAction<QueryError>>,
-    resultKey: 'result1' | 'result2',
-    errorKey: 'errorMessage1' | 'errorMessage2'
+    setQueryError: React.Dispatch<React.SetStateAction<QueryError>>
   ) => {
     if (Object.keys(requestBody).length === 0) return null;
 
     const isAgentic = agentHandler.isAgenticQuery(jsonQuery);
-    const searchPromise = isAgentic ?
-      agentHandler.performAgenticSearch(requestBody, datasource) :
-      searchHandler.performSearch(requestBody, datasource);
+    const searchPromise = isAgentic
+      ? agentHandler.performAgenticSearch(requestBody, datasource)
+      : searchHandler.performSearch(requestBody, datasource);
 
     return searchPromise
       .then((res) => {
-        // Normalize response format for query2
-        if (resultKey === 'result2' && res.result1) {
-          res = { result2: res.result1, errorMessage2: res.errorMessage1 };
-        }
-        return res;
-      })
-      .then((res) => {
         if (!isMountedRef.current) return;
 
-        if (res[resultKey]) {
-          setQueryResult(res[resultKey]);
-          updateComparedResult(res[resultKey]);
+        if (res.result) {
+          setQueryResult(res.result);
+          updateComparedResult(res.result);
         }
 
-        if (res[errorKey]) {
+        if (res.errorMessage) {
           setQueryError((error: QueryError) => ({
             ...error,
-            queryString: res[errorKey],
-            errorResponse: res[errorKey],
+            queryString: res.errorMessage,
+            errorResponse: res.errorMessage,
           }));
           setQueryResult({} as any);
           updateComparedResult({} as any);
@@ -355,12 +346,26 @@ export const SearchResult = ({
     const promises: Promise<any>[] = [];
 
     if (hasRequestBody1) {
-      const promise1 = processQuery(requestBody1, jsonQueries[0], datasource1 || '', setQueryResult1, updateComparedResult1, setQueryError1, 'result1', 'errorMessage1');
+      const promise1 = processQuery(
+        requestBody1,
+        jsonQueries[0],
+        datasource1 || '',
+        setQueryResult1,
+        updateComparedResult1,
+        setQueryError1
+      );
       if (promise1) promises.push(promise1);
     }
 
     if (hasRequestBody2) {
-      const promise2 = processQuery(requestBody2, jsonQueries[1], datasource2 || '', setQueryResult2, updateComparedResult2, setQueryError2, 'result2', 'errorMessage2');
+      const promise2 = processQuery(
+        requestBody2,
+        jsonQueries[1],
+        datasource2 || '',
+        setQueryResult2,
+        updateComparedResult2,
+        setQueryError2
+      );
       if (promise2) promises.push(promise2);
     }
 

--- a/public/components/query_compare/search_result/search/__tests__/search_handler.test.ts
+++ b/public/components/query_compare/search_result/search/__tests__/search_handler.test.ts
@@ -22,37 +22,42 @@ describe('SearchHandler', () => {
     it('should perform single search with correct parameters', async () => {
       const requestBody = { query: 'test' };
       const dataSourceId = 'test-datasource';
-      
+
       mockHttp.post.mockResolvedValue({ hits: { hits: [] } });
 
       await searchHandler.performSearch(requestBody, dataSourceId);
 
       expect(mockHttp.post).toHaveBeenCalledWith(ServiceEndpoints.GetSearchResults, {
         body: JSON.stringify({
-          query1: requestBody,
-          dataSourceId1: dataSourceId,
+          query: requestBody,
+          dataSourceId,
         }),
       });
     });
   });
 
   describe('performDualSearch', () => {
-    it('should perform dual search with correct parameters', async () => {
+    it('should perform two parallel searches with correct parameters', async () => {
       const requestBody1 = { query: 'test1' };
       const requestBody2 = { query: 'test2' };
       const dataSourceId1 = 'datasource1';
       const dataSourceId2 = 'datasource2';
-      
-      mockHttp.post.mockResolvedValue({ hits: { hits: [] } });
+
+      mockHttp.post.mockResolvedValue({ result: { hits: { hits: [] } } });
 
       await searchHandler.performDualSearch(requestBody1, requestBody2, dataSourceId1, dataSourceId2);
 
-      expect(mockHttp.post).toHaveBeenCalledWith(ServiceEndpoints.GetSearchResults, {
+      expect(mockHttp.post).toHaveBeenCalledTimes(2);
+      expect(mockHttp.post).toHaveBeenNthCalledWith(1, ServiceEndpoints.GetSearchResults, {
         body: JSON.stringify({
-          query1: requestBody1,
-          query2: requestBody2,
-          dataSourceId1: dataSourceId1,
-          dataSourceId2: dataSourceId2,
+          query: requestBody1,
+          dataSourceId: dataSourceId1,
+        }),
+      });
+      expect(mockHttp.post).toHaveBeenNthCalledWith(2, ServiceEndpoints.GetSearchResults, {
+        body: JSON.stringify({
+          query: requestBody2,
+          dataSourceId: dataSourceId2,
         }),
       });
     });

--- a/public/components/query_compare/search_result/search/search_handler.test.ts
+++ b/public/components/query_compare/search_result/search/search_handler.test.ts
@@ -26,8 +26,8 @@ describe('SearchHandler', () => {
 
       expect(mockHttp.post).toHaveBeenCalledWith(ServiceEndpoints.GetSearchResults, {
         body: JSON.stringify({
-          query1: requestBody,
-          dataSourceId1: dataSourceId,
+          query: requestBody,
+          dataSourceId,
         }),
       });
     });
@@ -43,30 +43,37 @@ describe('SearchHandler', () => {
   });
 
   describe('performDualSearch', () => {
-    it('should call http.post with both queries', async () => {
+    it('should call http.post twice with separate queries', async () => {
       const requestBody1 = { query: { match: { title: 'test' } } };
       const requestBody2 = { query: { term: { status: 'active' } } };
       const dataSourceId1 = 'ds-123';
       const dataSourceId2 = 'ds-456';
 
+      mockHttp.post
+        .mockResolvedValueOnce({ result: { hits: { hits: [{ _id: '1' }] } } })
+        .mockResolvedValueOnce({ result: { hits: { hits: [{ _id: '2' }] } } });
+
       await searchHandler.performDualSearch(requestBody1, requestBody2, dataSourceId1, dataSourceId2);
 
-      expect(mockHttp.post).toHaveBeenCalledWith(ServiceEndpoints.GetSearchResults, {
+      expect(mockHttp.post).toHaveBeenCalledTimes(2);
+      expect(mockHttp.post).toHaveBeenNthCalledWith(1, ServiceEndpoints.GetSearchResults, {
         body: JSON.stringify({
-          query1: requestBody1,
-          query2: requestBody2,
-          dataSourceId1: dataSourceId1,
-          dataSourceId2: dataSourceId2,
+          query: requestBody1,
+          dataSourceId: dataSourceId1,
+        }),
+      });
+      expect(mockHttp.post).toHaveBeenNthCalledWith(2, ServiceEndpoints.GetSearchResults, {
+        body: JSON.stringify({
+          query: requestBody2,
+          dataSourceId: dataSourceId2,
         }),
       });
     });
 
     it('should return dual search results', async () => {
-      const expectedResults = {
-        result1: { hits: { hits: [{ _id: '1' }] } },
-        result2: { hits: { hits: [{ _id: '2' }] } },
-      };
-      mockHttp.post.mockResolvedValue(expectedResults);
+      mockHttp.post
+        .mockResolvedValueOnce({ result: { hits: { hits: [{ _id: '1' }] } } })
+        .mockResolvedValueOnce({ result: { hits: { hits: [{ _id: '2' }] } } });
 
       const result = await searchHandler.performDualSearch(
         { query: {} },
@@ -75,7 +82,12 @@ describe('SearchHandler', () => {
         'ds-2'
       );
 
-      expect(result).toEqual(expectedResults);
+      expect(result).toEqual({
+        result1: { hits: { hits: [{ _id: '1' }] } },
+        result2: { hits: { hits: [{ _id: '2' }] } },
+        errorMessage1: undefined,
+        errorMessage2: undefined,
+      });
     });
   });
 });

--- a/public/components/query_compare/search_result/search/search_handler.ts
+++ b/public/components/query_compare/search_result/search/search_handler.ts
@@ -12,20 +12,22 @@ export class SearchHandler {
   async performSearch(requestBody: any, dataSourceId: string) {
     return this.http.post(ServiceEndpoints.GetSearchResults, {
       body: JSON.stringify({
-        query1: requestBody,
-        dataSourceId1: dataSourceId,
+        query: requestBody,
+        dataSourceId,
       }),
     });
   }
 
-  async performDualSearch(requestBody1: any, requestBody2: any, dataSourceId1: string, dataSourceId2: string) {
-    return this.http.post(ServiceEndpoints.GetSearchResults, {
-      body: JSON.stringify({
-        query1: requestBody1,
-        query2: requestBody2,
-        dataSourceId1: dataSourceId1,
-        dataSourceId2: dataSourceId2,
-      }),
-    });
+  async performDualSearch(
+    requestBody1: any,
+    requestBody2: any,
+    dataSourceId1: string,
+    dataSourceId2: string
+  ) {
+    const [res1, res2] = await Promise.all([
+      this.performSearch(requestBody1, dataSourceId1),
+      this.performSearch(requestBody2, dataSourceId2),
+    ]);
+    return { result1: res1.result, result2: res2.result, errorMessage1: res1.errorMessage, errorMessage2: res2.errorMessage };
   }
 }

--- a/server/metrics/index.ts
+++ b/server/metrics/index.ts
@@ -17,7 +17,6 @@ export enum METRIC_NAME {
 }
 
 export enum METRIC_ACTION {
-  COMPARISON_SEARCH = 'comparison_search',
   SINGLE_SEARCH = 'single_search',
   FETCH_INDEX = 'fetch_index',
   FETCH_PIPELINE = 'fetch_pipeline',

--- a/server/routes/dsl_route.ts
+++ b/server/routes/dsl_route.ts
@@ -10,13 +10,6 @@ import { ILegacyScopedClusterClient, IRouter } from '../../../../src/core/server
 import { ServiceEndpoints, SEARCH_API } from '../../common';
 import { METRIC_ACTION, METRIC_NAME } from '../metrics';
 
-interface SearchResultsResponse {
-  result1?: any;
-  result2?: any;
-  errorMessage1?: any;
-  errorMessage2?: any;
-}
-
 interface SearchResultResponse {
   result: any;
   errorMsg: any;
@@ -32,163 +25,105 @@ export function registerDslRoute(router: IRouter, dataSourceEnabled: boolean) {
       validate: { body: schema.any() },
     },
     async (context, request, response) => {
-      const { query1, dataSourceId1, query2, dataSourceId2 } = request.body;
-      const actionName =
-        query1 && query2 ? METRIC_ACTION.COMPARISON_SEARCH : METRIC_ACTION.SINGLE_SEARCH;
-      const resBody: SearchResultsResponse = {};
+      const { query, dataSourceId = '' } = request.body;
+      const { index, pipeline = '', size = 10, ...rest } = query ?? {};
 
-      if (query1) {
-        const { index, pipeline, size, ...rest } = query1;
-        const params: RequestParams.Search =
-          pipeline !== ''
-            ? {
-                index,
-                size,
-                body: rest,
-                search_pipeline: pipeline,
-              }
-            : {
-                index,
-                size,
-                body: rest,
-              };
-        const start = performance.now();
-        try {
-          let resp;
-          const invalidCharactersPattern = /[\s,:\"*+\/\\|?#><]/;
-          if (
-            index !== index.toLowerCase() ||
-            index.startsWith('_') ||
-            index.startsWith('-') ||
-            invalidCharactersPattern.test(index)
-          ) {
-            resBody.errorMessage1 = {
+      const invalidCharactersPattern = /[\s,\"*+\/\\|?#><]/;
+      if (
+        !index ||
+        index !== index.toLowerCase() ||
+        index.startsWith('_') ||
+        index.startsWith('-') ||
+        invalidCharactersPattern.test(index)
+      ) {
+        return response.ok({
+          body: {
+            errorMessage: {
               statusCode: 400,
               body: 'Invalid Index or missing',
-            };
-          }
-          if (
-            pipeline !== '*' &&
-            pipeline !== '_none' &&
-            pipeline !== '' &&
-            !/^[a-zA-Z0-9_\-*]+(,[a-zA-Z0-9_\-*]+)*$/.test(pipeline)
-          ) {
-            resBody.errorMessage1 = {
-              statusCode: 400,
-              body: 'Invalid Pipepline',
-            };
-          }
-          if (dataSourceEnabled && dataSourceId1) {
-            const client = context.dataSource.opensearch.legacy.getClient(dataSourceId1);
-            resp = await client.callAPI('search', params);
-          } else {
-            resp = await context.core.opensearch.legacy.client.callAsCurrentUser('search', params);
-          }
-          const end = performance.now();
-          context.searchRelevance.metricsService.addMetric(
-            METRIC_NAME.SEARCH_RELEVANCE,
-            actionName,
-            200,
-            end - start
-          );
-          resBody.result1 = resp;
-        } catch (error) {
-          const end = performance.now();
-          context.searchRelevance.metricsService.addMetric(
-            METRIC_NAME.SEARCH_RELEVANCE,
-            actionName,
-            error.statusCode,
-            end - start
-          );
-
-          if (error.statusCode !== 404) console.error(error);
-
-          // Template: Error: {{Error.type}} – {{Error.reason}}
-          const errorMessage = `Error: ${error.body?.error?.type} - ${error.body?.error?.reason}`;
-
-          resBody.errorMessage1 = {
-            statusCode: error.statusCode || 500,
-            body: errorMessage,
-          };
-        }
+            },
+          },
+        });
       }
 
-      if (query2) {
-        const { index, pipeline, size, ...rest } = query2;
-        const params: RequestParams.Search =
-          pipeline !== ''
-            ? {
-                index,
-                size,
-                body: rest,
-                search_pipeline: pipeline,
-              }
-            : {
-                index,
-                size,
-                body: rest,
-              };
-
-        const start = performance.now();
-        try {
-          let resp;
-          const invalidCharactersPattern = /[\s,\"*+\/\\|?#><]/;
-          if (
-            index !== index.toLowerCase() ||
-            index.startsWith('_') ||
-            index.startsWith('-') ||
-            invalidCharactersPattern.test(index)
-          ) {
-            throw new Error('Index invalid or missing.');
-          }
-          if (
-            pipeline !== '*' &&
-            pipeline !== '_none' &&
-            pipeline !== '' &&
-            !/^[a-zA-Z0-9_\-*]+(,[a-zA-Z0-9_\-*]+)*$/.test(pipeline)
-          ) {
-            resBody.errorMessage1 = {
+      if (
+        pipeline &&
+        pipeline !== '*' &&
+        pipeline !== '_none' &&
+        pipeline !== '' &&
+        !/^[a-zA-Z0-9_\-*]+(,[a-zA-Z0-9_\-*]+)*$/.test(pipeline)
+      ) {
+        return response.ok({
+          body: {
+            errorMessage: {
               statusCode: 400,
-              body: 'Invalid Pipepline',
-            };
-          }
-          if (dataSourceEnabled && dataSourceId2) {
-            const client = context.dataSource.opensearch.legacy.getClient(dataSourceId2);
-            resp = await client.callAPI('search', params);
-          } else {
-            resp = await context.core.opensearch.legacy.client.callAsCurrentUser('search', params);
-          }
-          const end = performance.now();
-          context.searchRelevance.metricsService.addMetric(
-            METRIC_NAME.SEARCH_RELEVANCE,
-            actionName,
-            200,
-            end - start
-          );
-          resBody.result2 = resp;
-        } catch (error) {
-          const end = performance.now();
-          if (error.statusCode !== 404) console.error(error);
-          context.searchRelevance.metricsService.addMetric(
-            METRIC_NAME.SEARCH_RELEVANCE,
-            actionName,
-            error.statusCode,
-            end - start
-          );
-
-          // Template: Error: {{Error.type}} – {{Error.reason}}
-          const errorMessage = `Error: ${error.body?.error?.type} - ${error.body?.error?.reason}`;
-
-          resBody.errorMessage2 = {
-            statusCode: error.statusCode || 500,
-            body: errorMessage,
-          };
-        }
+              body: 'Invalid Pipeline',
+            },
+          },
+        });
       }
 
-      return response.ok({
-        body: resBody,
-      });
+      const params: RequestParams.Search =
+        pipeline !== ''
+          ? {
+              index,
+              size,
+              body: rest,
+              search_pipeline: pipeline,
+            }
+          : {
+              index,
+              size,
+              body: rest,
+            };
+
+      const start = performance.now();
+      try {
+        let resp;
+        if (dataSourceEnabled && dataSourceId) {
+          const client = context.dataSource.opensearch.legacy.getClient(dataSourceId);
+          resp = await client.callAPI('search', params);
+        } else {
+          resp = await context.core.opensearch.legacy.client.callAsCurrentUser('search', params);
+        }
+
+        const end = performance.now();
+        context.searchRelevance.metricsService.addMetric(
+          METRIC_NAME.SEARCH_RELEVANCE,
+          METRIC_ACTION.SINGLE_SEARCH,
+          200,
+          end - start
+        );
+
+        return response.ok({
+          body: {
+            result: resp,
+          },
+        });
+      } catch (error) {
+        const end = performance.now();
+        context.searchRelevance.metricsService.addMetric(
+          METRIC_NAME.SEARCH_RELEVANCE,
+          METRIC_ACTION.SINGLE_SEARCH,
+          error.statusCode || 500,
+          end - start
+        );
+
+        if (error.statusCode !== 404) console.error(error);
+
+        const errorMessage = `Error: ${error.body?.error?.type || 'Unknown'} - ${
+          error.body?.error?.reason || 'Unknown reason'
+        }`;
+
+        return response.ok({
+          body: {
+            errorMessage: {
+              statusCode: error.statusCode || 500,
+              body: errorMessage,
+            },
+          },
+        });
+      }
     }
   );
 


### PR DESCRIPTION
## Description

Fixes #784.

This PR refactors `GetSearchResults` to operate on a single query per request, removing the duplicated `query1` / `query2` handling in the API while preserving existing functionality.

### Changes

#### Server

* Simplified `GetSearchResults` request/response contract:

  * Request: `{ query, dataSourceId }`
  * Response: `{ result }` or `{ errorMessage }`
* Removed duplicated search execution and validation logic
* Preserved support for cross-cluster indices (`remote:index`)
* Fixed pipeline validation typo (`Pipepline` → `Pipeline`)
* Return validation errors immediately instead of continuing execution
* Removed unused `COMPARISON_SEARCH` metric

#### Client

* Updated all `GetSearchResults` consumers to use the new API contract:

  * Query Compare
  * Pairwise Experiments
  * Evaluation Experiments
  * Hybrid Optimizer
  * Search and Agent handlers
* Query comparison now performs two parallel requests using `Promise.all`
* Removed response normalization logic that existed to support the old dual-query API

#### Tests

* Updated affected unit tests to reflect the new API contract
* All existing search result tests pass

### Notes

This work continues the approach originally proposed in #504, updated and rebased for the current codebase and the work tracked in #784.


### Check List

- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test
  - [ ] Integration tests pass: `yarn cypress:run-without-security --config "baseUrl=http://localhost:5601" --spec "cypress/integration/plugins/search-relevance-dashboards/*.js"` (see [Developer Guide](DEVELOPER_GUIDE.md#integration-tests))
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
