### PR TITLE
Fix issue with sample dataset

### DIFF
--- a/server/sample_data/ubi_sample_data.ts
+++ b/server/sample_data/ubi_sample_data.ts
@@ -10,7 +10,6 @@ import { AppLinkSchema } from '../../../../src/plugins/home/server/services/samp
 import {
   appendDataSourceId,
   getSavedObjectsWithDataSource,
-  overwriteSavedObjectsWithWorkspaceId,
 } from '../../../../src/plugins/home/server/services/sample_data/data_sets/util';
 import { getUbiSavedObjects } from './ubi_saved_objects';
 
@@ -142,8 +141,6 @@ export function ubiSpecProvider(): SampleDatasetSchema {
     savedObjects: getUbiSavedObjects(),
     getDataSourceIntegratedSavedObjects: (dataSourceId?: string, dataSourceTitle?: string) =>
       getSavedObjectsWithDataSource(getUbiSavedObjects(), dataSourceId, dataSourceTitle),
-    getWorkspaceIntegratedSavedObjects: (workspaceId: string) =>
-      overwriteSavedObjectsWithWorkspaceId(getUbiSavedObjects(), workspaceId),
     dataIndices: getUbiDataIndices(),
     status: 'not_installed',
   };


### PR DESCRIPTION
### Description

Fix issue with sample dataset

Currently the integ test is failing. 
https://github.com/opensearch-project/dashboards-search-relevance/actions/runs/27725061906/job/82019356025?pr=869
```
{"type":"log","@timestamp":"2026-06-17T23:27:13Z","tags":["fatal","root"],"pid":6802,"message":"Error: Unable to register sample dataset spec because it's invalid. ValidationError: \"getWorkspaceIntegratedSavedObjects\" is not allowed\n    at Object.registerSampleDataset (/home/runner/work/dashboards-search-relevance/dashboards-search-relevance/OpenSearch-Dashboards/src/plugins/home/server/services/sample_data/sample_data_registry.ts:88:17)\n    at SearchRelevancePlugin.addUbiSampleData (/home/runner/work/dashboards-search-relevance/dashboards-search-relevance/OpenSearch-Dashboards/plugins/dashboards-search-relevance/server/plugin.ts:56:21)\n    at SearchRelevancePlugin.setup (/home/runner/work/dashboards-search-relevance/dashboards-search-relevance/OpenSearch-Dashboards/plugins/dashboards-search-relevance/server/plugin.ts:110:12)"}
```

### Issues Resolved

N/A

### Check List

- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test
  - [ ] Integration tests pass: `yarn cypress:run-without-security --config "baseUrl=http://localhost:5601" --spec "cypress/integration/plugins/search-relevance-dashboards/*.js"` (see [Developer Guide](DEVELOPER_GUIDE.md#integration-tests))
- [ ] New functionality has been documented.
- [X] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
