### PR TITLE
fix: surface backend error message and status code instead of a generic unknown error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * Hide AnalyticEngine data sources from DSL-dependent data source dropdowns ([#846](https://github.com/opensearch-project/dashboards-search-relevance/pull/846))
 * Fix infinite re-render loop in useDataSourceUrlSync caused by unstable location object reference ([#859](https://github.com/opensearch-project/dashboards-search-relevance/pull/859))
 * Fix MetricsService.trim() to evict expired entries from all interval-keyed metric maps ([#879](https://github.com/opensearch-project/dashboards-search-relevance/issues/879))
+* Surface the backend error message and status code (e.g. a 403 security_exception) instead of a generic "unknown error" when list and detail views fail to load ([#873](https://github.com/opensearch-project/dashboards-search-relevance/issues/873))
 
 ### Infrastructure
 

--- a/common/error_handling.test.ts
+++ b/common/error_handling.test.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { DISABLED_BACKEND_PLUGIN_MESSAGE, extractUserMessageFromError } from './error_handling';
+
+describe('extractUserMessageFromError', () => {
+  it('returns the activation hint when the backend plugin is disabled', () => {
+    const err = { body: { message: DISABLED_BACKEND_PLUGIN_MESSAGE } };
+    expect(extractUserMessageFromError(err)).toBe(
+      'Search Relevance Workbench is disabled. Please activate the opensearch-search-relevance plugin.'
+    );
+  });
+
+  it('surfaces the status and backend message for a 403 security_exception (res.customError shape)', () => {
+    // Mirrors what the plugin server returns: status lives on the response,
+    // the reason on body.message, with no statusCode in the body.
+    const err = {
+      body: {
+        message:
+          'Data Source Error: [security_exception] no permissions for [cluster:admin/opensearch/search_relevance/experiment/get]',
+        attributes: { error: 'Forbidden' },
+      },
+      response: { status: 403 },
+    };
+    expect(extractUserMessageFromError(err)).toBe(
+      '403: Data Source Error: [security_exception] no permissions for [cluster:admin/opensearch/search_relevance/experiment/get]'
+    );
+  });
+
+  it('prefers body.statusCode over response.status when both are present', () => {
+    const err = { body: { statusCode: 502, message: 'boom' }, response: { status: 500 } };
+    expect(extractUserMessageFromError(err)).toBe('502: boom');
+  });
+
+  it('returns the bare message when no status code is available', () => {
+    const err = { body: { message: 'boom' } };
+    expect(extractUserMessageFromError(err)).toBe('boom');
+  });
+
+  it('returns null when the error has no body', () => {
+    expect(extractUserMessageFromError(new Error('plain'))).toBeNull();
+  });
+
+  it('returns null for a nullish error', () => {
+    expect(extractUserMessageFromError(undefined)).toBeNull();
+    expect(extractUserMessageFromError(null)).toBeNull();
+  });
+
+  it('returns null when the body has no usable message', () => {
+    expect(extractUserMessageFromError({ body: { statusCode: 502 } })).toBeNull();
+  });
+});

--- a/common/error_handling.ts
+++ b/common/error_handling.ts
@@ -1,11 +1,18 @@
 export const DISABLED_BACKEND_PLUGIN_MESSAGE = 'Search Relevance Workbench is disabled';
 
-export const extractUserMessageFromError = (err: any) => {
-  if (err instanceof Error) {
-    const errorWithBody = err as any;
-    if (errorWithBody.body && errorWithBody.body.message === DISABLED_BACKEND_PLUGIN_MESSAGE) {
-      return 'Search Relevance Workbench is disabled. Please activate the opensearch-search-relevance plugin.';
-    }
+export const extractUserMessageFromError = (err: any): string | null => {
+  const body = err?.body;
+  if (!body) {
+    return null;
+  }
+  if (body.message === DISABLED_BACKEND_PLUGIN_MESSAGE) {
+    return 'Search Relevance Workbench is disabled. Please activate the opensearch-search-relevance plugin.';
+  }
+  // Surface the backend-provided reason (e.g. a 403 security_exception) instead of a
+  // generic fallback, prefixing the HTTP status code when one is available.
+  if (typeof body.message === 'string' && body.message) {
+    const statusCode = body.statusCode ?? err?.response?.status;
+    return statusCode ? `${statusCode}: ${body.message}` : body.message;
   }
   return null;
 };


### PR DESCRIPTION
### Description

When a list or detail view failed to load, the UI showed a generic "Failed to load ... due to an unknown error", even when the backend returned a clear reason. For example, a 403 `security_exception` naming the exact missing cluster permission was discarded.

The cause is the shared `extractUserMessageFromError` helper (`common/error_handling.ts`): it only recognized the disabled-plugin case and returned `null` for everything else, so every caller fell back to the generic string.

This change makes the helper return the backend-provided `body.message`, prefixed with the HTTP status code when one is available (`body.statusCode`, falling back to `response.status`), while preserving the disabled-plugin activation hint. Because the helper is shared, this fixes the experiments, query set, search configuration, and judgment views together.

The issue also suggests an "ideally" 403/permissions hint. I scoped this PR to the two "at minimum" asks (status code + backend message) and am happy to add a tailored hint as a follow-up if you'd prefer.

Added unit tests for `extractUserMessageFromError` covering the disabled-plugin hint, the 403 `res.customError` shape, `body.statusCode` precedence, a bare message, and the null/no-body paths.

### Issues Resolved

Fixes #873

### Check List

- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.