### PR TITLE
Fix sample data registration failure when workspace is disabled

### DIFF
--- a/server/plugin.ts
+++ b/server/plugin.ts
@@ -50,10 +50,12 @@ export class SearchRelevancePlugin
     this.staticAssetsService = new StaticAssetsService(this.logger.get('static-assets'));
   }
 
-  // Register standalone UBI sample dataset
   private addUbiSampleData(home: HomeServerPluginSetup) {
-    // Register standalone UBI sample dataset
-    home.sampleData.registerSampleDataset(ubiSpecProvider);
+    try {
+      home.sampleData.registerSampleDataset(() => ubiSpecProvider(true));
+    } catch (e) {
+      home.sampleData.registerSampleDataset(() => ubiSpecProvider(false));
+    }
   }
 
   public async setup(core: CoreSetup, { dataSource, home }: SearchRelevancePluginSetupDependencies) {

--- a/server/sample_data/ubi_sample_data.ts
+++ b/server/sample_data/ubi_sample_data.ts
@@ -126,7 +126,7 @@ const ubiDescription = i18n.translate('searchRelevance.sampleData.ubiSpecDescrip
   defaultMessage: 'Sample User Behavior Insights (UBI) data for search relevance analysis.',
 });
 
-export function ubiSpecProvider(): SampleDatasetSchema {
+export function ubiSpecProvider(workspaceEnabled: boolean = false): SampleDatasetSchema {
   return {
     id: 'ubi',
     name: ubiName,
@@ -142,8 +142,10 @@ export function ubiSpecProvider(): SampleDatasetSchema {
     savedObjects: getUbiSavedObjects(),
     getDataSourceIntegratedSavedObjects: (dataSourceId?: string, dataSourceTitle?: string) =>
       getSavedObjectsWithDataSource(getUbiSavedObjects(), dataSourceId, dataSourceTitle),
-    getWorkspaceIntegratedSavedObjects: (workspaceId: string) =>
-      overwriteSavedObjectsWithWorkspaceId(getUbiSavedObjects(), workspaceId),
+    ...(workspaceEnabled && {
+      getWorkspaceIntegratedSavedObjects: (workspaceId: string) =>
+        overwriteSavedObjectsWithWorkspaceId(getUbiSavedObjects(), workspaceId),
+    }),
     dataIndices: getUbiDataIndices(),
     status: 'not_installed',
   };


### PR DESCRIPTION
### Description

Fix sample data registration failure when workspace is disabled.


### Issues Resolved

Binary build has been failing while registering sample data as it does not contains workspace

### Check List

- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test
  - [ ] Integration tests pass: `yarn cypress:run-without-security --config "baseUrl=http://localhost:5601" --spec "cypress/integration/plugins/search-relevance-dashboards/*.js"` (see [Developer Guide](DEVELOPER_GUIDE.md#integration-tests))
- [ ] New functionality has been documented.
- [X] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
