### PR TITLE
Fix MetricsService.trim() to evict expired entries from all interval-keyed maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * Poll judgment detail view while status is PROCESSING so ratings appear when async generation completes ([#857](https://github.com/opensearch-project/dashboards-search-relevance/issues/857))
 * Hide AnalyticEngine data sources from DSL-dependent data source dropdowns ([#846](https://github.com/opensearch-project/dashboards-search-relevance/pull/846))
 * Fix infinite re-render loop in useDataSourceUrlSync caused by unstable location object reference ([#859](https://github.com/opensearch-project/dashboards-search-relevance/pull/859))
+* Fix MetricsService.trim() to evict expired entries from all interval-keyed metric maps ([#879](https://github.com/opensearch-project/dashboards-search-relevance/issues/879))
 
 ### Infrastructure
 

--- a/server/metrics/metrics_service.test.ts
+++ b/server/metrics/metrics_service.test.ts
@@ -3,7 +3,25 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { METRIC_INTERVAL } from './';
 import { MetricsService, MetricsServiceSetup } from './';
+
+type InternalMetricsService = MetricsService & {
+  data: Record<number, unknown>;
+  overall: Record<number, unknown>;
+  componentCounts: Record<number, unknown>;
+  statusCodeCounts: Record<number, unknown>;
+};
+
+const getIntervalKeys = (service: MetricsService) => {
+  const internal = service as InternalMetricsService;
+  return {
+    data: Object.keys(internal.data),
+    overall: Object.keys(internal.overall),
+    componentCounts: Object.keys(internal.componentCounts),
+    statusCodeCounts: Object.keys(internal.statusCodeCounts),
+  };
+};
 
 describe('MetricsService', () => {
   let metricsService: MetricsService;
@@ -96,22 +114,84 @@ describe('MetricsService', () => {
   });
 
   describe('trim', () => {
-    it('should remove old metrics data', () => {
+    it('should trim all interval-keyed maps when the retention window expires', () => {
       jest.useFakeTimers('modern');
       jest.setSystemTime(0);
-      setup.addMetric('component1', 'action1', 200, 100);
-      jest.advanceTimersByTime(60000);
-      setup.addMetric('component1', 'action1', 200, 200);
-      jest.advanceTimersByTime(60000);
-      setup.addMetric('component1', 'action1', 200, 300);
-      jest.advanceTimersByTime(60000);
-      metricsService.trim();
+
+      const WINDOW_SIZE = 3;
+      const intervalMs = METRIC_INTERVAL.ONE_MINUTE;
+      const trimmedSetup = metricsService.setup(intervalMs, WINDOW_SIZE);
+
+      for (let i = 0; i < 10; i++) {
+        trimmedSetup.addMetric('component1', 'action1', 200, 100);
+        jest.advanceTimersByTime(intervalMs);
+      }
+
+      const keys = getIntervalKeys(metricsService);
+
+      expect(keys.data.length).toBeLessThanOrEqual(WINDOW_SIZE + 1);
+      expect(keys.overall).toEqual(keys.data);
+      expect(keys.componentCounts).toEqual(keys.data);
+      expect(keys.statusCodeCounts).toEqual(keys.data);
+    });
+
+    it('should remove expired intervals from all maps on explicit trim', () => {
+      jest.useFakeTimers('modern');
       jest.setSystemTime(0);
-      const stats = setup.getStats();
-      expect(stats.data).toEqual({});
-      expect(stats.overall).toEqual({ response_time_avg: 0, requests_per_second: 0 });
-      expect(stats.counts_by_component).toEqual({});
-      expect(stats.counts_by_status_code).toEqual({});
+
+      const intervalMs = METRIC_INTERVAL.ONE_MINUTE;
+      const trimmedSetup = metricsService.setup(intervalMs, 3);
+
+      trimmedSetup.addMetric('component1', 'action1', 200, 100);
+      jest.advanceTimersByTime(intervalMs);
+      trimmedSetup.addMetric('component1', 'action1', 200, 200);
+      jest.advanceTimersByTime(intervalMs);
+      trimmedSetup.addMetric('component1', 'action1', 200, 300);
+      jest.advanceTimersByTime(intervalMs);
+      trimmedSetup.addMetric('component1', 'action1', 200, 400);
+
+      expect(getIntervalKeys(metricsService)).toEqual({
+        data: ['0', '1', '2', '3'],
+        overall: ['0', '1', '2', '3'],
+        componentCounts: ['0', '1', '2', '3'],
+        statusCodeCounts: ['0', '1', '2', '3'],
+      });
+
+      jest.advanceTimersByTime(intervalMs * 2);
+      metricsService.trim();
+
+      expect(getIntervalKeys(metricsService)).toEqual({
+        data: ['2', '3'],
+        overall: ['2', '3'],
+        componentCounts: ['2', '3'],
+        statusCodeCounts: ['2', '3'],
+      });
+    });
+
+    it('should retain recent interval stats after trim', () => {
+      jest.useFakeTimers('modern');
+      jest.setSystemTime(0);
+
+      const intervalMs = METRIC_INTERVAL.ONE_MINUTE;
+      const trimmedSetup = metricsService.setup(intervalMs, 3);
+
+      trimmedSetup.addMetric('component1', 'action1', 200, 100);
+      jest.advanceTimersByTime(intervalMs);
+      trimmedSetup.addMetric('component1', 'action1', 200, 200);
+      jest.advanceTimersByTime(intervalMs);
+      trimmedSetup.addMetric('component1', 'action1', 200, 300);
+      jest.advanceTimersByTime(intervalMs);
+      trimmedSetup.addMetric('component1', 'action1', 200, 400);
+      jest.advanceTimersByTime(intervalMs);
+
+      const stats = trimmedSetup.getStats();
+      expect(stats.data['component1']['action1'][200]).toEqual({
+        response_time_total: 400,
+        count: 1,
+      });
+      expect(stats.overall.response_time_avg).toEqual(400);
+      expect(stats.counts_by_component['component1']).toEqual(1);
+      expect(stats.counts_by_status_code[200]).toEqual(1);
     });
   });
 });

--- a/server/metrics/metrics_service.ts
+++ b/server/metrics/metrics_service.ts
@@ -145,10 +145,17 @@ export class MetricsService {
     const oldestTimestampToKeep = Math.floor(
       (Date.now() - this.windowSize * this.interval) / this.interval
     );
-    for (const timestampStr in this.data) {
-      const timestamp = parseInt(timestampStr);
+    this.trimIntervalMap(this.data, oldestTimestampToKeep);
+    this.trimIntervalMap(this.overall, oldestTimestampToKeep);
+    this.trimIntervalMap(this.componentCounts, oldestTimestampToKeep);
+    this.trimIntervalMap(this.statusCodeCounts, oldestTimestampToKeep);
+  }
+
+  private trimIntervalMap<T>(map: Record<number, T>, oldestTimestampToKeep: number): void {
+    for (const timestampStr of Object.keys(map)) {
+      const timestamp = parseInt(timestampStr, 10);
       if (timestamp < oldestTimestampToKeep) {
-        delete this.data[timestamp];
+        delete map[timestamp];
       }
     }
   }


### PR DESCRIPTION
## Summary

Fixes #879.

`MetricsService.trim()` only evicted expired interval entries from `data`. The corresponding entries in `overall`, `componentCounts`, and `statusCodeCounts` were never removed, causing stale interval data to accumulate indefinitely over the lifetime of the Dashboards process.

This change applies retention trimming consistently across all interval-keyed metric maps and adds regression tests to verify bounded retention behavior.

## Changes

### Metrics retention fix

* Update `MetricsService.trim()` to evict expired intervals from:

  * `data`
  * `overall`
  * `componentCounts`
  * `statusCodeCounts`
* Extract shared trimming logic into `trimIntervalMap()` to avoid duplication and ensure consistent retention behavior.

### Test coverage

* Add regression test verifying that all interval-keyed maps respect the configured retention window.
* Add regression test verifying explicit `trim()` behavior across all metric maps.
* Add regression test ensuring recent interval statistics remain available after trimming.
* Replace the previous trim test, which validated behavior indirectly through `getStats()` and did not detect stale entries in the underlying interval maps.

### Documentation

* Add changelog entry for the fix.

## Testing

```bash
yarn test server/metrics/metrics_service.test.ts
```

All metrics service tests pass, including the new retention regression tests.

## Impact

This change prevents stale interval entries from accumulating in server-side metric structures while preserving existing metrics aggregation and `/stats` behavior.
