### PR TITLE
Load experiment resources in parallel after experiment fetch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * Add /search-relevance slash command for chatbot with welcome message and AI-assisted search relevance tuning ([#843](https://github.com/opensearch-project/dashboards-search-relevance/pull/843))
 
 ### Enhancements
+* Load experiment detail resources in parallel after the initial experiment fetch ([#882](https://github.com/opensearch-project/dashboards-search-relevance/issues/882))
 * Make Query Set description optional on create ([#758](https://github.com/opensearch-project/dashboards-search-relevance/issues/758))
 
 ### Bug Fixes

--- a/public/components/experiment/__tests__/experiment_resource_loader.test.ts
+++ b/public/components/experiment/__tests__/experiment_resource_loader.test.ts
@@ -1,0 +1,117 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ServiceEndpoints } from '../../../../common';
+import {
+  ExperimentResourceIds,
+  loadExperimentResourcesParallel,
+} from '../services/experiment_resource_loader';
+
+const sampleIds: ExperimentResourceIds = {
+  experimentId: 'exp-1',
+  searchConfigurationId: 'sc-1',
+  querySetId: 'qs-1',
+  judgmentId: 'j-1',
+  isScheduled: true,
+  scheduledExperimentJobId: 'sched-1',
+};
+
+const sourceForPath = (path: string) => {
+  const id = path.split('/').pop();
+  return { hits: { hits: [{ _source: { id } }] } };
+};
+
+const createConcurrentTrackingHttp = () => {
+  let inFlight = 0;
+  let maxConcurrent = 0;
+
+  const get = jest.fn(async () => {
+    inFlight += 1;
+    maxConcurrent = Math.max(maxConcurrent, inFlight);
+    await new Promise((resolve) => setImmediate(resolve));
+    inFlight -= 1;
+    return { hits: { hits: [{ _source: { id: 'resource' } }] } };
+  });
+
+  return {
+    http: { get },
+    getMaxConcurrent: () => maxConcurrent,
+  };
+};
+
+describe('loadExperimentResourcesParallel', () => {
+  it('returns null when the experiment is not found', async () => {
+    const http = {
+      get: jest.fn().mockResolvedValue({ hits: { hits: [] } }),
+    };
+
+    const resources = await loadExperimentResourcesParallel(http, sampleIds);
+
+    expect(resources).toBeNull();
+    expect(http.get).toHaveBeenCalledTimes(1);
+    expect(http.get).toHaveBeenCalledWith(`${ServiceEndpoints.Experiments}/exp-1`, {});
+  });
+
+  it('loads dependent resources concurrently after the experiment fetch', async () => {
+    const { http, getMaxConcurrent } = createConcurrentTrackingHttp();
+
+    await loadExperimentResourcesParallel(http, sampleIds);
+
+    expect(http.get).toHaveBeenCalledTimes(5);
+    expect(getMaxConcurrent()).toBeGreaterThanOrEqual(4);
+  });
+
+  it('returns all experiment resources', async () => {
+    const http = {
+      get: jest.fn(async (path: string) => sourceForPath(path)),
+    };
+
+    const resources = await loadExperimentResourcesParallel(http, sampleIds);
+
+    expect(resources).toEqual({
+      experiment: { id: 'exp-1' },
+      searchConfiguration: { id: 'sc-1' },
+      querySet: { id: 'qs-1' },
+      judgmentSet: { id: 'j-1' },
+      scheduledExperimentJob: { id: 'sched-1' },
+    });
+  });
+
+  it('calls expected endpoints with dataSourceId when provided', async () => {
+    const http = {
+      get: jest.fn(async (path: string) => sourceForPath(path)),
+    };
+    const dsOptions = { query: { dataSourceId: 'ds-abc' } };
+
+    await loadExperimentResourcesParallel(http, sampleIds, 'ds-abc');
+
+    expect(http.get).toHaveBeenCalledTimes(5);
+    expect(http.get).toHaveBeenCalledWith(`${ServiceEndpoints.Experiments}/exp-1`, dsOptions);
+    expect(http.get).toHaveBeenCalledWith(
+      `${ServiceEndpoints.SearchConfigurations}/sc-1`,
+      dsOptions
+    );
+    expect(http.get).toHaveBeenCalledWith(`${ServiceEndpoints.QuerySets}/qs-1`, dsOptions);
+    expect(http.get).toHaveBeenCalledWith(`${ServiceEndpoints.Judgments}/j-1`, dsOptions);
+    expect(http.get).toHaveBeenCalledWith(
+      `${ServiceEndpoints.ScheduledExperiments}/sched-1`,
+      dsOptions
+    );
+  });
+
+  it('skips scheduled job fetch when the experiment is not scheduled', async () => {
+    const http = {
+      get: jest.fn(async (path: string) => sourceForPath(path)),
+    };
+
+    const resources = await loadExperimentResourcesParallel(http, {
+      ...sampleIds,
+      isScheduled: false,
+    });
+
+    expect(http.get).toHaveBeenCalledTimes(4);
+    expect(resources?.scheduledExperimentJob).toBeNull();
+  });
+});

--- a/public/components/experiment/services/experiment_resource_loader.ts
+++ b/public/components/experiment/services/experiment_resource_loader.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { CoreStart } from '../../../../../../../src/core/public';
+import { ServiceEndpoints } from '../../../../common';
+
+export interface ExperimentResourceIds {
+  experimentId: string;
+  searchConfigurationId: string;
+  querySetId: string;
+  judgmentId: string;
+  isScheduled?: boolean;
+  scheduledExperimentJobId?: string;
+}
+
+export interface ExperimentResources {
+  experiment: unknown;
+  searchConfiguration: unknown;
+  querySet: unknown;
+  judgmentSet: unknown;
+  scheduledExperimentJob: unknown | null;
+}
+
+const sanitizeResponse = (response: unknown) =>
+  (response as { hits?: { hits?: Array<{ _source?: unknown }> } })?.hits?.hits?.[0]?._source ??
+  undefined;
+
+const dsOpts = (dataSourceId?: string | null) =>
+  dataSourceId ? { query: { dataSourceId } } : {};
+
+/**
+ * Fetch experiment first, then load independent resources in parallel.
+ * Used by evaluation_experiment_view.tsx and hybrid_optimizer_experiment_view.tsx.
+ */
+export async function loadExperimentResourcesParallel(
+  http: CoreStart['http'],
+  ids: ExperimentResourceIds,
+  dataSourceId?: string | null
+): Promise<ExperimentResources | null> {
+  const options = dsOpts(dataSourceId);
+
+  const experiment = await http
+    .get(`${ServiceEndpoints.Experiments}/${ids.experimentId}`, options)
+    .then(sanitizeResponse);
+
+  if (!experiment) {
+    return null;
+  }
+
+  const schedulePromise =
+    ids.isScheduled && ids.scheduledExperimentJobId
+      ? http
+          .get(`${ServiceEndpoints.ScheduledExperiments}/${ids.scheduledExperimentJobId}`, options)
+          .then(sanitizeResponse)
+      : Promise.resolve(null);
+
+  const [searchConfiguration, querySet, judgmentSet, scheduledExperimentJob] = await Promise.all([
+    http
+      .get(`${ServiceEndpoints.SearchConfigurations}/${ids.searchConfigurationId}`, options)
+      .then(sanitizeResponse),
+    http.get(`${ServiceEndpoints.QuerySets}/${ids.querySetId}`, options).then(sanitizeResponse),
+    http.get(`${ServiceEndpoints.Judgments}/${ids.judgmentId}`, options).then(sanitizeResponse),
+    schedulePromise,
+  ]);
+
+  return { experiment, searchConfiguration, querySet, judgmentSet, scheduledExperimentJob };
+}

--- a/public/components/experiment/views/evaluation_experiment_view.tsx
+++ b/public/components/experiment/views/evaluation_experiment_view.tsx
@@ -57,6 +57,7 @@ import {
   QueryEvaluationRow,
   QueryEvaluationStatus,
 } from '../utils/query_evaluation_builder';
+import { loadExperimentResourcesParallel } from '../services/experiment_resource_loader';
 
 interface EvaluationExperimentViewProps extends RouteComponentProps<{ id: string }> {
   http: CoreStart['http'];
@@ -89,8 +90,6 @@ export const EvaluationExperimentView: React.FC<EvaluationExperimentViewProps> =
   const [selectedQueryScores, setSelectedQueryScores] = useState<
     Array<{ docId: string; rating: string }>
   >([]);
-
-  const sanitizeResponse = (response: any) => response?.hits?.hits?.[0]?._source || undefined;
 
   const handleQueryClick = useCallback(
     (queryText: string) => {
@@ -145,39 +144,26 @@ export const EvaluationExperimentView: React.FC<EvaluationExperimentViewProps> =
     const fetchExperiment = async () => {
       try {
         setLoading(true);
-        const options = dataSourceId ? { query: { dataSourceId } } : {};
-        
-        const _experiment = await http
-          .get(ServiceEndpoints.Experiments + '/' + inputExperiment.id, options)
-          .then(sanitizeResponse);
-        const parsedExperiment = _experiment && toExperiment(_experiment);
-        const _searchConfiguration =
-          _experiment &&
-          (await http
-            .get(
-              ServiceEndpoints.SearchConfigurations + '/' + inputExperiment.searchConfigurationId,
-              options
-            )
-            .then(sanitizeResponse));
-        const _querySet =
-          _experiment &&
-          (await http
-            .get(ServiceEndpoints.QuerySets + '/' + inputExperiment.querySetId, options)
-            .then(sanitizeResponse));
-        const _judgmentSet =
-          _experiment &&
-          (await http
-            .get(ServiceEndpoints.Judgments + '/' + inputExperiment.judgmentId, options)
-            .then(sanitizeResponse));
 
-        const _scheduledExperimentJob =
-          _experiment && inputExperiment.isScheduled &&
-          (await http
-            .get(
-              ServiceEndpoints.ScheduledExperiments + '/' + inputExperiment.scheduledExperimentJobId,
-              options
-            )
-            .then(sanitizeResponse));
+        const resources = await loadExperimentResourcesParallel(
+          http,
+          {
+            experimentId: inputExperiment.id,
+            searchConfigurationId: inputExperiment.searchConfigurationId,
+            querySetId: inputExperiment.querySetId,
+            judgmentId: inputExperiment.judgmentId,
+            isScheduled: inputExperiment.isScheduled,
+            scheduledExperimentJobId: inputExperiment.scheduledExperimentJobId,
+          },
+          dataSourceId
+        );
+
+        const _experiment = resources?.experiment;
+        const parsedExperiment = _experiment && toExperiment(_experiment);
+        const _searchConfiguration = resources?.searchConfiguration;
+        const _querySet = resources?.querySet;
+        const _judgmentSet = resources?.judgmentSet;
+        const _scheduledExperimentJob = resources?.scheduledExperimentJob;
 
         const queryTexts = getQueryTextsFromQuerySet(_querySet?.querySetQueries);
         const querySetSize = queryTexts.length;

--- a/public/components/experiment/views/hybrid_optimizer_experiment_view.tsx
+++ b/public/components/experiment/views/hybrid_optimizer_experiment_view.tsx
@@ -30,6 +30,7 @@ import {
   MAP_TOOL_TIP,
   COVERAGE_TOOL_TIP,
 } from '../../../../common';
+import { loadExperimentResourcesParallel } from '../services/experiment_resource_loader';
 
 interface VariantEvaluation {
   metrics: Record<string, number>;
@@ -71,44 +72,29 @@ export const HybridOptimizerExperimentView: React.FC<HybridOptimizerExperimentVi
 
   const [tableColumns, setTableColumns] = useState<any[]>([]);
 
-  const sanitizeResponse = (response: any) => response?.hits?.hits?.[0]?._source || undefined;
-
   useEffect(() => {
     const fetchExperiment = async () => {
       try {
         setLoading(true);
-        const options = dataSourceId ? { query: { dataSourceId } } : {};
-        
-        const _experiment = await http
-          .get(ServiceEndpoints.Experiments + '/' + inputExperiment.id, options)
-          .then(sanitizeResponse);
-        const _searchConfiguration =
-          _experiment &&
-          (await http
-            .get(
-              ServiceEndpoints.SearchConfigurations + '/' + inputExperiment.searchConfigurationId,
-              options
-            )
-            .then(sanitizeResponse));
-        const _querySet =
-          _experiment &&
-          (await http
-            .get(ServiceEndpoints.QuerySets + '/' + inputExperiment.querySetId, options)
-            .then(sanitizeResponse));
-        const _judgmentSet =
-          _experiment &&
-          (await http
-            .get(ServiceEndpoints.Judgments + '/' + inputExperiment.judgmentId, options)
-            .then(sanitizeResponse));
 
-        const _scheduledExperimentJob =
-          _experiment && inputExperiment.isScheduled &&
-          (await http
-            .get(
-              ServiceEndpoints.ScheduledExperiments + '/' + inputExperiment.scheduledExperimentJobId,
-              options
-            )
-            .then(sanitizeResponse));            
+        const resources = await loadExperimentResourcesParallel(
+          http,
+          {
+            experimentId: inputExperiment.id,
+            searchConfigurationId: inputExperiment.searchConfigurationId,
+            querySetId: inputExperiment.querySetId,
+            judgmentId: inputExperiment.judgmentId,
+            isScheduled: inputExperiment.isScheduled,
+            scheduledExperimentJobId: inputExperiment.scheduledExperimentJobId,
+          },
+          dataSourceId
+        );
+
+        const _experiment = resources?.experiment;
+        const _searchConfiguration = resources?.searchConfiguration;
+        const _querySet = resources?.querySet;
+        const _judgmentSet = resources?.judgmentSet;
+        const _scheduledExperimentJob = resources?.scheduledExperimentJob;
 
         if (_experiment && _searchConfiguration && _querySet && _judgmentSet) {
           const querySetSize = _querySet && Object.keys(_querySet.querySetQueries).length;
@@ -228,7 +214,7 @@ export const HybridOptimizerExperimentView: React.FC<HybridOptimizerExperimentVi
     };
 
     fetchExperiment();
-  }, [http, inputExperiment]);
+  }, [http, inputExperiment, dataSourceId]);
 
   const fetchVariantDetails = async (variantId: string) => {
     try {


### PR DESCRIPTION
## Summary

* Extract shared `loadExperimentResourcesParallel` helper for experiment detail resource loading
* Load Search Configuration, Query Set, Judgment Set, and Scheduled Job (when applicable) concurrently via `Promise.all`
* Update both `evaluation_experiment_view.tsx` and `hybrid_optimizer_experiment_view.tsx` to use the shared loader
* Add unit tests covering concurrent execution, endpoint invocation, returned resource shape, and scheduled-job skip behavior

Closes #882.

After the experiment record is fetched, the remaining resource requests are independent. This change loads those resources concurrently, reducing experiment detail page latency without changing API contracts or user-visible behavior.

Resource identifiers are already validated upstream by `toExperiment()` before these views render, so behavior remains unchanged while improving load performance.

## Test Plan

```bash
yarn test public/components/experiment/__tests__/experiment_resource_loader.test.ts
```

Manual verification:

* Open a Search Evaluation experiment detail page and verify Search Configuration, Query Set, Judgment Set, and metrics load correctly
* Open a Hybrid Optimizer experiment detail page and verify the same behavior
* Open a scheduled experiment and verify schedule details are displayed correctly
* Open a non-scheduled experiment and verify no scheduled-job requests are made and no related errors appear
