### PR TITLE
feat: add chatCommandEnabled feature flag for /search-relevance command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Features
 * Add optional description field to Search Configuration create form, detail view, and listing ([#798](https://github.com/opensearch-project/dashboards-search-relevance/issues/798))
 * Add /search-relevance slash command for chatbot with welcome message and AI-assisted search relevance tuning ([#843](https://github.com/opensearch-project/dashboards-search-relevance/pull/843))
+* Add chatCommandEnabled dynamic config feature flag to gate /search-relevance command registration ([#890](https://github.com/opensearch-project/dashboards-search-relevance/pull/890))
 
 ### Enhancements
 * Load experiment detail resources in parallel after the initial experiment fetch ([#882](https://github.com/opensearch-project/dashboards-search-relevance/issues/882))

--- a/config.ts
+++ b/config.ts
@@ -8,6 +8,7 @@ import { schema, TypeOf } from '@osd/config-schema';
 import { METRIC_INTERVAL, DEFAULT_WINDOW_SIZE } from './server/metrics';
 
 export const configSchema = schema.object({
+  chatCommandEnabled: schema.boolean({ defaultValue: false }),
   metrics: schema.object({
     metricInterval: schema.number({ defaultValue: METRIC_INTERVAL.ONE_MINUTE }),
     windowSize: schema.number({ min: 2, max: 10, defaultValue: DEFAULT_WINDOW_SIZE }),

--- a/opensearch_dashboards.json
+++ b/opensearch_dashboards.json
@@ -16,5 +16,8 @@
     "home",
     "chat"
   ],
-  "supportedOSDataSourceVersions": ">=2.8.0"
+  "supportedOSDataSourceVersions": ">=2.8.0",
+  "configPath": [
+    "searchRelevanceDashboards"
+  ]
 }

--- a/public/plugin.test.ts
+++ b/public/plugin.test.ts
@@ -1,0 +1,157 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { SearchRelevancePlugin } from './plugin';
+import { coreMock } from '../../../src/core/public/mocks';
+
+const mockRegisterCommand = jest.fn().mockReturnValue(jest.fn());
+
+jest.mock('./chat/search_relevance_command', () => ({
+  registerSearchRelevanceCommand: jest.fn().mockReturnValue(jest.fn()),
+}));
+
+jest.mock('./plugin_nav', () => ({
+  registerAllPluginNavGroups: jest.fn(),
+}));
+
+jest.mock('./components/service_card/compare_query_card', () => ({
+  registerCompareQueryCard: jest.fn(),
+}));
+
+import { registerSearchRelevanceCommand } from './chat/search_relevance_command';
+
+describe('SearchRelevancePlugin', () => {
+  let plugin: SearchRelevancePlugin;
+  let coreSetupMock: ReturnType<typeof coreMock.createSetup>;
+  let coreStartMock: ReturnType<typeof coreMock.createStart>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    plugin = new SearchRelevancePlugin();
+    coreSetupMock = coreMock.createSetup();
+    coreStartMock = coreMock.createStart();
+  });
+
+  afterEach(() => {
+    plugin.stop();
+  });
+
+  describe('chatCommandEnabled feature flag', () => {
+    it('registers the command when chatCommandEnabled is true', () => {
+      const chatSetup = {
+        commandRegistry: { registerCommand: mockRegisterCommand },
+      };
+
+      plugin.setup(coreSetupMock as any, {
+        dataSource: {} as any,
+        dataSourceManagement: {} as any,
+        chat: chatSetup as any,
+      });
+
+      // Set capability to true
+      coreStartMock.application.capabilities = {
+        ...coreStartMock.application.capabilities,
+        searchRelevanceDashboards: { chatCommandEnabled: true },
+      };
+
+      plugin.start(coreStartMock as any, { dataSource: {} as any });
+
+      expect(registerSearchRelevanceCommand).toHaveBeenCalledWith(
+        coreSetupMock,
+        chatSetup
+      );
+    });
+
+    it('does not register the command when chatCommandEnabled is false', () => {
+      const chatSetup = {
+        commandRegistry: { registerCommand: mockRegisterCommand },
+      };
+
+      plugin.setup(coreSetupMock as any, {
+        dataSource: {} as any,
+        dataSourceManagement: {} as any,
+        chat: chatSetup as any,
+      });
+
+      // Set capability to false (default)
+      coreStartMock.application.capabilities = {
+        ...coreStartMock.application.capabilities,
+        searchRelevanceDashboards: { chatCommandEnabled: false },
+      };
+
+      plugin.start(coreStartMock as any, { dataSource: {} as any });
+
+      expect(registerSearchRelevanceCommand).not.toHaveBeenCalled();
+    });
+
+    it('does not register the command when chatCommandEnabled capability is missing', () => {
+      const chatSetup = {
+        commandRegistry: { registerCommand: mockRegisterCommand },
+      };
+
+      plugin.setup(coreSetupMock as any, {
+        dataSource: {} as any,
+        dataSourceManagement: {} as any,
+        chat: chatSetup as any,
+      });
+
+      // No searchRelevanceDashboards capability
+      coreStartMock.application.capabilities = {
+        ...coreStartMock.application.capabilities,
+      };
+
+      plugin.start(coreStartMock as any, { dataSource: {} as any });
+
+      expect(registerSearchRelevanceCommand).not.toHaveBeenCalled();
+    });
+
+    it('passes undefined chatSetup when chat plugin is not available', () => {
+      (registerSearchRelevanceCommand as jest.Mock).mockReturnValue(undefined);
+
+      plugin.setup(coreSetupMock as any, {
+        dataSource: {} as any,
+        dataSourceManagement: {} as any,
+        // No chat plugin
+      });
+
+      coreStartMock.application.capabilities = {
+        ...coreStartMock.application.capabilities,
+        searchRelevanceDashboards: { chatCommandEnabled: true },
+      };
+
+      plugin.start(coreStartMock as any, { dataSource: {} as any });
+
+      expect(registerSearchRelevanceCommand).toHaveBeenCalledWith(
+        coreSetupMock,
+        undefined
+      );
+    });
+
+    it('calls unregister on stop when command was registered', () => {
+      const mockUnregister = jest.fn();
+      (registerSearchRelevanceCommand as jest.Mock).mockReturnValue(mockUnregister);
+
+      const chatSetup = {
+        commandRegistry: { registerCommand: mockRegisterCommand },
+      };
+
+      plugin.setup(coreSetupMock as any, {
+        dataSource: {} as any,
+        dataSourceManagement: {} as any,
+        chat: chatSetup as any,
+      });
+
+      coreStartMock.application.capabilities = {
+        ...coreStartMock.application.capabilities,
+        searchRelevanceDashboards: { chatCommandEnabled: true },
+      };
+
+      plugin.start(coreStartMock as any, { dataSource: {} as any });
+      plugin.stop();
+
+      expect(mockUnregister).toHaveBeenCalled();
+    });
+  });
+});

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -96,9 +96,12 @@ export class SearchRelevancePlugin
       registerCompareQueryCard(contentManagement, core);
     }
 
-    if (core.application.capabilities.searchRelevanceDashboards?.chatCommandEnabled) {
+    if (
+      this.coreSetup &&
+      core.application.capabilities.searchRelevanceDashboards?.chatCommandEnabled
+    ) {
       this.unregisterSearchRelevanceCommand = registerSearchRelevanceCommand(
-        this.coreSetup!,
+        this.coreSetup,
         this.chatSetup
       );
     }

--- a/public/plugin.ts
+++ b/public/plugin.ts
@@ -36,11 +36,15 @@ export interface SearchRelevanceStartDependencies {
 export class SearchRelevancePlugin
   implements Plugin<SearchRelevancePluginSetup, SearchRelevancePluginStart> {
   private unregisterSearchRelevanceCommand?: () => void;
+  private coreSetup?: CoreSetup;
+  private chatSetup?: ChatPluginSetup;
 
   public setup(
     core: CoreSetup,
     { dataSource, dataSourceManagement, chat }: SearchRelevancePluginSetupDependencies
   ): SearchRelevancePluginSetup {
+    this.coreSetup = core;
+    this.chatSetup = chat;
     // Register an application into the side navigation menu
     core.application.register({
       id: PLUGIN_ID,
@@ -71,7 +75,6 @@ export class SearchRelevancePlugin
       },
     });
     registerAllPluginNavGroups(core);
-    this.unregisterSearchRelevanceCommand = registerSearchRelevanceCommand(core, chat);
     // Return methods that should be available to other plugins
     return {
       getGreeting() {
@@ -92,6 +95,14 @@ export class SearchRelevancePlugin
     if (contentManagement) {
       registerCompareQueryCard(contentManagement, core);
     }
+
+    if (core.application.capabilities.searchRelevanceDashboards?.chatCommandEnabled) {
+      this.unregisterSearchRelevanceCommand = registerSearchRelevanceCommand(
+        this.coreSetup!,
+        this.chatSetup
+      );
+    }
+
     return {};
   }
 

--- a/server/plugin.test.ts
+++ b/server/plugin.test.ts
@@ -1,0 +1,273 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { of } from 'rxjs';
+import { SearchRelevancePlugin } from './plugin';
+
+jest.mock('./routes', () => ({
+  defineRoutes: jest.fn(),
+  registerSearchRelevanceRoutes: jest.fn(),
+}));
+
+jest.mock('./routes/ml_route_service', () => ({
+  registerMLRoutes: jest.fn(),
+}));
+
+jest.mock('./sample_data/ubi_sample_data', () => ({
+  ubiSpecProvider: {},
+}));
+
+jest.mock('./services/static_assets_service', () => ({
+  StaticAssetsService: jest.fn().mockImplementation(() => ({
+    setup: jest.fn(),
+  })),
+}));
+
+jest.mock('./metrics/metrics_service', () => ({
+  MetricsService: jest.fn().mockImplementation(() => ({
+    setup: jest.fn().mockReturnValue({}),
+  })),
+}));
+
+describe('SearchRelevancePlugin (server)', () => {
+  let mockInitializerContext: any;
+  let mockCoreSetup: any;
+  let mockDeps: any;
+  let registerProviderFn: jest.Mock;
+  let registerSwitcherFn: jest.Mock;
+
+  const createPlugin = (configOverrides: Record<string, any> = {}) => {
+    const config = {
+      chatCommandEnabled: false,
+      metrics: { metricInterval: 60000, windowSize: 5 },
+      ...configOverrides,
+    };
+
+    const mockLoggerInstance: any = {
+      debug: jest.fn(),
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      get: jest.fn(),
+    };
+    // logger.get() returns a child logger with the same shape
+    mockLoggerInstance.get.mockReturnValue(mockLoggerInstance);
+
+    mockInitializerContext = {
+      config: {
+        create: jest.fn().mockReturnValue(of(config)),
+      },
+      logger: {
+        get: jest.fn().mockReturnValue(mockLoggerInstance),
+      },
+    };
+
+    return new SearchRelevancePlugin(mockInitializerContext);
+  };
+
+  beforeEach(() => {
+    registerProviderFn = jest.fn();
+    registerSwitcherFn = jest.fn();
+
+    mockCoreSetup = {
+      uiSettings: { register: jest.fn() },
+      capabilities: {
+        registerProvider: registerProviderFn,
+        registerSwitcher: registerSwitcherFn,
+      },
+      dynamicConfigService: {
+        getStartService: jest.fn(),
+      },
+      http: {
+        createRouter: jest.fn().mockReturnValue({
+          get: jest.fn(),
+          post: jest.fn(),
+          put: jest.fn(),
+          delete: jest.fn(),
+        }),
+        registerRouteHandlerContext: jest.fn(),
+      },
+      opensearch: {
+        legacy: {
+          createClient: jest.fn(),
+        },
+      },
+    };
+
+    mockDeps = {
+      dataSource: {},
+    };
+  });
+
+  describe('capabilities provider', () => {
+    it('registers chatCommandEnabled as false when config default is false', async () => {
+      const plugin = createPlugin({ chatCommandEnabled: false });
+      await plugin.setup(mockCoreSetup, mockDeps);
+
+      expect(registerProviderFn).toHaveBeenCalledTimes(1);
+      const provider = registerProviderFn.mock.calls[0][0];
+      const capabilities = provider();
+
+      expect(capabilities).toEqual({
+        searchRelevanceDashboards: {
+          chatCommandEnabled: false,
+        },
+      });
+    });
+
+    it('registers chatCommandEnabled as true when config is true', async () => {
+      const plugin = createPlugin({ chatCommandEnabled: true });
+      await plugin.setup(mockCoreSetup, mockDeps);
+
+      expect(registerProviderFn).toHaveBeenCalledTimes(1);
+      const provider = registerProviderFn.mock.calls[0][0];
+      const capabilities = provider();
+
+      expect(capabilities).toEqual({
+        searchRelevanceDashboards: {
+          chatCommandEnabled: true,
+        },
+      });
+    });
+  });
+
+  describe('capabilities switcher', () => {
+    it('overrides chatCommandEnabled from dynamic config', async () => {
+      const plugin = createPlugin({ chatCommandEnabled: false });
+      await plugin.setup(mockCoreSetup, mockDeps);
+
+      expect(registerSwitcherFn).toHaveBeenCalledTimes(1);
+      const switcher = registerSwitcherFn.mock.calls[0][0];
+
+      const mockRequest = {};
+      const mockCapabilities = {
+        searchRelevanceDashboards: { chatCommandEnabled: false },
+      };
+
+      const mockStore = {};
+      const mockClient = {
+        getConfig: jest.fn().mockResolvedValue({ chatCommandEnabled: true }),
+      };
+
+      mockCoreSetup.dynamicConfigService.getStartService.mockResolvedValue({
+        createStoreFromRequest: jest.fn().mockReturnValue(mockStore),
+        getClient: jest.fn().mockReturnValue(mockClient),
+      });
+
+      const result = await switcher(mockRequest, mockCapabilities);
+
+      expect(result).toEqual({
+        searchRelevanceDashboards: {
+          chatCommandEnabled: true,
+        },
+      });
+      expect(mockClient.getConfig).toHaveBeenCalledWith(
+        { pluginConfigPath: 'searchRelevanceDashboards' },
+        { asyncLocalStorageContext: mockStore }
+      );
+    });
+
+    it('returns empty object when store cannot be created', async () => {
+      const plugin = createPlugin({ chatCommandEnabled: true });
+      await plugin.setup(mockCoreSetup, mockDeps);
+
+      const switcher = registerSwitcherFn.mock.calls[0][0];
+      const mockRequest = {};
+      const mockCapabilities = {
+        searchRelevanceDashboards: { chatCommandEnabled: true },
+      };
+
+      mockCoreSetup.dynamicConfigService.getStartService.mockResolvedValue({
+        createStoreFromRequest: jest.fn().mockReturnValue(null),
+        getClient: jest.fn(),
+      });
+
+      const result = await switcher(mockRequest, mockCapabilities);
+
+      expect(result).toEqual({});
+    });
+
+    it('returns empty object and logs warning when dynamic config throws', async () => {
+      const plugin = createPlugin({ chatCommandEnabled: false });
+      await plugin.setup(mockCoreSetup, mockDeps);
+
+      const switcher = registerSwitcherFn.mock.calls[0][0];
+      const mockRequest = {};
+      const mockCapabilities = {
+        searchRelevanceDashboards: { chatCommandEnabled: false },
+      };
+
+      mockCoreSetup.dynamicConfigService.getStartService.mockRejectedValue(
+        new Error('Dynamic config unavailable')
+      );
+
+      const result = await switcher(mockRequest, mockCapabilities);
+
+      expect(result).toEqual({});
+      // Verify the warn was called
+      const logger = mockInitializerContext.logger.get();
+      expect(logger.warn).toHaveBeenCalledWith(
+        'Failed to read dynamic config for searchRelevanceDashboards capability',
+        expect.any(Error)
+      );
+    });
+
+    it('returns empty object when getConfig throws', async () => {
+      const plugin = createPlugin({ chatCommandEnabled: false });
+      await plugin.setup(mockCoreSetup, mockDeps);
+
+      const switcher = registerSwitcherFn.mock.calls[0][0];
+      const mockRequest = {};
+      const mockCapabilities = {
+        searchRelevanceDashboards: { chatCommandEnabled: false },
+      };
+
+      const mockClient = {
+        getConfig: jest.fn().mockRejectedValue(new Error('Config read failed')),
+      };
+
+      mockCoreSetup.dynamicConfigService.getStartService.mockResolvedValue({
+        createStoreFromRequest: jest.fn().mockReturnValue({}),
+        getClient: jest.fn().mockReturnValue(mockClient),
+      });
+
+      const result = await switcher(mockRequest, mockCapabilities);
+
+      expect(result).toEqual({});
+    });
+
+    it('preserves existing capabilities while overriding chatCommandEnabled', async () => {
+      const plugin = createPlugin({ chatCommandEnabled: false });
+      await plugin.setup(mockCoreSetup, mockDeps);
+
+      const switcher = registerSwitcherFn.mock.calls[0][0];
+      const mockRequest = {};
+      const mockCapabilities = {
+        searchRelevanceDashboards: {
+          chatCommandEnabled: false,
+          someOtherCapability: true,
+        },
+      };
+
+      const mockClient = {
+        getConfig: jest.fn().mockResolvedValue({ chatCommandEnabled: true }),
+      };
+
+      mockCoreSetup.dynamicConfigService.getStartService.mockResolvedValue({
+        createStoreFromRequest: jest.fn().mockReturnValue({}),
+        getClient: jest.fn().mockReturnValue(mockClient),
+      });
+
+      const result = await switcher(mockRequest, mockCapabilities);
+
+      expect(result).toEqual({
+        searchRelevanceDashboards: {
+          chatCommandEnabled: true,
+          someOtherCapability: true,
+        },
+      });
+    });
+  });
+});

--- a/server/plugin.ts
+++ b/server/plugin.ts
@@ -72,6 +72,33 @@ export class SearchRelevancePlugin
 
     const config: SearchRelevancePluginConfigType = await this.config$.pipe(first()).toPromise();
 
+    core.capabilities.registerProvider(() => ({
+      searchRelevanceDashboards: {
+        chatCommandEnabled: config.chatCommandEnabled,
+      },
+    }));
+
+    core.capabilities.registerSwitcher(async (request, capabilities) => {
+      try {
+        const dynamicConfigStartService = await core.dynamicConfigService.getStartService();
+        const store = dynamicConfigStartService.createStoreFromRequest(request);
+        if (!store) return {};
+        const client = dynamicConfigStartService.getClient();
+        const dynamicConfig = await client.getConfig(
+          { pluginConfigPath: 'searchRelevanceDashboards' },
+          { asyncLocalStorageContext: store }
+        );
+        return {
+          searchRelevanceDashboards: {
+            ...capabilities.searchRelevanceDashboards,
+            chatCommandEnabled: dynamicConfig.chatCommandEnabled,
+          },
+        };
+      } catch (e) {
+        return {};
+      }
+    });
+
     const metricsService: MetricsServiceSetup = this.metricsService.setup(
       config.metrics.metricInterval,
       config.metrics.windowSize

--- a/server/plugin.ts
+++ b/server/plugin.ts
@@ -95,6 +95,10 @@ export class SearchRelevancePlugin
           },
         };
       } catch (e) {
+        this.logger.warn(
+          'Failed to read dynamic config for searchRelevanceDashboards capability',
+          e
+        );
         return {};
       }
     });


### PR DESCRIPTION
### Description

Gate the /search-relevance slash command behind a dynamic config feature flag (`searchRelevanceDashboards.chatCommandEnabled`, default: `false`). When disabled, the command is not registered and will not appear in the chat interface.

The flag is exposed via capabilities and supports runtime override through the dynamic config service using `createStoreFromRequest` for correct request-scoped store resolution.

### Issues Resolved

N/A

### Check List

- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test
  - [ ] Integration tests pass: `yarn cypress:run-without-security --config "baseUrl=http://localhost:5601" --spec "cypress/integration/plugins/search-relevance-dashboards/*.js"` (see [Developer Guide](DEVELOPER_GUIDE.md#integration-tests))
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).