### PR TITLE
fix: accept numeric tokenLimit in judgment route validation (#662)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * Make Query Set description optional on create ([#758](https://github.com/opensearch-project/dashboards-search-relevance/issues/758))
 
 ### Bug Fixes
+* Fix judgment list creation failing when Token Limit is changed from the default 4000; server route validation expected a string but the UI sends a number ([#662](https://github.com/opensearch-project/dashboards-search-relevance/issues/662))
 * Fix Search Evaluation experiment view treating failed OpenSearch queries as zero search results (ZSR); show per-query status and separate notifications for failed, ZSR, and not-evaluated queries ([#733](https://github.com/opensearch-project/dashboards-search-relevance/pull/849))
 * Display stored reference answers on Query Set Details page ([#855](https://github.com/opensearch-project/dashboards-search-relevance/issues/855))
 * Poll judgment detail view while status is PROCESSING so ratings appear when async generation completes ([#857](https://github.com/opensearch-project/dashboards-search-relevance/issues/857))

--- a/server/routes/search_relevance_route_service.test.ts
+++ b/server/routes/search_relevance_route_service.test.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { IRouter } from '../../../../src/core/server';
+import { ServiceEndpoints } from '../../common';
+import { registerSearchRelevanceRoutes } from './search_relevance_route_service';
+
+const createMockRouter = () =>
+  ({
+    get: jest.fn(),
+    put: jest.fn(),
+    post: jest.fn(),
+    delete: jest.fn(),
+  }) as unknown as IRouter;
+
+const getJudgmentCreateRouteSchema = (router: IRouter) => {
+  const putCalls = (router.put as jest.Mock).mock.calls;
+  const judgmentRoute = putCalls.find(([config]) => config.path === ServiceEndpoints.Judgments);
+
+  if (!judgmentRoute) {
+    throw new Error('Judgment create route was not registered');
+  }
+
+  return judgmentRoute[0].validate.body;
+};
+
+describe('registerSearchRelevanceRoutes', () => {
+  describe('judgment create route validation', () => {
+    let bodySchema: ReturnType<typeof getJudgmentCreateRouteSchema>;
+
+    beforeEach(() => {
+      const router = createMockRouter();
+      registerSearchRelevanceRoutes(router, false);
+      bodySchema = getJudgmentCreateRouteSchema(router);
+    });
+
+    it('accepts tokenLimit as a number, matching the client payload', () => {
+      const payload = {
+        name: 'test judgment',
+        type: 'LLM',
+        querySetId: 'qs-1',
+        searchConfigurationList: ['sc-1'],
+        size: 5,
+        modelId: 'model-1',
+        tokenLimit: 1000,
+      };
+
+      expect(bodySchema.validate(payload)).toEqual(payload);
+    });
+
+    it('rejects non-numeric tokenLimit values', () => {
+      expect(() =>
+        bodySchema.validate({
+          name: 'test judgment',
+          type: 'LLM',
+          tokenLimit: 'not-a-number',
+        })
+      ).toThrow();
+    });
+  });
+});

--- a/server/routes/search_relevance_route_service.ts
+++ b/server/routes/search_relevance_route_service.ts
@@ -246,7 +246,7 @@ export function registerSearchRelevanceRoutes(router: IRouter, dataSourceEnabled
           searchConfigurationList: schema.maybe(schema.arrayOf(schema.string())),
           size: schema.maybe(schema.number()),
           modelId: schema.maybe(schema.string()),
-          tokenLimit: schema.maybe(schema.string()),
+          tokenLimit: schema.maybe(schema.number()),
           ignoreFailure: schema.maybe(schema.boolean()),
           contextFields: schema.maybe(schema.arrayOf(schema.string())),
           promptTemplate: schema.maybe(schema.string()),


### PR DESCRIPTION
## Summary

Fixes #662 

The Judgment creation form submits `tokenLimit` as a number, while the judgment create route validated it as a string. As a result, creating a judgment failed whenever the Token Limit was changed from the default value.

This PR:
- Changes the route validation for `tokenLimit` from `schema.maybe(schema.string())` to `schema.maybe(schema.number())`.
- Adds route-level regression tests covering the registered judgment create route schema.
- Updates the CHANGELOG.

## Testing

### Verified
- Added route-level regression tests that:
  - Accept a numeric `tokenLimit` on the registered judgment create route.
  - Reject non-numeric `tokenLimit` values.
- Ran:
  ```bash
  yarn test server/routes/search_relevance_route_service.test.ts
  ```
  All tests passed.

### End-to-end verification
I wasn't able to perform an end-to-end verification because my local environment doesn't have an LLM model configured. The Judgment creation form requires a Model ID before submission, so I couldn't verify the full create workflow. The added regression tests cover the route validation change directly.

The added regression tests cover the route validation change directly. If a maintainer has an environment with an LLM model configured, I'd appreciate it if you could also verify that creating a judgment with a non-default Token Limit (for example, `1000`) now succeeds.

### Check List

- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test
  - [ ] Integration tests pass: `yarn cypress:run-without-security --config "baseUrl=http://localhost:5601" --spec "cypress/integration/plugins/search-relevance-dashboards/*.js"` (see [Developer Guide](DEVELOPER_GUIDE.md#integration-tests))
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
