### PR TITLE
fix: surface backend error messages in detail views (#894)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * Fix infinite re-render loop in useDataSourceUrlSync caused by unstable location object reference ([#859](https://github.com/opensearch-project/dashboards-search-relevance/pull/859))
 * Fix MetricsService.trim() to evict expired entries from all interval-keyed metric maps ([#879](https://github.com/opensearch-project/dashboards-search-relevance/issues/879))
 * Surface the backend error message and status code (e.g. a 403 security_exception) instead of a generic "unknown error" when list and detail views fail to load ([#873](https://github.com/opensearch-project/dashboards-search-relevance/issues/873))
+* Surface backend error messages in Search Configuration and Judgment detail views instead of generic load-failure messages ([#894](https://github.com/opensearch-project/dashboards-search-relevance/issues/894))
 
 ### Infrastructure
 

--- a/public/components/judgment/__tests__/use_judgment_view.test.ts
+++ b/public/components/judgment/__tests__/use_judgment_view.test.ts
@@ -5,7 +5,16 @@
 
 import { renderHook, waitFor } from '@testing-library/react';
 import { useJudgmentView } from '../hooks/use_judgment_view';
-import { ServiceEndpoints } from '../../../../common';
+import { ServiceEndpoints, extractUserMessageFromError } from '../../../../common';
+
+jest.mock('../../../../common', () => ({
+  ...jest.requireActual('../../../../common'),
+  extractUserMessageFromError: jest.fn(),
+}));
+
+const mockExtractUserMessageFromError = extractUserMessageFromError as jest.MockedFunction<
+  typeof extractUserMessageFromError
+>;
 
 const mockHttp = {
   get: jest.fn(),
@@ -14,6 +23,7 @@ const mockHttp = {
 describe('useJudgmentView', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockExtractUserMessageFromError.mockReturnValue(null);
   });
 
   it('should fetch judgment by id successfully', async () => {
@@ -63,9 +73,7 @@ describe('useJudgmentView', () => {
 
     mockHttp.get.mockResolvedValue(mockResponse);
 
-    const { result } = renderHook(() =>
-      useJudgmentView(mockHttp as any, 'nonexistent')
-    );
+    const { result } = renderHook(() => useJudgmentView(mockHttp as any, 'nonexistent'));
 
     await waitFor(() => expect(result.current.loading).toBe(false));
 
@@ -84,6 +92,28 @@ describe('useJudgmentView', () => {
     expect(result.current.judgment).toBe(null);
     expect(result.current.loading).toBe(false);
     expect(result.current.error).toBe('Error loading judgment data');
+  });
+
+  it('should surface backend error message when available', async () => {
+    const customError = {
+      body: {
+        statusCode: 404,
+        message: '[resource_not_found_exception] Document not found: judgment-1',
+      },
+    };
+    mockHttp.get.mockRejectedValue(customError);
+    mockExtractUserMessageFromError.mockReturnValue(
+      '404: [resource_not_found_exception] Document not found: judgment-1'
+    );
+
+    const { result } = renderHook(() => useJudgmentView(mockHttp as any, 'judgment-1'));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.error).toBe(
+      '404: [resource_not_found_exception] Document not found: judgment-1'
+    );
+    expect(mockExtractUserMessageFromError).toHaveBeenCalledWith(customError);
   });
 
   it('should format JSON correctly', () => {
@@ -150,10 +180,9 @@ describe('useJudgmentView', () => {
 
     await waitFor(() => expect(result.current.loading).toBe(false));
 
-    expect(mockHttp.get).toHaveBeenCalledWith(
-      `${ServiceEndpoints.Judgments}/1`,
-      { query: { dataSourceId: 'my-ds' } }
-    );
+    expect(mockHttp.get).toHaveBeenCalledWith(`${ServiceEndpoints.Judgments}/1`, {
+      query: { dataSourceId: 'my-ds' },
+    });
   });
 
   it('should poll while judgment status is PROCESSING and stop when COMPLETED', async () => {
@@ -200,9 +229,7 @@ describe('useJudgmentView', () => {
       },
     };
 
-    mockHttp.get
-      .mockResolvedValueOnce(processingResponse)
-      .mockResolvedValueOnce(completedResponse);
+    mockHttp.get.mockResolvedValueOnce(processingResponse).mockResolvedValueOnce(completedResponse);
 
     const { result } = renderHook(() => useJudgmentView(mockHttp as any, '1'));
 
@@ -236,9 +263,6 @@ describe('useJudgmentView', () => {
 
     await waitFor(() => expect(result.current.loading).toBe(false));
 
-    expect(mockHttp.get).toHaveBeenCalledWith(
-      `${ServiceEndpoints.Judgments}/1`,
-      {}
-    );
+    expect(mockHttp.get).toHaveBeenCalledWith(`${ServiceEndpoints.Judgments}/1`, {});
   });
 });

--- a/public/components/judgment/hooks/use_judgment_view.ts
+++ b/public/components/judgment/hooks/use_judgment_view.ts
@@ -5,7 +5,7 @@
 
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { CoreStart } from '../../../../../../src/core/public';
-import { ServiceEndpoints } from '../../../../common';
+import { ServiceEndpoints, extractUserMessageFromError } from '../../../../common';
 
 export interface JudgmentData {
   id: string;
@@ -20,7 +20,11 @@ export interface JudgmentData {
 const POLL_INTERVAL_MS = 5000;
 const MAX_POLL_ERRORS = 3;
 
-export const useJudgmentView = (http: CoreStart['http'], id: string, dataSourceId?: string | null) => {
+export const useJudgmentView = (
+  http: CoreStart['http'],
+  id: string,
+  dataSourceId?: string | null
+) => {
   const [judgment, setJudgment] = useState<JudgmentData | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
@@ -68,7 +72,8 @@ export const useJudgmentView = (http: CoreStart['http'], id: string, dataSourceI
         console.error('Failed to load judgment', err);
         if (showLoading) {
           setJudgment(null);
-          setError('Error loading judgment data');
+          const errorMessage = extractUserMessageFromError(err);
+          setError(errorMessage || 'Error loading judgment data');
           stopPolling();
         } else {
           pollErrorCount.current += 1;

--- a/public/components/query_set/__tests__/use_query_set_view.test.ts
+++ b/public/components/query_set/__tests__/use_query_set_view.test.ts
@@ -5,16 +5,16 @@
 
 import { renderHook, act, waitFor } from '@testing-library/react';
 import { useQuerySetView } from '../hooks/use_query_set_view';
+import { extractUserMessageFromError, ServiceEndpoints } from '../../../../common';
 
-// Mock the common module
 jest.mock('../../../../common', () => ({
-  ServiceEndpoints: {
-    QuerySets: '/api/relevancy/querySets',
-  },
-  extractUserMessageFromError: jest.fn(
-    (err) => 'Failed to load query set due to an unknown error.'
-  ),
+  ...jest.requireActual('../../../../common'),
+  extractUserMessageFromError: jest.fn(),
 }));
+
+const mockExtractUserMessageFromError = extractUserMessageFromError as jest.MockedFunction<
+  typeof extractUserMessageFromError
+>;
 
 const mockHttp = {
   get: jest.fn(),
@@ -23,6 +23,7 @@ const mockHttp = {
 describe('useQuerySetView', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockExtractUserMessageFromError.mockReturnValue(null);
   });
 
   it('initializes with loading state', () => {
@@ -95,8 +96,30 @@ describe('useQuerySetView', () => {
     await waitFor(() => expect(result.current.loading).toBe(false));
 
     expect(result.current.loading).toBe(false);
-    expect(result.current.error).toBe('Failed to load query set due to an unknown error.');
+    expect(result.current.error).toBe('Error loading query set data');
     expect(result.current.querySet).toBe(null);
+  });
+
+  it('surfaces backend error message when available', async () => {
+    const customError = {
+      body: {
+        statusCode: 404,
+        message: '[resource_not_found_exception] Document not found: query-set-1',
+      },
+    };
+    mockHttp.get.mockRejectedValue(customError);
+    mockExtractUserMessageFromError.mockReturnValue(
+      '404: [resource_not_found_exception] Document not found: query-set-1'
+    );
+
+    const { result } = renderHook(() => useQuerySetView(mockHttp, 'query-set-1'));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.error).toBe(
+      '404: [resource_not_found_exception] Document not found: query-set-1'
+    );
+    expect(mockExtractUserMessageFromError).toHaveBeenCalledWith(customError);
   });
 
   it('does not fetch when id is empty', () => {
@@ -116,7 +139,7 @@ describe('useQuerySetView', () => {
 
     await waitFor(() => expect(result.current.loading).toBe(false));
 
-    expect(mockHttp.get).toHaveBeenCalledWith('/api/relevancy/querySets/test-id', {
+    expect(mockHttp.get).toHaveBeenCalledWith(`${ServiceEndpoints.QuerySets}/test-id`, {
       query: { dataSourceId: 'my-datasource' },
     });
   });
@@ -131,7 +154,7 @@ describe('useQuerySetView', () => {
 
     await waitFor(() => expect(result.current.loading).toBe(false));
 
-    expect(mockHttp.get).toHaveBeenCalledWith('/api/relevancy/querySets/test-id', {});
+    expect(mockHttp.get).toHaveBeenCalledWith(`${ServiceEndpoints.QuerySets}/test-id`, {});
   });
 
   it('refetches when id changes', async () => {

--- a/public/components/search_configuration/__tests__/use_search_configuration_view.test.ts
+++ b/public/components/search_configuration/__tests__/use_search_configuration_view.test.ts
@@ -5,7 +5,16 @@
 
 import { renderHook, waitFor } from '@testing-library/react';
 import { useSearchConfigurationView } from '../hooks/use_search_configuration_view';
-import { ServiceEndpoints } from '../../../../common';
+import { ServiceEndpoints, extractUserMessageFromError } from '../../../../common';
+
+jest.mock('../../../../common', () => ({
+  ...jest.requireActual('../../../../common'),
+  extractUserMessageFromError: jest.fn(),
+}));
+
+const mockExtractUserMessageFromError = extractUserMessageFromError as jest.MockedFunction<
+  typeof extractUserMessageFromError
+>;
 
 // Mock console.error to avoid noise in tests
 const mockConsoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
@@ -17,6 +26,7 @@ const mockHttp = {
 describe('useSearchConfigurationView', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockExtractUserMessageFromError.mockReturnValue(null);
   });
 
   afterEach(() => {
@@ -42,9 +52,7 @@ describe('useSearchConfigurationView', () => {
 
     mockHttp.get.mockResolvedValue(mockResponse);
 
-    const { result } = renderHook(() =>
-      useSearchConfigurationView(mockHttp as any, '1')
-    );
+    const { result } = renderHook(() => useSearchConfigurationView(mockHttp as any, '1'));
 
     await waitFor(() => expect(result.current.loading).toBe(false));
 
@@ -68,9 +76,7 @@ describe('useSearchConfigurationView', () => {
 
     mockHttp.get.mockResolvedValue(mockResponse);
 
-    const { result } = renderHook(() =>
-      useSearchConfigurationView(mockHttp as any, 'nonexistent')
-    );
+    const { result } = renderHook(() => useSearchConfigurationView(mockHttp as any, 'nonexistent'));
 
     await waitFor(() => expect(result.current.loading).toBe(false));
 
@@ -132,9 +138,7 @@ describe('useSearchConfigurationView', () => {
   it('should handle fetch error', async () => {
     mockHttp.get.mockRejectedValue(new Error('Fetch failed'));
 
-    const { result } = renderHook(() =>
-      useSearchConfigurationView(mockHttp as any, '1')
-    );
+    const { result } = renderHook(() => useSearchConfigurationView(mockHttp as any, '1'));
 
     await waitFor(() => expect(result.current.loading).toBe(false));
 
@@ -143,22 +147,41 @@ describe('useSearchConfigurationView', () => {
     expect(result.current.error).toBe('Error loading search configuration data');
   });
 
+  it('should surface backend error message when available', async () => {
+    const customError = {
+      body: {
+        statusCode: 404,
+        message: '[resource_not_found_exception] Document not found: config-1',
+      },
+    };
+    mockHttp.get.mockRejectedValue(customError);
+    mockExtractUserMessageFromError.mockReturnValue(
+      '404: [resource_not_found_exception] Document not found: config-1'
+    );
+
+    const { result } = renderHook(() => useSearchConfigurationView(mockHttp as any, 'config-1'));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.error).toBe(
+      '404: [resource_not_found_exception] Document not found: config-1'
+    );
+    expect(mockExtractUserMessageFromError).toHaveBeenCalledWith(customError);
+  });
+
   it('should pass dataSourceId when fetching a search configuration', async () => {
     const mockResponse = {
       hits: { hits: [{ _source: { id: '1', name: 'Test' } }] },
     };
     mockHttp.get.mockResolvedValue(mockResponse);
 
-    const { result } = renderHook(() =>
-      useSearchConfigurationView(mockHttp as any, '1', 'my-ds')
-    );
+    const { result } = renderHook(() => useSearchConfigurationView(mockHttp as any, '1', 'my-ds'));
 
     await waitFor(() => expect(result.current.loading).toBe(false));
 
-    expect(mockHttp.get).toHaveBeenCalledWith(
-      `${ServiceEndpoints.SearchConfigurations}/1`,
-      { query: { dataSourceId: 'my-ds' } }
-    );
+    expect(mockHttp.get).toHaveBeenCalledWith(`${ServiceEndpoints.SearchConfigurations}/1`, {
+      query: { dataSourceId: 'my-ds' },
+    });
   });
 
   it('should omit dataSourceId query param when not provided', async () => {
@@ -167,15 +190,10 @@ describe('useSearchConfigurationView', () => {
     };
     mockHttp.get.mockResolvedValue(mockResponse);
 
-    const { result } = renderHook(() =>
-      useSearchConfigurationView(mockHttp as any, '1')
-    );
+    const { result } = renderHook(() => useSearchConfigurationView(mockHttp as any, '1'));
 
     await waitFor(() => expect(result.current.loading).toBe(false));
 
-    expect(mockHttp.get).toHaveBeenCalledWith(
-      `${ServiceEndpoints.SearchConfigurations}/1`,
-      {}
-    );
+    expect(mockHttp.get).toHaveBeenCalledWith(`${ServiceEndpoints.SearchConfigurations}/1`, {});
   });
 });

--- a/public/components/search_configuration/hooks/use_search_configuration_view.ts
+++ b/public/components/search_configuration/hooks/use_search_configuration_view.ts
@@ -5,7 +5,7 @@
 
 import { useState, useEffect } from 'react';
 import { CoreStart } from '../../../../../../src/core/public';
-import { ServiceEndpoints } from '../../../../common';
+import { ServiceEndpoints, extractUserMessageFromError } from '../../../../common';
 
 export interface SearchConfigurationData {
   id: string;
@@ -18,7 +18,11 @@ export interface SearchConfigurationData {
   timestamp: string;
 }
 
-export const useSearchConfigurationView = (http: CoreStart['http'], id: string, dataSourceId?: string | null) => {
+export const useSearchConfigurationView = (
+  http: CoreStart['http'],
+  id: string,
+  dataSourceId?: string | null
+) => {
   const [searchConfiguration, setSearchConfiguration] = useState<SearchConfigurationData | null>(
     null
   );
@@ -29,8 +33,12 @@ export const useSearchConfigurationView = (http: CoreStart['http'], id: string, 
     const fetchSearchConfiguration = async () => {
       try {
         setLoading(true);
+        setError(null);
         const queryParams = dataSourceId ? { query: { dataSourceId } } : {};
-        const response = await http.get(`${ServiceEndpoints.SearchConfigurations}/${id}`, queryParams);
+        const response = await http.get(
+          `${ServiceEndpoints.SearchConfigurations}/${id}`,
+          queryParams
+        );
 
         if (response && response.hits && response.hits.hits && response.hits.hits.length > 0) {
           setSearchConfiguration(response.hits.hits[0]._source);
@@ -39,7 +47,8 @@ export const useSearchConfigurationView = (http: CoreStart['http'], id: string, 
         }
       } catch (err) {
         console.error('Failed to load search config', err);
-        setError('Error loading search configuration data');
+        const errorMessage = extractUserMessageFromError(err);
+        setError(errorMessage || 'Error loading search configuration data');
       } finally {
         setLoading(false);
       }


### PR DESCRIPTION
## Summary

Fixes #894 

The Query Set, Search Configuration, and Judgment detail pages displayed generic error messages even when the backend returned a more descriptive error.

This PR:

- Updates the Search Configuration detail view to use `extractUserMessageFromError()`.
- Updates the Judgment detail view to use `extractUserMessageFromError()`.
- Adds regression tests covering backend error message handling for Query Set, Search Configuration, and Judgment detail views.

> **Note:** The Query Set detail view already used `extractUserMessageFromError()` on `main`; this PR adds regression tests to ensure that behavior remains covered.

## Testing

### Verified

Added/updated unit tests to verify that:

- Query Set detail view surfaces backend error messages.
- Search Configuration detail view surfaces backend error messages.
- Judgment detail view surfaces backend error messages.

Ran:

```bash
yarn test public/components/query_set/__tests__/use_query_set_view.test.ts
yarn test public/components/search_configuration/__tests__/use_search_configuration_view.test.ts
yarn test public/components/judgment/__tests__/use_judgment_view.test.ts
```

All tests passed.


<img width="867" height="580" alt="Screenshot 2026-07-01 at 12 42 24 AM" src="https://github.com/user-attachments/assets/1b3e25cf-c2dd-44e7-84b7-0ed47d00d9de" />
similar for all 3

### Check List

- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test
  - [ ] Integration tests pass: `yarn cypress:run-without-security --config "baseUrl=http://localhost:5601" --spec "cypress/integration/plugins/search-relevance-dashboards/*.js"` (see [Developer Guide](DEVELOPER_GUIDE.md#integration-tests))
- [ ] New functionality has been documented.
- [ ] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
