### PR TITLE
Add venkat as maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # This should match the list of maintainers in https://github.com/opensearch-project/dashboards-search-relevance/blob/main/MAINTAINERS.md
-*   @bzhangam @fen-qin @heemin32 @junqiu-lei @martin-gaievski @epugh @iprithv
+*   @bzhangam @fen-qin @heemin32 @junqiu-lei @martin-gaievski @epugh @iprithv @venkateshwaracholan

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -13,6 +13,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Heemin Kim | [heemin32](https://github.com/heemin32)       | Amazon      |
 | Martin Gaievski | [heemin32](https://github.com/martin-gaievski)               | Amazon      |
 | Prithvi S    | [iprithv](https://github.com/iprithv)         | Cloudera      |
+| Venkateshwaran Shanmugham | [venkateshwaracholan](https://github.com/venkateshwaracholan)        | Cloudera |
 
 
 


### PR DESCRIPTION
### Description

I'm emailing (_copied from email thread_) because I'd like to nominate Venkat (@venkateshwaracholan) as a maintainer to the dashboards-search-relevance repository.

I'm structuring this email to try and highlight that he is more then a "let me take a ticket and write code for the narrow specific ticket", but that he has the best interests of the dashboards-search-relevance repo at heart.

Though of course he has written a lot of code, especially fixing things that I got wrong or couldn't fully implement in the first turn of the SRW crank:

Sustained contributions across the full plugin
Over roughly eight months (Nov 2025 – Jun 2026), Venkat has authored 17 PRs (~14 merged) and filed 8 issues, ranking #4 by commits. His work touches every major SRW surface — Query Sets, Judgments, Search Configurations, Experiments, Query Analysis, UX/accessibility, CI, and technical-debt cleanup. Recent highlights:

- **Judgment CSV Upload UI (#715)** — full CSV import with live preview, removing the need for manual API calls for non-technical users.
- **Failed Query vs Zero Search Results (#849)** — fixed misleading evaluation metrics by distinguishing Evaluated / Failed / ZSR / Not-run statuses.
- **Reference Answer Display (#856)** — closed the gap between backend storage and the UI for the `referenceAnswer` field.
- **Search Config Descriptions (#854)** — exposed the backend `description` field across create / list / detail / filter surfaces.

More importantly as a prospective Maintainer, he has been taking a holisitic view of the repo.  Here are some of my favorite examples:

Architectural review and community unblocking. On PR #832 he reviewed a community fix for metadata leaking into query text and argued against a `#`-delimiter hack that would break valid queries; @heemin32 agreed and redirected the fix to the root cause. On PR #843 he diagnosed a cross-PR CI failure, linked it to #857, and pointed maintainers to #858 so another contributor's PR could merge cleanly.

Proactive project health. Fixed 41 TypeScript syntax errors blocking judgment tests (#778), removed unused dead code after a codebase audit (#853, 979 tests passing), proposed the Clone & Edit RFC (#780) aligned with maintainer feedback on immutability, opened an i18n roadmap (#783), and attempted a CI infrastructure fix (#838) for Node.js version compatibility.


Lastly, I think it's important to measure if he will continue to be involved in the project for a signficant time, and I believe he will:

Professional alignment. As a Staff Software Engineer at Cloudera (Bangalore), Venkat works with OpenSearch-based systems in production daily, which gives him a strong read on the usability, operational, and workflow gaps that turn into improvements for SRW.

Planned responsibilities as maintainer: triage and mentor new contributors; review PRs (especially Query Sets, Judgments, Experiments, and CI/E2E areas where he has deep context); continue diagnosing flaky E2E tests and async-processing gaps; drive the RFCs he has already started (#780 Clone & Edit, #783 i18n); and help validate features across SRW workflows before milestone cuts. He's happy to begin with a trial reviewer/triage role before full write access if maintainers prefer a gradual path.