### PR TITLE
Show failed documents in the Judgment view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * Add chatCommandEnabled dynamic config feature flag to gate /search-relevance command registration ([#890](https://github.com/opensearch-project/dashboards-search-relevance/pull/890))
 
 ### Enhancements
+* Show which documents failed in the Judgment view: the ratings table now lists each query's unrated docs with a Failed status alongside the rated ones ([#899](https://github.com/opensearch-project/dashboards-search-relevance/pull/899))
 * Load experiment detail resources in parallel after the initial experiment fetch ([#882](https://github.com/opensearch-project/dashboards-search-relevance/issues/882))
 * Make Query Set description optional on create ([#758](https://github.com/opensearch-project/dashboards-search-relevance/issues/758))
 

--- a/public/components/judgment/__tests__/judgment_view.test.tsx
+++ b/public/components/judgment/__tests__/judgment_view.test.tsx
@@ -417,9 +417,16 @@ describe('JudgmentView', () => {
     );
 
     // The failed doc shows up alongside the rated one, with a Failed status and no score
-    expect(screen.getAllByText('C9').length).toBeGreaterThan(0);
-    expect(screen.getAllByText('Rated').length).toBeGreaterThan(0);
-    expect(screen.getAllByText('Failed').length).toBeGreaterThan(0);
-    expect(screen.getAllByText('N/A').length).toBeGreaterThan(0);
+    const rows = screen.getAllByRole('row');
+
+    const failedRow = rows.find((row) => row.textContent?.includes('C9'));
+    expect(failedRow).toBeDefined();
+    expect(failedRow!.textContent).toContain('Failed');
+    expect(failedRow!.textContent).toContain('N/A');
+
+    const ratedRow = rows.find((row) => row.textContent?.includes('A1'));
+    expect(ratedRow).toBeDefined();
+    expect(ratedRow!.textContent).toContain('Rated');
+    expect(ratedRow!.textContent).not.toContain('N/A');
   });
 });

--- a/public/components/judgment/__tests__/judgment_view.test.tsx
+++ b/public/components/judgment/__tests__/judgment_view.test.tsx
@@ -388,4 +388,38 @@ describe('JudgmentView', () => {
     const rows = screen.getAllByRole('row');
     expect(rows.length).toBeGreaterThan(1);
   });
+
+  it('renders failed docs from the failures list with an N/A rating', () => {
+    mockUseJudgmentView.mockReturnValue({
+      judgment: {
+        id: '1',
+        name: 'Failures Judgment',
+        type: 'LLM',
+        status: 'COMPLETED',
+        metadata: { totalQueries: 1, successfulQueries: 0, failedQueries: 1 },
+        judgmentRatings: [
+          {
+            query: 'laptop',
+            ratings: [{ docId: 'A1', rating: '1.0' }],
+            failures: [{ docId: 'C9' }],
+          },
+        ],
+        timestamp: '2023-01-01',
+      },
+      loading: false,
+      error: null,
+    });
+
+    render(
+      <Router history={history}>
+        <JudgmentView {...defaultProps} />
+      </Router>
+    );
+
+    // The failed doc shows up alongside the rated one, with a Failed status and no score
+    expect(screen.getAllByText('C9').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Rated').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Failed').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('N/A').length).toBeGreaterThan(0);
+  });
 });

--- a/public/components/judgment/views/judgment_view.tsx
+++ b/public/components/judgment/views/judgment_view.tsx
@@ -37,7 +37,7 @@ const JudgmentRatingsTable = ({ ratings }: { ratings: any[] }) => {
   const [search, setSearch] = useState('');
   const [pageIndex, setPageIndex] = useState(0);
   const [pageSize, setPageSize] = useState(20);
-  const [sortField, setSortField] = useState<'query' | 'docId' | 'rating'>(
+  const [sortField, setSortField] = useState<'query' | 'docId' | 'rating' | 'status'>(
     'query'
   );
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc');
@@ -45,13 +45,22 @@ const JudgmentRatingsTable = ({ ratings }: { ratings: any[] }) => {
   // Flatten JSON → table rows
   const flattened = useMemo(() => {
     if (!Array.isArray(ratings)) return [];
-    return ratings.flatMap(item =>
-      (item.ratings || []).map(r => ({
+    return ratings.flatMap(item => {
+      const rated = (item.ratings || []).map(r => ({
         query: item.query,
         docId: r.docId,
         rating: Number(r.rating),
-      }))
-    );
+        status: 'Rated',
+      }));
+      // Docs sent to the LLM that came back without a rating are reported under "failures".
+      const failed = (item.failures || []).map(fnf => ({
+        query: item.query,
+        docId: fnf.docId,
+        rating: null,
+        status: 'Failed',
+      }));
+      return [...rated, ...failed];
+    });
   }, [ratings]);
 
   // Filtering
@@ -87,7 +96,14 @@ const JudgmentRatingsTable = ({ ratings }: { ratings: any[] }) => {
   const columns = [
     { field: 'query', name: 'Query', sortable: true },
     { field: 'docId', name: 'Doc ID', sortable: true },
-    { field: 'rating', name: 'Rating', sortable: true },
+    { field: 'status', name: 'Status', sortable: true },
+    {
+      field: 'rating',
+      name: 'Rating',
+      sortable: true,
+      render: (rating: number | null) =>
+        rating === null || Number.isNaN(rating) ? 'N/A' : rating,
+    },
   ];
 
   const pagination = {

--- a/public/types/index.ts
+++ b/public/types/index.ts
@@ -142,9 +142,14 @@ export interface JudgmentRating {
   rating: string;
 }
 
+export interface JudgmentFailure {
+  docId: string;
+}
+
 export interface QueryJudgment {
   query: string;
   ratings: JudgmentRating[];
+  failures?: JudgmentFailure[];
 }
 
 export interface JudgmentSet {


### PR DESCRIPTION
### Description
The LLM-as-a-judge flow can leave some (query, document) pairs unrated. The backend (opensearch-project/search-relevance#521) now reports these per query under a `failures` list, but the Judgment view's ratings table only rendered successful ratings, so users couldn't see which documents failed.

This PR surfaces them:
- Adds a **Status** column to the ratings table; each row is **Rated** or **Failed**.
- Failed rows (docs sent to the model but never rated) show an **N/A** score.
- Display-only change — metric calculations are unaffected, as they continue to use the numeric `ratings` list; `failures` is kept as a separate list.
- The per-run summary (`totalQueries` / `successfulQueries` / `failedQueries` / `lastFailureReason`) surfaces through the existing metadata section.

Verified end-to-end against a local OpenSearch running the #521 backend, driving the real judgment pipeline through ml-commons. All three outcomes were reproduced and render correctly in the view:
<img width="1769" height="466" alt="1" src="https://github.com/user-attachments/assets/43fd804c-3006-4f01-ab19-d9cbe5dc7c38" />

1. **All succeed** — every row Rated, no failures, no `lastFailureReason`.
<img width="1740" height="716" alt="4" src="https://github.com/user-attachments/assets/03ca4dab-9c7c-4832-a3ee-67cab8170002" />

3. **All fail** — every row Failed / N/A, with `failedQueries` and `lastFailureReason` set.
<img width="1736" height="764" alt="3" src="https://github.com/user-attachments/assets/1c53ccf7-a618-435b-b4d8-5ad2be5a045b" />

5. **Partial failure** — within one query, some docs Rated and some Failed / N/A.
<img width="1739" height="796" alt="2" src="https://github.com/user-attachments/assets/f8237037-eead-4c5d-99b2-528031c627a8" />


### Issues Resolved
https://github.com/opensearch-project/dashboards-search-relevance/issues/898
Counterpart backend PR: opensearch-project/search-relevance#521.

### Check List
- [x] New functionality includes testing.
- [x] All tests pass, including unit test, integration test
- [ ] Integration tests pass: `yarn cypress:run-without-security --config "baseUrl=http://localhost:5601" --spec "cypress/integration/plugins/search-relevance-dashboards/*.js"` (see [Developer Guide](DEVELOPER_GUIDE.md#integration-tests))
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
