### PR TITLE
Render error state on Experiment Details page when experiment fails t…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * Fix MetricsService.trim() to evict expired entries from all interval-keyed metric maps ([#879](https://github.com/opensearch-project/dashboards-search-relevance/issues/879))
 * Surface the backend error message and status code (e.g. a 403 security_exception) instead of a generic "unknown error" when list and detail views fail to load ([#873](https://github.com/opensearch-project/dashboards-search-relevance/issues/873))
 * Surface backend error messages in Search Configuration and Judgment detail views instead of generic load-failure messages ([#894](https://github.com/opensearch-project/dashboards-search-relevance/issues/894))
+* Render an error callout on the Experiment Details page when the experiment fails to load (missing id, invalid data, or fetch error) instead of a blank content area ([#892](https://github.com/opensearch-project/dashboards-search-relevance/issues/892))
 
 ### Infrastructure
 

--- a/public/components/experiment/__tests__/experiment_view.test.tsx
+++ b/public/components/experiment/__tests__/experiment_view.test.tsx
@@ -20,8 +20,10 @@ jest.mock('../../../types/index', () => ({
     POINTWISE_EVALUATION: 'POINTWISE_EVALUATION',
     HYBRID_OPTIMIZER: 'HYBRID_OPTIMIZER',
   },
-  toExperiment: (source: any) => ({ success: true, data: source }),
+  toExperiment: jest.fn((source: any) => ({ success: true, data: source })),
 }));
+
+const { toExperiment: mockToExperiment } = jest.requireMock('../../../types/index');
 
 const mockHttp = {
   get: jest.fn(),
@@ -114,7 +116,15 @@ describe('ExperimentView', () => {
     });
   });
 
-  it('handles fetch error', async () => {
+  it('shows a loading indicator while the experiment is being fetched', () => {
+    mockHttp.get.mockReturnValue(new Promise(() => {}));
+
+    render(<ExperimentView {...defaultProps} />);
+
+    expect(screen.getByText('Loading experiment data...')).toBeInTheDocument();
+  });
+
+  it('renders an error callout when the fetch fails', async () => {
     mockHttp.get.mockRejectedValue(new Error('Fetch failed'));
 
     render(<ExperimentView {...defaultProps} />);
@@ -122,15 +132,76 @@ describe('ExperimentView', () => {
     await waitFor(() => {
       expect(mockHttp.get).toHaveBeenCalledWith('/api/relevancy/experiments/test-experiment-id');
     });
+
+    await waitFor(() => {
+      expect(screen.getByText('Unable to load experiment')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Error loading experiment data')).toBeInTheDocument();
+    expect(screen.getByText('Experiment Details')).toBeInTheDocument();
   });
 
-  it('handles no experiment found', async () => {
+  it('shows not-found message when the backend returns 404', async () => {
+    mockHttp.get.mockRejectedValue({ body: { statusCode: 404, message: 'Document not found: abc' } });
+
+    render(<ExperimentView {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('No matching experiment found')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Unable to load experiment')).toBeInTheDocument();
+  });
+
+  it('surfaces the backend error message for non-404 failures', async () => {
+    mockHttp.get.mockRejectedValue({ body: { statusCode: 403, message: 'security_exception' } });
+
+    render(<ExperimentView {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('security_exception')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Unable to load experiment')).toBeInTheDocument();
+  });
+
+  it('renders an error callout when no experiment matches the id', async () => {
     mockHttp.get.mockResolvedValue({ hits: { hits: [] } });
 
     render(<ExperimentView {...defaultProps} />);
 
     await waitFor(() => {
-      expect(mockHttp.get).toHaveBeenCalled();
+      expect(screen.getByText('No matching experiment found')).toBeInTheDocument();
     });
+    expect(screen.getByText('Unable to load experiment')).toBeInTheDocument();
+  });
+
+  it('renders an error callout when the experiment data is invalid', async () => {
+    mockToExperiment.mockReturnValueOnce({ success: false });
+    mockHttp.get.mockResolvedValue({
+      hits: {
+        hits: [{ _source: { id: 'exp-1', type: 'UNKNOWN' } }],
+      },
+    });
+
+    render(<ExperimentView {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Invalid experiment data format')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Unable to load experiment')).toBeInTheDocument();
+  });
+
+  it('does not render an error callout when the experiment loads successfully', async () => {
+    mockHttp.get.mockResolvedValue({
+      hits: {
+        hits: [{ _source: { id: 'exp-1', type: ExperimentType.PAIRWISE_COMPARISON } }],
+      },
+    });
+
+    render(<ExperimentView {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Pairwise View')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('Unable to load experiment')).not.toBeInTheDocument();
+    expect(screen.queryByText('Loading experiment data...')).not.toBeInTheDocument();
   });
 });

--- a/public/components/experiment/views/experiment_view.tsx
+++ b/public/components/experiment/views/experiment_view.tsx
@@ -6,6 +6,7 @@
 import {
   EuiBadge,
   EuiButtonEmpty,
+  EuiCallOut,
   EuiFlexGroup,
   EuiFlexItem,
   EuiPageHeader,
@@ -42,6 +43,7 @@ export const ExperimentView: React.FC<ExperimentViewProps> = ({
   history,
 }) => {
   const [experiment, setExperiment] = useState<any | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
   const [refreshRevision, setRefreshRevision] = useState(0);
   const [isEditOpen, setIsEditOpen] = useState(false);
@@ -50,6 +52,7 @@ export const ExperimentView: React.FC<ExperimentViewProps> = ({
   useEffect(() => {
     const fetchExperiment = async () => {
       setError(null);
+      setLoading(true);
       try {
         const response = await experimentService.getExperiment(id, dataSourceId);
         const source = response?.hits?.hits?.[0]?._source;
@@ -67,9 +70,14 @@ export const ExperimentView: React.FC<ExperimentViewProps> = ({
         }
       } catch (err) {
         console.error('Failed to fetch experiment', err);
-        console.error(err);
         setExperiment(null);
-        setError('Error loading experiment data');
+        if (err?.body?.statusCode === 404) {
+          setError('No matching experiment found');
+        } else {
+          setError(err?.body?.message || 'Error loading experiment data');
+        }
+      } finally {
+        setLoading(false);
       }
     };
 
@@ -129,6 +137,27 @@ export const ExperimentView: React.FC<ExperimentViewProps> = ({
         }
         description={descriptionText}
       />
+      {!experiment && loading && (
+        <>
+          <EuiSpacer size="l" />
+          <EuiText size="s" color="subdued" data-test-subj="experimentViewLoading">
+            Loading experiment data...
+          </EuiText>
+        </>
+      )}
+      {!loading && error && (
+        <>
+          <EuiSpacer size="l" />
+          <EuiCallOut
+            title="Unable to load experiment"
+            color="danger"
+            iconType="alert"
+            data-test-subj="experimentViewErrorCallOut"
+          >
+            <p>{error}</p>
+          </EuiCallOut>
+        </>
+      )}
       {experiment && (
         <>
           <EuiSpacer size="s" />


### PR DESCRIPTION
### Description

The Experiment Details page set an `error` state on every failure path (experiment not found, invalid document format, fetch failure) but never rendered it — all content blocks in the JSX were gated on `experiment &&`, so when loading failed, users saw only the "Experiment Details" page header with a blank content area and no feedback.

This change fixes the rendering and improves the error messages:

- Renders a danger `EuiCallOut` ("Unable to load experiment") in the content area with the specific error message when loading fails, keeping the page header visible
- Maps backend 404 responses (`resource_not_found_exception`) to "No matching experiment found" — e.g. when the experiment id in the URL does not exist
- Surfaces the backend's own error message for other HTTP failures (e.g. a 403 `security_exception`), falling back to a generic
  "Error loading experiment data" for errors without a response body
- Shows "Invalid experiment data format" when the document exists but fails `toExperiment` validation
- Adds a "Loading experiment data..." indicator during the initial fetch,  gated so existing content does not flash away during the refetch after  editing experiment metadata
- Adds `data-test-subj` attributes (`experimentViewErrorCallOut`, `experimentViewLoading`) for testability

**All Tests Passed:**

<img width="1728" height="1039" alt="404 not found" src="https://github.com/user-attachments/assets/07671720-c7c2-4885-98a8-88d7fd4be225" />

<img width="1728" height="1018" alt="Request blocked" src="https://github.com/user-attachments/assets/4ac4c0cc-0291-42c1-9652-8d74096e38fc" />


### Testing

- Added 7 new/strengthened unit tests in `experiment_view.test.tsx` (suite now has 10), covering every render state: loading indicator, generic fetch failure, 404 not-found mapping, backend error message surfacing, empty hits, invalid data format, and a no-callout-on-success regression guard
- The two pre-existing failure tests only asserted that the HTTP call was made — which is how this bug shipped unnoticed. They now assert the rendered error UI, so a regression of this behavior fails the suite
- Manually verified in a local OSD + search-relevance backend setup:  navigating to `#/experiment/view/abc` (non-existent id) now shows the  error callout with "No matching experiment found" instead of a blank page; valid experiments render unchanged; the loading indicator appears briefly during fetch

### Changelog

- Added an entry under `[Unreleased] → Bug Fixes` in `CHANGELOG.md`


### Issues Resolved

Resolves #892

### Check List

- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test
  - [ ] Integration tests pass: `yarn cypress:run-without-security --config "baseUrl=http://localhost:5601" --spec "cypress/integration/plugins/search-relevance-dashboards/*.js"` (see [Developer Guide](DEVELOPER_GUIDE.md#integration-tests))
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).