### PR TITLE
Add unit tests for metrics route handler (#893)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * Surface backend error messages in Search Configuration and Judgment detail views instead of generic load-failure messages ([#894](https://github.com/opensearch-project/dashboards-search-relevance/issues/894))
 
 ### Infrastructure
+* Add unit tests for the metrics route handler (`GET /api/relevancy/stats`): route registration config, success response, and error status mapping ([#893](https://github.com/opensearch-project/dashboards-search-relevance/issues/893))
 
 ### Documentation
 

--- a/server/routes/metrics_route.test.ts
+++ b/server/routes/metrics_route.test.ts
@@ -1,0 +1,145 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { IRouter } from '../../../../src/core/server';
+import { ServiceEndpoints } from '../../common';
+import { registerMetricsRoute } from './metrics_route';
+
+const createMockRouter = () =>
+  ({
+    get: jest.fn(),
+    put: jest.fn(),
+    post: jest.fn(),
+    delete: jest.fn(),
+  } as unknown as IRouter);
+
+const getMetricsStatsRoute = (router: IRouter) => {
+  const getCalls = (router.get as jest.Mock).mock.calls;
+  const statsRoute = getCalls.find(([config]) => config.path === ServiceEndpoints.GetStats);
+
+  if (!statsRoute) {
+    throw new Error('Metrics stats route was not registered');
+  }
+
+  const [config, handler] = statsRoute;
+  return { config, handler };
+};
+
+const sampleStats = {
+  data: {
+    search_relevance: {
+      fetch_index: {
+        200: { response_time_total: 120, count: 2 },
+      },
+    },
+  },
+  overall: {
+    response_time_avg: 60,
+    requests_per_second: 0.033,
+  },
+  counts_by_component: { search_relevance: 2 },
+  counts_by_status_code: { 200: 2 },
+};
+
+describe('registerMetricsRoute', () => {
+  let router: IRouter;
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    router = createMockRouter();
+    registerMetricsRoute(router);
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  describe('route registration', () => {
+    it('registers a single GET route at the stats endpoint without validation and without auth', () => {
+      expect(router.get).toHaveBeenCalledTimes(1);
+      expect(router.get).toHaveBeenCalledWith(
+        expect.objectContaining({
+          path: ServiceEndpoints.GetStats,
+          validate: false,
+          options: {
+            authRequired: false,
+          },
+        }),
+        expect.any(Function)
+      );
+    });
+  });
+
+  describe('request handling', () => {
+    let getStats: jest.Mock;
+    let mockContext: {
+      searchRelevance: { metricsService: { getStats: jest.Mock } };
+    };
+    let mockResponse: { ok: jest.Mock; custom: jest.Mock };
+
+    beforeEach(() => {
+      getStats = jest.fn();
+      mockContext = {
+        searchRelevance: {
+          metricsService: {
+            getStats,
+          },
+        },
+      };
+      mockResponse = {
+        ok: jest.fn(),
+        custom: jest.fn(),
+      };
+    });
+
+    const invokeHandler = async () => {
+      const { handler } = getMetricsStatsRoute(router);
+      await handler(mockContext, {}, mockResponse);
+    };
+
+    it('returns metrics from the metrics service as pretty-printed JSON', async () => {
+      getStats.mockReturnValue(sampleStats);
+
+      await invokeHandler();
+
+      expect(getStats).toHaveBeenCalledTimes(1);
+      expect(mockResponse.ok).toHaveBeenCalledWith({
+        body: JSON.stringify(sampleStats, null, 2),
+      });
+      expect(mockResponse.custom).not.toHaveBeenCalled();
+    });
+
+    it('propagates the error status code when getStats throws an error with one', async () => {
+      const error = Object.assign(new Error('metrics unavailable'), { statusCode: 503 });
+      getStats.mockImplementation(() => {
+        throw error;
+      });
+
+      await invokeHandler();
+
+      expect(mockResponse.custom).toHaveBeenCalledWith({
+        statusCode: 503,
+        body: 'metrics unavailable',
+      });
+      expect(mockResponse.ok).not.toHaveBeenCalled();
+      expect(consoleErrorSpy).toHaveBeenCalledWith(error);
+    });
+
+    it('falls back to a 500 status code when getStats throws a plain error', async () => {
+      getStats.mockImplementation(() => {
+        throw new Error('unexpected failure');
+      });
+
+      await invokeHandler();
+
+      expect(mockResponse.custom).toHaveBeenCalledWith({
+        statusCode: 500,
+        body: 'unexpected failure',
+      });
+      expect(mockResponse.ok).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
### Description

The route handler for `GET /api/relevancy/stats` in `server/routes/metrics_route.ts` had no test coverage, while the underlying
`MetricsService` is already tested.

This change adds `server/routes/metrics_route.test.ts` , following the pattern established in `search_relevance_route_service.test.ts`:

- Route registration: registered once at `ServiceEndpoints.GetStats` with `validate: false` and `authRequired: false`
- Success path: `getStats()` result is returned via `response.ok` as  pretty-printed JSON (and `response.custom` is not called)
- Error path, both branches of `error.statusCode || 500`: an error carrying  its own status code (503) is propagated with its message and logged, and a  plain error falls back to a 500

- Also added a `CHANGELOG.md` entry under Unreleased → Infrastructure

### Issues Resolved

Resolves #893

### Testing

- `yarn test metrics_route.test.ts` — 4/4 pass
- Full `yarn test`: 1095/1097 pass. The 2 failures are in
  `search_relevance_route_service.test.ts` and are pre-existing on `main`,  unrelated to this change: the test's mock router lacks a `patch` stub while #823 added a `router.patch` registration (reported separately in #902 )
- Manually verified the live endpoint in a local dev environment: `GET /api/relevancy/stats` returns the stats JSON without authentication,consistent with the route's `authRequired: false` configuration, and metrics populate correctly after plugin API traffic (component counts,status-code counts, requests-per-second, and response-time average all consistent with the recorded calls)

### Check List
- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test
  - [ ] Integration tests pass: `yarn cypress:run-without-security --config "baseUrl=http://localhost:5601" --spec "cypress/integration/plugins/search-relevance-dashboards/*.js"` (see [Developer Guide](DEVELOPER_GUIDE.md#integration-tests))
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).**