### PR TITLE
Add missing patch stub to mock router in route service tests (#902)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Maintenance
 * Remove debug console logging from production UI code ([#878](https://github.com/opensearch-project/dashboards-search-relevance/pull/878))
+* Fix `search_relevance_route_service.test.ts` failing on main by adding the missing `patch` stub to the test's mock router ([#902](https://github.com/opensearch-project/dashboards-search-relevance/issues/902))
 
 ### Refactoring
 * Refactor `GetSearchResults` to a single-query endpoint; fixes inconsistent query1/query2 validation, wrong error routing for query2, and cross-cluster index rejection ([#784](https://github.com/opensearch-project/dashboards-search-relevance/issues/784))

--- a/server/routes/search_relevance_route_service.test.ts
+++ b/server/routes/search_relevance_route_service.test.ts
@@ -13,6 +13,7 @@ const createMockRouter = () =>
     put: jest.fn(),
     post: jest.fn(),
     delete: jest.fn(),
+    patch: jest.fn(),
   }) as unknown as IRouter;
 
 const getJudgmentCreateRouteSchema = (router: IRouter) => {


### PR DESCRIPTION
### Description

`search_relevance_route_service.test.ts` fails on `main` with `TypeError: router.patch is not a function`: `registerSearchRelevanceRoutes` registers a `PATCH` route, but the test's `createMockRouter` helper only
stubbed `get`, `put`, `post`, and `delete`, so route registration threw in `beforeEach` before any assertion ran.

This fix adds the missing `patch: jest.fn()` stub to the mock router (server/routes/search_relevance_route_service.test.ts)

### Issues Resolved

Resolves #902

### Testing

- `yarn test search_relevance_route_service.test.ts` — both tests now pass
- Full `yarn test` now passes completely (previously exited with code 1 on
  `main` due to these 2 failures)

- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test
  - [ ] Integration tests pass: `yarn cypress:run-without-security --config "baseUrl=http://localhost:5601" --spec "cypress/integration/plugins/search-relevance-dashboards/*.js"` (see [Developer Guide](DEVELOPER_GUIDE.md#integration-tests))
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`
