### PR TITLE
perf: precompute VisualComparison result lookups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * Add experiment name and description across the full lifecycle: optional fields on creation forms, display in list and detail views (tooltips, header, search), and edit from the detail view ([#823](https://github.com/opensearch-project/dashboards-search-relevance/pull/823))
 
 ### Enhancements
+* Precompute result ID lookups in VisualComparison to avoid O(n²) matching work for statistics, status colors, and connection lines ([#881](https://github.com/opensearch-project/dashboards-search-relevance/issues/881))
 * Show which documents failed in the Judgment view: the ratings table now lists each query's unrated docs with a Failed status alongside the rated ones ([#899](https://github.com/opensearch-project/dashboards-search-relevance/pull/899))
 * Load experiment detail resources in parallel after the initial experiment fetch ([#882](https://github.com/opensearch-project/dashboards-search-relevance/issues/882))
 * Make Query Set description optional on create ([#758](https://github.com/opensearch-project/dashboards-search-relevance/issues/758))

--- a/public/components/query_compare/search_result/visual_comparison/__tests__/comparison_utils.test.ts
+++ b/public/components/query_compare/search_result/visual_comparison/__tests__/comparison_utils.test.ts
@@ -1,0 +1,57 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { calculateStatistics, createResultLookup } from '../comparison_utils';
+
+describe('comparison utilities', () => {
+  it('indexes result items with their positions', () => {
+    const results = [
+      { _id: 'a', rank: 1 },
+      { _id: 'b', rank: 2 },
+    ];
+
+    expect(createResultLookup(results).get('b')).toEqual({ item: results[1], index: 1 });
+  });
+
+  it('calculates overlap and rank changes', () => {
+    const result1 = [
+      { _id: 'a', rank: 1 },
+      { _id: 'b', rank: 2 },
+      { _id: 'c', rank: 1 },
+      { _id: 'left-only', rank: 4 },
+    ];
+    const result2 = [
+      { _id: 'b', rank: 1 },
+      { _id: 'a', rank: 1 },
+      { _id: 'c', rank: 3 },
+      { _id: 'right-only', rank: 4 },
+    ];
+
+    expect(calculateStatistics(result1, result2)).toEqual({
+      inBoth: 3,
+      onlyInResult1: 1,
+      onlyInResult2: 1,
+      unchanged: 1,
+      improved: 1,
+      worsened: 1,
+    });
+  });
+
+  it('reads result IDs linearly', () => {
+    let idReads = 0;
+    const makeResult = (size: number) =>
+      Array.from({ length: size }, (_, index) => ({
+        get _id() {
+          idReads += 1;
+          return String(index);
+        },
+        rank: index,
+      }));
+
+    calculateStatistics(makeResult(100), makeResult(100));
+
+    expect(idReads).toBeLessThanOrEqual(300);
+  });
+});

--- a/public/components/query_compare/search_result/visual_comparison/__tests__/connection_lines.test.tsx
+++ b/public/components/query_compare/search_result/visual_comparison/__tests__/connection_lines.test.tsx
@@ -30,6 +30,7 @@ const defaultProps = {
   result1ItemsRef: { current: {} },
   result2ItemsRef: { current: {} },
   lineColors: mockLineColors,
+  sizeMultiplier: 1,
 };
 
 describe('ConnectionLines', () => {
@@ -49,5 +50,25 @@ describe('ConnectionLines', () => {
     const { container } = render(<ConnectionLines {...defaultProps} result1={[]} result2={[]} />);
     const lines = container.querySelectorAll('line');
     expect(lines).toHaveLength(0);
+  });
+
+  it('uses the precomputed result position for matching lines', () => {
+    const element = document.createElement('div');
+    const result2 = [
+      { _id: '3', rank: 1 },
+      { _id: '1', rank: 2 },
+    ];
+    const { container } = render(
+      <ConnectionLines
+        {...defaultProps}
+        result2={result2}
+        result1ItemsRef={{ current: { '1': element } }}
+        result2ItemsRef={{ current: { '1': element } }}
+      />
+    );
+
+    const line = container.querySelector('line');
+    expect(line).toHaveAttribute('y1', '26');
+    expect(line).toHaveAttribute('y2', '78');
   });
 });

--- a/public/components/query_compare/search_result/visual_comparison/comparison_utils.ts
+++ b/public/components/query_compare/search_result/visual_comparison/comparison_utils.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export interface ComparisonResult {
+  _id: string;
+  rank: number;
+}
+
+export interface ResultLookupEntry<T extends ComparisonResult> {
+  item: T;
+  index: number;
+}
+
+export const createResultLookup = <T extends ComparisonResult>(results: T[]) =>
+  new Map<string, ResultLookupEntry<T>>(results.map((item, index) => [item._id, { item, index }]));
+
+export const calculateStatistics = (result1: ComparisonResult[], result2: ComparisonResult[]) => {
+  const result2ById = createResultLookup(result2);
+  let inBoth = 0;
+  let unchanged = 0;
+  let improved = 0;
+  let worsened = 0;
+
+  for (const item1 of result1) {
+    const item2 = result2ById.get(item1._id)?.item;
+    if (!item2) continue;
+
+    inBoth += 1;
+    if (item1.rank === item2.rank) unchanged += 1;
+    else if (item1.rank > item2.rank) improved += 1;
+    else worsened += 1;
+  }
+
+  return {
+    inBoth,
+    onlyInResult1: result1.length - inBoth,
+    onlyInResult2: result2.length - inBoth,
+    unchanged,
+    improved,
+    worsened,
+  };
+};

--- a/public/components/query_compare/search_result/visual_comparison/connection_lines.tsx
+++ b/public/components/query_compare/search_result/visual_comparison/connection_lines.tsx
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React from 'react';
+import React, { useMemo } from 'react';
+import { createResultLookup } from './comparison_utils';
 
 interface ConnectionLinesProps {
   mounted: boolean;
@@ -24,8 +25,12 @@ export const ConnectionLines: React.FC<ConnectionLinesProps> = ({
   lineColors,
   sizeMultiplier,
 }) => {
-  const containerHeight = Math.max(420, Math.max(result1.length, result2.length) * (32 * sizeMultiplier + 20));
-  
+  const containerHeight = Math.max(
+    420,
+    Math.max(result1.length, result2.length) * (32 * sizeMultiplier + 20)
+  );
+  const result2ById = useMemo(() => createResultLookup(result2), [result2]);
+
   return (
     <svg
       width="100%"
@@ -36,10 +41,11 @@ export const ConnectionLines: React.FC<ConnectionLinesProps> = ({
     >
       {/* Only draw lines after component has mounted to ensure refs are available */}
       {mounted &&
-        result1.map((r1Item) => {
+        result1.map((r1Item, r1Index) => {
           // Find if this item exists in result2
-          const r2Match = result2.find((r2) => r2._id === r1Item._id);
-          if (!r2Match) return null; // Skip if no match
+          const r2Entry = result2ById.get(r1Item._id);
+          if (!r2Entry) return null; // Skip if no match
+          const { item: r2Match, index: r2Index } = r2Entry;
 
           // Get elements by ref to ensure we have their positions
           const r1El = result1ItemsRef.current[r1Item._id];
@@ -50,9 +56,6 @@ export const ConnectionLines: React.FC<ConnectionLinesProps> = ({
 
           try {
             // Calculate positions based on item index and size multiplier
-            const r1Index = result1.findIndex(item => item._id === r1Item._id);
-            const r2Index = result2.findIndex(item => item._id === r1Item._id);
-            
             const itemHeight = 32 * sizeMultiplier + 20; // Image size + padding/margins
             const y1 = r1Index * itemHeight + itemHeight / 2;
             const y2 = r2Index * itemHeight + itemHeight / 2;
@@ -65,12 +68,12 @@ export const ConnectionLines: React.FC<ConnectionLinesProps> = ({
             }
 
             return (
-              <line 
-                key={`line-${r1Item._id}`} 
-                x1="0%" 
-                y1={y1} 
-                x2="100%" 
-                y2={y2} 
+              <line
+                key={`line-${r1Item._id}`}
+                x1="0%"
+                y1={y1}
+                x2="100%"
+                y2={y2}
                 stroke={lineProps.stroke}
                 strokeWidth={lineProps.strokeWidth * sizeMultiplier}
               />

--- a/public/components/query_compare/search_result/visual_comparison/visual_comparison.tsx
+++ b/public/components/query_compare/search_result/visual_comparison/visual_comparison.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useState, useEffect, useRef, useLayoutEffect } from 'react';
+import React, { useState, useEffect, useRef, useLayoutEffect, useMemo } from 'react';
 import {
   EuiPanel,
   EuiEmptyPrompt,
@@ -24,6 +24,7 @@ import './visual_comparison.scss';
 import { ItemDetailHoverPane } from './item_detail_hover_pane';
 import { ConnectionLines } from './connection_lines';
 import { ResultItems } from './result_items';
+import { calculateStatistics, createResultLookup } from './comparison_utils';
 
 // Interface should match the first component
 interface OpenSearchComparisonProps {
@@ -105,34 +106,6 @@ const getDisplayFieldsAndImageField = (sampleItem) => {
   return {
     displayFields: [{ value: '_id', label: 'ID' }, ...fields],
     imageFieldName: imageField || null,
-  };
-};
-
-// Utility function to calculate statistics for the Venn diagram and rank changes
-const calculateStatistics = (result1, result2) => {
-  const inBoth = result1.filter((item1) => result2.some((item2) => item2._id === item1._id)).length;
-  const onlyInResult1 = result1.length - inBoth;
-  const onlyInResult2 = result2.length - inBoth;
-  const unchanged = result1.filter((item1) => {
-    const item2 = result2.find((item2) => item2._id === item1._id);
-    return item2 && item1.rank === item2.rank;
-  }).length;
-  const improved = result1.filter((item1) => {
-    const item2 = result2.find((item2) => item2._id === item1._id);
-    return item2 && item1.rank > item2.rank;
-  }).length;
-  const worsened = result1.filter((item1) => {
-    const item2 = result2.find((item2) => item2._id === item1._id);
-    return item2 && item1.rank < item2.rank;
-  }).length;
-
-  return {
-    inBoth,
-    onlyInResult1,
-    onlyInResult2,
-    unchanged,
-    improved,
-    worsened,
   };
 };
 
@@ -276,8 +249,10 @@ export const VisualComparison = ({
   const [singleResultMode, setSingleResultMode] = useState(false);
 
   // Process the results into the format we need
-  const [result1, setResult1] = useState([]);
-  const [result2, setResult2] = useState([]);
+  const [result1, setResult1] = useState<any[]>([]);
+  const [result2, setResult2] = useState<any[]>([]);
+  const result1ById = useMemo(() => createResultLookup(result1), [result1]);
+  const result2ById = useMemo(() => createResultLookup(result2), [result2]);
 
   // Summary statistics
   const [statistics, setStatistics] = useState({
@@ -388,8 +363,8 @@ export const VisualComparison = ({
   // Color function for item status
   const getStatusColor = (item, resultNum) => {
     const isResult1 = resultNum === 1;
-    const otherResult = isResult1 ? result2 : result1;
-    const matchingItem = otherResult.find((r) => r._id === item._id);
+    const otherResultById = isResult1 ? result2ById : result1ById;
+    const matchingItem = otherResultById.get(item._id)?.item;
 
     if (!matchingItem) {
       if (isResult1) {


### PR DESCRIPTION
## Summary

- replace repeated result scans in comparison statistics with one ID lookup map and one pass
- memoize lookup maps used for per-row status calculation
- reuse indexed result positions when drawing connection lines instead of calling `find` and `findIndex` for every row
- add pure utility coverage, a linear ID-read regression check, and a connection-line position regression test
- record the optimization in the unreleased changelog

Closes #881.

## Validation

- exercised the pure TypeScript utilities with `tsx`: overlap/rank semantics passed and the 100-by-100 case completed with 200 ID reads
- parsed all changed source TS/TSX files with esbuild
- Prettier check passed for the new utility, lookup code, and tests
- `git diff --check`

## Local test limitation

The repository test command expects an OpenSearch Dashboards checkout two directories above the plugin, including its root Jest binary and dependencies. This standalone plugin clone does not contain that monorepo environment, so the added Jest tests are left for the repository CI to execute.