### PR TITLE
fix: add missing patch mock to router in route service test

### DIFF
--- a/server/routes/search_relevance_route_service.test.ts
+++ b/server/routes/search_relevance_route_service.test.ts
@@ -12,6 +12,7 @@ const createMockRouter = () =>
     get: jest.fn(),
     put: jest.fn(),
     post: jest.fn(),
+    patch: jest.fn(),
     delete: jest.fn(),
   }) as unknown as IRouter;
 


### PR DESCRIPTION


### Description

The experiment edit feature (dc47fed) added router.patch() but the test mock was not updated, causing test failures.

### Issues Resolved
N/A

### Check List

- [ ] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test
  - [ ] Integration tests pass: `yarn cypress:run-without-security --config "baseUrl=http://localhost:5601" --spec "cypress/integration/plugins/search-relevance-dashboards/*.js"` (see [Developer Guide](DEVELOPER_GUIDE.md#integration-tests))
- [ ] New functionality has been documented.
- [X] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
