### PR TITLE
Reduce O(n²) result matching in VisualComparison with id lookup maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * Add experiment name and description across the full lifecycle: optional fields on creation forms, display in list and detail views (tooltips, header, search), and edit from the detail view ([#823](https://github.com/opensearch-project/dashboards-search-relevance/pull/823))
 
 ### Enhancements
+* Reduce O(n²) result matching in VisualComparison and connection lines by precomputing `_id` lookup maps ([#881](https://github.com/opensearch-project/dashboards-search-relevance/issues/881))
 * Show which documents failed in the Judgment view: the ratings table now lists each query's unrated docs with a Failed status alongside the rated ones ([#899](https://github.com/opensearch-project/dashboards-search-relevance/pull/899))
 * Load experiment detail resources in parallel after the initial experiment fetch ([#882](https://github.com/opensearch-project/dashboards-search-relevance/issues/882))
 * Make Query Set description optional on create ([#758](https://github.com/opensearch-project/dashboards-search-relevance/issues/758))

--- a/public/components/query_compare/search_result/visual_comparison/__tests__/calculate_statistics.test.tsx
+++ b/public/components/query_compare/search_result/visual_comparison/__tests__/calculate_statistics.test.tsx
@@ -1,0 +1,112 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { calculateStatistics } from '../visual_comparison';
+
+// `rank` is a 1-based position where rank 1 is the top of the list (assigned as
+// `index + 1` in convertFromSearchResult). For a document present in both result
+// sets, a smaller rank in result2 than in result1 means it moved *up* toward the
+// top => "improved"; a larger rank means it moved down => "worsened".
+const item = (id: string, rank: number) => ({ _id: id, rank, title: `Doc ${id}` });
+
+describe('calculateStatistics', () => {
+  it('counts documents present in both result sets (inBoth) and those unique to each', () => {
+    const result1 = [item('1', 1), item('2', 2), item('3', 3)];
+    const result2 = [item('2', 1), item('3', 2), item('4', 3)];
+
+    const stats = calculateStatistics(result1, result2);
+
+    expect(stats.inBoth).toBe(2); // ids 2 and 3
+    expect(stats.onlyInResult1).toBe(1); // id 1
+    expect(stats.onlyInResult2).toBe(1); // id 4
+  });
+
+  it('counts a document as unchanged when its rank is identical in both sets', () => {
+    const result1 = [item('1', 1), item('2', 2)];
+    const result2 = [item('1', 1), item('2', 2)];
+
+    const stats = calculateStatistics(result1, result2);
+
+    expect(stats.unchanged).toBe(2);
+    expect(stats.improved).toBe(0);
+    expect(stats.worsened).toBe(0);
+  });
+
+  it('counts a document as improved when it moves toward the top (rank decreases)', () => {
+    // id 1 goes from rank 3 in result1 to rank 1 in result2 -> improved.
+    const result1 = [item('1', 3)];
+    const result2 = [item('1', 1)];
+
+    const stats = calculateStatistics(result1, result2);
+
+    expect(stats.improved).toBe(1);
+    expect(stats.worsened).toBe(0);
+    expect(stats.unchanged).toBe(0);
+  });
+
+  it('counts a document as worsened when it moves down (rank increases)', () => {
+    // id 1 goes from rank 1 in result1 to rank 3 in result2 -> worsened.
+    const result1 = [item('1', 1)];
+    const result2 = [item('1', 3)];
+
+    const stats = calculateStatistics(result1, result2);
+
+    expect(stats.worsened).toBe(1);
+    expect(stats.improved).toBe(0);
+    expect(stats.unchanged).toBe(0);
+  });
+
+  it('handles a mixed scenario covering every bucket at once', () => {
+    const result1 = [
+      item('unchanged', 1),
+      item('improved', 3),
+      item('worsened', 2),
+      item('onlyIn1', 4),
+    ];
+    const result2 = [
+      item('unchanged', 1), // same rank
+      item('improved', 1), // 3 -> 1: improved
+      item('worsened', 4), // 2 -> 4: worsened
+      item('onlyIn2', 3),
+    ];
+
+    const stats = calculateStatistics(result1, result2);
+
+    expect(stats).toEqual({
+      inBoth: 3,
+      onlyInResult1: 1,
+      onlyInResult2: 1,
+      unchanged: 1,
+      improved: 1,
+      worsened: 1,
+    });
+  });
+
+  it('returns all-zero counts for empty result sets', () => {
+    const stats = calculateStatistics([], []);
+
+    expect(stats).toEqual({
+      inBoth: 0,
+      onlyInResult1: 0,
+      onlyInResult2: 0,
+      unchanged: 0,
+      improved: 0,
+      worsened: 0,
+    });
+  });
+
+  it('matches the first occurrence when a result set contains duplicate _ids', () => {
+    // Mirrors the previous .find()/.some() "first occurrence wins" behavior: the
+    // rank of the first id '1' in result2 (rank 1) is used, so 2 -> 1 is improved.
+    const result1 = [item('1', 2)];
+    const result2 = [item('1', 1), item('1', 5)];
+
+    const stats = calculateStatistics(result1, result2);
+
+    expect(stats.inBoth).toBe(1);
+    expect(stats.improved).toBe(1);
+    expect(stats.worsened).toBe(0);
+  });
+});

--- a/public/components/query_compare/search_result/visual_comparison/__tests__/visual_comparison.test.tsx
+++ b/public/components/query_compare/search_result/visual_comparison/__tests__/visual_comparison.test.tsx
@@ -71,6 +71,29 @@ describe('VisualComparison', () => {
     expect(screen.getByText('Common')).toBeInTheDocument();
   });
 
+  it('computes overlap counts via id lookup maps', () => {
+    // result1: ids [1,2,3], result2: ids [1,2,4]
+    // => common (inBoth) = 2, unique-to-1 = 1, unique-to-2 = 1
+    const { container } = render(
+      <VisualComparison
+        {...defaultProps}
+        queryResult1={[
+          { _id: '1', _score: 0.9, rank: 1, title: 'A' },
+          { _id: '2', _score: 0.8, rank: 2, title: 'B' },
+          { _id: '3', _score: 0.7, rank: 3, title: 'C' },
+        ]}
+        queryResult2={[
+          { _id: '1', _score: 0.85, rank: 2, title: 'A' },
+          { _id: '2', _score: 0.75, rank: 1, title: 'B' },
+          { _id: '4', _score: 0.65, rank: 3, title: 'D' },
+        ]}
+      />
+    );
+    expect(container.querySelector('.venn-left .venn-value')?.textContent).toBe('1');
+    expect(container.querySelector('.venn-middle .venn-value')?.textContent).toBe('2');
+    expect(container.querySelector('.venn-right .venn-value')?.textContent).toBe('1');
+  });
+
   it('shows empty prompt when results are not arrays', () => {
     render(<VisualComparison {...defaultProps} queryResult1={null} queryResult2={null} />);
     expect(screen.getByText('You need two Setups to display comparison.')).toBeInTheDocument();

--- a/public/components/query_compare/search_result/visual_comparison/connection_lines.tsx
+++ b/public/components/query_compare/search_result/visual_comparison/connection_lines.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React from 'react';
+import React, { useMemo } from 'react';
 
 interface ConnectionLinesProps {
   mounted: boolean;
@@ -25,7 +25,32 @@ export const ConnectionLines: React.FC<ConnectionLinesProps> = ({
   sizeMultiplier,
 }) => {
   const containerHeight = Math.max(420, Math.max(result1.length, result2.length) * (32 * sizeMultiplier + 20));
-  
+
+  // Precompute `_id` -> { item, index } for result2 and `_id` -> index for
+  // result1 so drawing each connection line is O(1) rather than re-scanning both
+  // result sets (previously one `.find()` plus two `.findIndex()` per row, i.e.
+  // O(n²) overall). "First occurrence wins" matches the prior find/findIndex
+  // behaviour for the (unexpected) duplicate-id case.
+  const result2ById = useMemo(() => {
+    const map = new Map<string, { item: any; index: number }>();
+    result2.forEach((item, index) => {
+      if (!map.has(item._id)) {
+        map.set(item._id, { item, index });
+      }
+    });
+    return map;
+  }, [result2]);
+
+  const result1IndexById = useMemo(() => {
+    const map = new Map<string, number>();
+    result1.forEach((item, index) => {
+      if (!map.has(item._id)) {
+        map.set(item._id, index);
+      }
+    });
+    return map;
+  }, [result1]);
+
   return (
     <svg
       width="100%"
@@ -38,8 +63,9 @@ export const ConnectionLines: React.FC<ConnectionLinesProps> = ({
       {mounted &&
         result1.map((r1Item) => {
           // Find if this item exists in result2
-          const r2Match = result2.find((r2) => r2._id === r1Item._id);
-          if (!r2Match) return null; // Skip if no match
+          const r2Entry = result2ById.get(r1Item._id);
+          if (!r2Entry) return null; // Skip if no match
+          const r2Match = r2Entry.item;
 
           // Get elements by ref to ensure we have their positions
           const r1El = result1ItemsRef.current[r1Item._id];
@@ -50,9 +76,9 @@ export const ConnectionLines: React.FC<ConnectionLinesProps> = ({
 
           try {
             // Calculate positions based on item index and size multiplier
-            const r1Index = result1.findIndex(item => item._id === r1Item._id);
-            const r2Index = result2.findIndex(item => item._id === r1Item._id);
-            
+            const r1Index = result1IndexById.get(r1Item._id);
+            const r2Index = r2Entry.index;
+
             const itemHeight = 32 * sizeMultiplier + 20; // Image size + padding/margins
             const y1 = r1Index * itemHeight + itemHeight / 2;
             const y2 = r2Index * itemHeight + itemHeight / 2;

--- a/public/components/query_compare/search_result/visual_comparison/visual_comparison.tsx
+++ b/public/components/query_compare/search_result/visual_comparison/visual_comparison.tsx
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import React, { useState, useEffect, useRef, useLayoutEffect } from 'react';
+import React, { useState, useEffect, useRef, useLayoutEffect, useMemo } from 'react';
 import {
   EuiPanel,
   EuiEmptyPrompt,
@@ -108,23 +108,46 @@ const getDisplayFieldsAndImageField = (sampleItem) => {
   };
 };
 
+// Build a Map from `_id` to the first item carrying that id. Precomputing this
+// once turns the repeated linear `_id` lookups (Array.prototype.find/some) used
+// throughout comparison rendering into O(1) map reads, reducing the overall
+// matching cost from O(n²) to O(n). The "first occurrence wins" rule mirrors the
+// previous `.find()`/`.some()` semantics for the (unexpected) duplicate-id case.
+const buildResultMap = (results) => {
+  const map = new Map();
+  for (const item of results) {
+    if (!map.has(item._id)) {
+      map.set(item._id, item);
+    }
+  }
+  return map;
+};
+
 // Utility function to calculate statistics for the Venn diagram and rank changes
 const calculateStatistics = (result1, result2) => {
-  const inBoth = result1.filter((item1) => result2.some((item2) => item2._id === item1._id)).length;
+  const result2ById = buildResultMap(result2);
+
+  let inBoth = 0;
+  let unchanged = 0;
+  let improved = 0;
+  let worsened = 0;
+
+  for (const item1 of result1) {
+    const item2 = result2ById.get(item1._id);
+    if (!item2) continue;
+
+    inBoth++;
+    if (item1.rank === item2.rank) {
+      unchanged++;
+    } else if (item1.rank > item2.rank) {
+      improved++;
+    } else {
+      worsened++;
+    }
+  }
+
   const onlyInResult1 = result1.length - inBoth;
   const onlyInResult2 = result2.length - inBoth;
-  const unchanged = result1.filter((item1) => {
-    const item2 = result2.find((item2) => item2._id === item1._id);
-    return item2 && item1.rank === item2.rank;
-  }).length;
-  const improved = result1.filter((item1) => {
-    const item2 = result2.find((item2) => item2._id === item1._id);
-    return item2 && item1.rank > item2.rank;
-  }).length;
-  const worsened = result1.filter((item1) => {
-    const item2 = result2.find((item2) => item2._id === item1._id);
-    return item2 && item1.rank < item2.rank;
-  }).length;
 
   return {
     inBoth,
@@ -385,11 +408,17 @@ export const VisualComparison = ({
     forceRerender((v) => v + 1);
   }, [result1, result2, displayField, imageFieldName]);
 
+  // Precompute `_id` lookup maps so per-row status resolution (getStatusColor,
+  // called once for every rendered item) is O(1) instead of scanning the other
+  // result set each time.
+  const result1ById = useMemo(() => buildResultMap(result1), [result1]);
+  const result2ById = useMemo(() => buildResultMap(result2), [result2]);
+
   // Color function for item status
   const getStatusColor = (item, resultNum) => {
     const isResult1 = resultNum === 1;
-    const otherResult = isResult1 ? result2 : result1;
-    const matchingItem = otherResult.find((r) => r._id === item._id);
+    const otherResultById = isResult1 ? result2ById : result1ById;
+    const matchingItem = otherResultById.get(item._id);
 
     if (!matchingItem) {
       if (isResult1) {

--- a/public/components/query_compare/search_result/visual_comparison/visual_comparison.tsx
+++ b/public/components/query_compare/search_result/visual_comparison/visual_comparison.tsx
@@ -124,7 +124,7 @@ const buildResultMap = (results) => {
 };
 
 // Utility function to calculate statistics for the Venn diagram and rank changes
-const calculateStatistics = (result1, result2) => {
+export const calculateStatistics = (result1, result2) => {
   const result2ById = buildResultMap(result2);
 
   let inBoth = 0;


### PR DESCRIPTION
### Description

`VisualComparison` and its connection-line renderer repeatedly matched results by `_id` using `Array.prototype.find`/`some`/`findIndex`, scanning one result set while iterating the other. This scales as **O(n²)** with result size across three paths: statistics calculation, per-row status coloring, and connection-line generation.

This PR precomputes `_id` → item (and `_id` → index) lookup maps once and reads from them in O(1):

- **`calculateStatistics`** — a single pass over `result1` against a `result2` map replaces the four `.filter(... .some()/.find())` passes.
- **`getStatusColor`** — memoized `result1ById` / `result2ById` maps replace the `.find()` executed once per rendered row.
- **`ConnectionLines`** — memoized `result2` (`_id` → `{ item, index }`) and `result1` (`_id` → index) maps replace one `.find()` plus two `.findIndex()` per row.

Building each map with "first occurrence wins" preserves the prior `find`/`findIndex` semantics for the (unexpected) duplicate-`_id` case, so behavior is unchanged.

### Issues Resolved

Resolves #881

### Check List

- [x] New functionality includes testing.
  - [x] Added a unit test asserting Venn overlap counts (Common / Unique) are computed correctly via the lookup maps.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.