### PR TITLE
Surface Hybrid Optimizer experiment errors instead of a generic message (#550)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * Surface the backend error message and status code (e.g. a 403 security_exception) instead of a generic "unknown error" when list and detail views fail to load ([#873](https://github.com/opensearch-project/dashboards-search-relevance/issues/873))
 * Surface backend error messages in Search Configuration and Judgment detail views instead of generic load-failure messages ([#894](https://github.com/opensearch-project/dashboards-search-relevance/issues/894))
 * Render an error callout on the Experiment Details page when the experiment fails to load (missing id, invalid data, or fetch error) instead of a blank content area ([#892](https://github.com/opensearch-project/dashboards-search-relevance/issues/892))
+* Surface the detailed error message on the Hybrid Optimizer experiment view, and show an informative empty state instead of a blank results table when an experiment completes with no evaluation results ([#550](https://github.com/opensearch-project/dashboards-search-relevance/issues/550))
 
 ### Infrastructure
 * Add unit tests for the metrics route handler (`GET /api/relevancy/stats`): route registration config, success response, and error status mapping ([#893](https://github.com/opensearch-project/dashboards-search-relevance/issues/893))

--- a/public/components/experiment/__tests__/hybrid_optimizer_experiment_view.test.tsx
+++ b/public/components/experiment/__tests__/hybrid_optimizer_experiment_view.test.tsx
@@ -4,32 +4,119 @@
  */
 
 import React from 'react';
-import { render } from '@testing-library/react';
-
-const mockPrintType = jest.fn(() => 'Hybrid Optimizer');
-const mockHttp = { get: jest.fn() };
-const mockNotifications = { toasts: { addError: jest.fn() } };
-const mockHistory = { push: jest.fn(), createHref: jest.fn(() => '#') };
+import { render, screen } from '@testing-library/react';
 
 jest.mock('../../../types/index', () => ({
-  printType: mockPrintType,
+  printType: jest.fn((type: string) => type),
 }));
 
 jest.mock('../../../../../../src/plugins/opensearch_dashboards_react/public', () => ({
+  // The repo configures testing-library with testIdAttribute: 'data-test-subj'
+  // (see test/setup.jest.ts), so expose the mock table under that attribute.
+  TableListView: () => <div data-test-subj="table-list-view" />,
   reactRouterNavigate: jest.fn(() => ({ href: '#', onClick: jest.fn() })),
 }));
 
-jest.mock('@elastic/eui', () => ({
-  ...jest.requireActual('@elastic/eui'),
-  EuiResizableContainer: ({ children }) => <div data-testid="resizable-container">{children}</div>,
-  EuiResizablePanel: ({ children }) => <div data-testid="resizable-panel">{children}</div>,
+jest.mock('../../common/ScheduleDetails', () => ({
+  ScheduleDetails: () => null,
 }));
 
-const HybridOptimizerExperimentView = () => <div>Hybrid View</div>;
+jest.mock('../metrics/variant_details', () => ({
+  VariantDetailsModal: () => null,
+}));
+
+const mockLoadResources = jest.fn();
+jest.mock('../services/experiment_resource_loader', () => ({
+  loadExperimentResourcesParallel: (...args: any[]) => mockLoadResources(...args),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { HybridOptimizerExperimentView } = require('../views/hybrid_optimizer_experiment_view');
+
+const inputExperiment = {
+  id: 'exp-1',
+  type: 'HYBRID_OPTIMIZER',
+  searchConfigurationId: 'sc-1',
+  querySetId: 'qs-1',
+  judgmentId: 'j-1',
+  isScheduled: false,
+};
+
+const validResources = {
+  experiment: inputExperiment,
+  searchConfiguration: { id: 'sc-1', name: 'My Config' },
+  querySet: { id: 'qs-1', name: 'My QuerySet', querySetQueries: { a: {}, b: {} } },
+  judgmentSet: { id: 'j-1', name: 'My Judgments' },
+  scheduledExperimentJob: null,
+};
+
+const renderView = (http: any) => {
+  const props: any = {
+    http,
+    notifications: { toasts: { addWarning: jest.fn(), addError: jest.fn() } },
+    inputExperiment,
+    history: { push: jest.fn(), createHref: jest.fn(() => '#') },
+  };
+  return render(<HybridOptimizerExperimentView {...props} />);
+};
 
 describe('HybridOptimizerExperimentView', () => {
-  it('renders without crashing', () => {
-    const { getByText } = render(<HybridOptimizerExperimentView />);
-    expect(getByText('Hybrid View')).toBeInTheDocument();
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('surfaces the detailed API error message instead of a generic string', async () => {
+    mockLoadResources.mockRejectedValue({
+      body: { message: 'query in search configuration must be of type hybrid' },
+    });
+
+    renderView({ post: jest.fn() });
+
+    expect(
+      await screen.findByText('query in search configuration must be of type hybrid')
+    ).toBeInTheDocument();
+  });
+
+  it('falls back to a generic message when the error has no detail', async () => {
+    mockLoadResources.mockRejectedValue(new Error('boom'));
+
+    renderView({ post: jest.fn() });
+
+    expect(await screen.findByText('Error loading experiment data')).toBeInTheDocument();
+  });
+
+  it('shows an informative empty state when the experiment produced no results', async () => {
+    mockLoadResources.mockResolvedValue(validResources);
+    const http = { post: jest.fn().mockResolvedValue({ result: { hits: { hits: [] } } }) };
+
+    renderView(http);
+
+    expect(await screen.findByText('No evaluation results')).toBeInTheDocument();
+  });
+
+  it('renders the results table when evaluation results are present', async () => {
+    mockLoadResources.mockResolvedValue(validResources);
+    const http = {
+      post: jest.fn().mockResolvedValue({
+        result: {
+          hits: {
+            hits: [
+              {
+                _source: {
+                  searchText: 'shoes',
+                  experimentVariantId: 'v1',
+                  metrics: [{ metric: 'ndcg@10', value: 0.5 }],
+                },
+              },
+            ],
+          },
+        },
+      }),
+    };
+
+    renderView(http);
+
+    expect(await screen.findByTestId('table-list-view')).toBeInTheDocument();
+    expect(screen.queryByText('No evaluation results')).not.toBeInTheDocument();
   });
 });

--- a/public/components/experiment/views/hybrid_optimizer_experiment_view.tsx
+++ b/public/components/experiment/views/hybrid_optimizer_experiment_view.tsx
@@ -6,6 +6,8 @@
 import {
   EuiButtonEmpty,
   EuiCallOut,
+  EuiCode,
+  EuiEmptyPrompt,
   EuiPanel,
   EuiDescriptionList,
   EuiDescriptionListTitle,
@@ -63,6 +65,7 @@ export const HybridOptimizerExperimentView: React.FC<HybridOptimizerExperimentVi
   const [scheduledExperimentJob, setScheduledExperimentJob] = useState<ScheduledJob | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
+  const [noResults, setNoResults] = useState<boolean>(false);
 
   const [queryEvaluations, setQueryEvaluations] = useState<QueryVariantEvaluations>({});
   const [searchConfiguration, setSearchConfiguration] = useState<any | null>(null);
@@ -76,6 +79,8 @@ export const HybridOptimizerExperimentView: React.FC<HybridOptimizerExperimentVi
     const fetchExperiment = async () => {
       try {
         setLoading(true);
+        setError(null);
+        setNoResults(false);
 
         const resources = await loadExperimentResourcesParallel(
           http,
@@ -168,12 +173,17 @@ export const HybridOptimizerExperimentView: React.FC<HybridOptimizerExperimentVi
           }
 
           if (!allResults || allResults.length === 0) {
-            console.error('No evaluation results found');
-            notifications.toasts.addWarning({
-              title: 'No Results',
-              text: 'No evaluation results found for this experiment',
-            });
+            // The experiment completed but produced no evaluation results,
+            // which typically means every query variant failed to run (e.g.
+            // the search configuration query is not of type `hybrid`). Still
+            // surface the experiment metadata and render an informative empty
+            // state instead of leaving a blank results table.
+            setExperiment(_experiment);
+            setSearchConfiguration(_searchConfiguration);
+            setQuerySet(_querySet);
+            setJudgmentSet(_judgmentSet);
             setQueryEvaluations({});
+            setNoResults(true);
             return;
           }
 
@@ -201,7 +211,10 @@ export const HybridOptimizerExperimentView: React.FC<HybridOptimizerExperimentVi
         }
       } catch (err) {
         console.error('Failed to load experiment', err);
-        setError('Error loading experiment data');
+        // Surface the detailed message from the API response when available
+        // instead of a generic string, so failures like an invalid query type
+        // are visible to the user.
+        setError(err?.body?.message || 'Error loading experiment data');
       } finally {
         setLoading(false);
       }
@@ -418,9 +431,23 @@ export const HybridOptimizerExperimentView: React.FC<HybridOptimizerExperimentVi
       <EuiSpacer size="m" />
       <EuiPanel hasBorder paddingSize="l">
         {error ? (
-          <EuiCallOut title="Error" color="danger">
+          <EuiCallOut title="Error loading experiment" color="danger">
             <p>{error}</p>
           </EuiCallOut>
+        ) : noResults ? (
+          <EuiEmptyPrompt
+            iconType="alert"
+            title={<h3>No evaluation results</h3>}
+            body={
+              <p>
+                This experiment completed but produced no evaluation results. This usually
+                means all query variants failed to run — for a Hybrid Optimizer experiment, a
+                common cause is that the search configuration&apos;s query is not of type{' '}
+                <EuiCode>hybrid</EuiCode>. Check the search configuration and run the experiment
+                again.
+              </p>
+            }
+          />
         ) : (
           <AnyTableListView
             key={`table-${Object.keys(queryEvaluations).length}`}

--- a/public/components/experiment/views/hybrid_optimizer_experiment_view.tsx
+++ b/public/components/experiment/views/hybrid_optimizer_experiment_view.tsx
@@ -213,8 +213,10 @@ export const HybridOptimizerExperimentView: React.FC<HybridOptimizerExperimentVi
         console.error('Failed to load experiment', err);
         // Surface the detailed message from the API response when available
         // instead of a generic string, so failures like an invalid query type
-        // are visible to the user.
-        setError(err?.body?.message || 'Error loading experiment data');
+        // are visible to the user. Only surface it when it is actually a
+        // string so a non-string/absent body falls back to the generic text.
+        const detail = err?.body?.message;
+        setError(typeof detail === 'string' && detail ? detail : 'Error loading experiment data');
       } finally {
         setLoading(false);
       }


### PR DESCRIPTION
### Description

When a Hybrid Optimizer experiment is run against a search configuration whose query is not of type `hybrid`, all query variants fail on the backend. As discussed in #550, the backend currently continues past those failures and returns the experiment as `COMPLETED` with 0 evaluation results, so the specific reason (`query in search configuration must be of type hybrid`) only exists in backend logs. On the dashboards side, `HybridOptimizerExperimentView` then handled this poorly in two ways:

1. **Swallowed errors.** The `catch` block discarded the actual error and always set the hardcoded string `"Error loading experiment data"`, so even when the API *did* return a detailed message, the user never saw it.
2. **Blank results table.** When there were 0 evaluation results, it fired a transient "No Results" toast and rendered an empty table, returning before it set the experiment metadata — leaving a screen with no explanation.

This PR addresses the dashboards side (the issue's "at minimum" ask):

- Surface `err.body?.message` from the API response when available, falling back to the generic string — matching the existing pattern in `experiment_view.tsx`.
- Render an informative in-panel empty state (and still show the experiment metadata) when an experiment completes with no evaluation results, pointing at the common cause (non-`hybrid` query type).
- Replace the placeholder test with real tests covering the detailed-error, generic-fallback, no-results, and results-present paths.

The exact backend reason will surface in the UI once the backend stores per-variant errors / sets `ERROR` status (opensearch-project/search-relevance#174); this change makes the dashboards side ready to display real errors and stops leaving the user with a blank screen in the meantime. Scope was proposed in a [comment on the issue](https://github.com/opensearch-project/dashboards-search-relevance/issues/550#issuecomment-5011377521).

### Issues Resolved

Partially addresses #550 (dashboards-side error visibility). Full resolution also depends on backend work in opensearch-project/search-relevance#174.

### Check List

- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
