### PR TITLE
Pass dataSourceId in Hybrid Optimizer and Pairwise experiment result queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Bug Fixes
 
+- Pass dataSourceId in Hybrid Optimizer and Pairwise experiment result queries so experiment views render on multi-data-source deployments ([#921](https://github.com/opensearch-project/dashboards-search-relevance/pull/921))
+
 ### Infrastructure
 
 ### Documentation

--- a/public/components/experiment/views/hybrid_optimizer_experiment_view.tsx
+++ b/public/components/experiment/views/hybrid_optimizer_experiment_view.tsx
@@ -96,6 +96,8 @@ export const HybridOptimizerExperimentView: React.FC<HybridOptimizerExperimentVi
         const _judgmentSet = resources?.judgmentSet;
         const _scheduledExperimentJob = resources?.scheduledExperimentJob;
 
+        const requestBase = dataSourceId ? { dataSourceId } : {};
+
         if (_experiment && _searchConfiguration && _querySet && _judgmentSet) {
           const querySetSize = _querySet && Object.keys(_querySet.querySetQueries).length;
           const maxSize = 10000; // OpenSearch max result window
@@ -124,9 +126,9 @@ export const HybridOptimizerExperimentView: React.FC<HybridOptimizerExperimentVi
                 size: batchSize,
               };
               const result = await http.post(ServiceEndpoints.GetSearchResults, {
-                body: JSON.stringify({ query }),
+                body: JSON.stringify({ query, ...requestBase }),
               });
-              
+
               if (result?.result?.hits?.hits && result.result.hits.hits.length > 0) {
                 allResults = allResults.concat(result.result.hits.hits);
                 from += result.result.hits.hits.length;
@@ -159,7 +161,7 @@ export const HybridOptimizerExperimentView: React.FC<HybridOptimizerExperimentVi
           };
 
           const result = await http.post(ServiceEndpoints.GetSearchResults, {
-            body: JSON.stringify({ query }),
+            body: JSON.stringify({ query, ...requestBase }),
           });
 
           if (result?.result?.hits?.hits) {
@@ -222,7 +224,7 @@ export const HybridOptimizerExperimentView: React.FC<HybridOptimizerExperimentVi
       };
 
       const result = await http.post(ServiceEndpoints.GetSearchResults, {
-        body: JSON.stringify({ query }),
+        body: JSON.stringify({ query, ...(dataSourceId ? { dataSourceId } : {}) }),
       });
 
       const variantDetails = result?.result?.hits?.hits?.[0]?._source;

--- a/public/components/experiment/views/pairwise_experiment_view.tsx
+++ b/public/components/experiment/views/pairwise_experiment_view.tsx
@@ -234,12 +234,14 @@ export const PairwiseExperimentView: React.FC<PairwiseExperimentViewProps> = ({
         },
       };
 
+      const requestBase = dataSourceId ? { dataSourceId } : {};
+
       Promise.all([
         http.post(ServiceEndpoints.GetSearchResults, {
-          body: JSON.stringify({ query: query1 }),
+          body: JSON.stringify({ query: query1, ...requestBase }),
         }),
         http.post(ServiceEndpoints.GetSearchResults, {
-          body: JSON.stringify({ query: query2 }),
+          body: JSON.stringify({ query: query2, ...requestBase }),
         }),
       ])
         .then(([res1, res2]) => {


### PR DESCRIPTION
## Description

On multi-data-source deployments, the Hybrid Optimizer and Pairwise (Query Set Comparison) experiment views POST to `/search` without `dataSourceId` in the request body, so the query runs against the default cluster instead of the selected data source:

- Hybrid Optimizer: "No evaluation results found", empty table, despite a completed experiment
- Pairwise: page loads, but clicking a query to compare documents does nothing

The Pointwise Evaluation view already sends `dataSourceId` (its `requestBase`), which is why it renders correctly on the same deployments.

## Fix

Apply the evaluation view's `requestBase` pattern to the five unlabelled call sites:

- `hybrid_optimizer_experiment_view.tsx` — paginated fetch, single fetch, variant details
- `pairwise_experiment_view.tsx` — two document-comparison fetches

## Verification

- The `/search` handler reads `dataSourceId` from the request body and falls back to the default cluster when it is empty ([dsl_route.ts#L28](https://github.com/opensearch-project/dashboards-search-relevance/blob/90604f30c7dc77955d652b96956044a8fa2132e1/server/routes/dsl_route.ts#L28), [L83-L88](https://github.com/opensearch-project/dashboards-search-relevance/blob/90604f30c7dc77955d652b96956044a8fa2132e1/server/routes/dsl_route.ts#L83-L88)) — an omitted identifier queries a cluster that lacks the experiment's results.
- Single-data-source path is unaffected: `dataSourceId` is null, so the request body is unchanged.
- Existing unit tests pass; fix mirrors the working pattern in `evaluation_experiment_view.tsx`.
- Not exercised against a multi-data-source deployment end-to-end.

## Check List
- [x] All tests pass (`yarn test`)
- [x] New functionality is documented (CHANGELOG.md updated)
- [x] Commits are signed per the DCO using `--signoff`
