### PR TITLE
fix: scope search config to data source; fix UBI index issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Bug Fixes
 
 - Pass dataSourceId in Hybrid Optimizer and Pairwise experiment result queries so experiment views render on multi-data-source deployments ([#921](https://github.com/opensearch-project/dashboards-search-relevance/pull/921))
-- Query Analysis: fetch search configurations from the selected data source so the Search Configuration dropdown is populated on multi-data-source deployments. Judgments: show a clear error for the COEC click model when no UBI events data is available, while keeping the UBI Events Index optional (COEC uses the default UBI events index) ([#923](https://github.com/opensearch-project/dashboards-search-relevance/pull/923))
+-  fix: scope search config to data source; require UBI index for COEC ([#923](https://github.com/opensearch-project/dashboards-search-relevance/pull/923))
 
 ### Infrastructure
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Bug Fixes
 
 - Pass dataSourceId in Hybrid Optimizer and Pairwise experiment result queries so experiment views render on multi-data-source deployments ([#921](https://github.com/opensearch-project/dashboards-search-relevance/pull/921))
+- Query Analysis: fetch search configurations from the selected data source so the Search Configuration dropdown is populated on multi-data-source deployments ([#923](https://github.com/opensearch-project/dashboards-search-relevance/pull/923))
+- Judgments: require the UBI Events Index when the COEC click model is selected and block submission when it is empty ([#923](https://github.com/opensearch-project/dashboards-search-relevance/pull/923))
 
 ### Infrastructure
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Bug Fixes
 
 - Pass dataSourceId in Hybrid Optimizer and Pairwise experiment result queries so experiment views render on multi-data-source deployments ([#921](https://github.com/opensearch-project/dashboards-search-relevance/pull/921))
-- Query Analysis: fetch search configurations from the selected data source so the Search Configuration dropdown is populated on multi-data-source deployments ([#923](https://github.com/opensearch-project/dashboards-search-relevance/pull/923))
-- Judgments: require the UBI Events Index when the COEC click model is selected and block submission when it is empty ([#923](https://github.com/opensearch-project/dashboards-search-relevance/pull/923))
+- Query Analysis: fetch search configurations from the selected data source so the Search Configuration dropdown is populated on multi-data-source deployments. Judgments: show a clear error for the COEC click model when no UBI events data is available, while keeping the UBI Events Index optional (COEC uses the default UBI events index) ([#923](https://github.com/opensearch-project/dashboards-search-relevance/pull/923))
 
 ### Infrastructure
 

--- a/public/components/judgment/__tests__/ubi_judgment_fields.test.tsx
+++ b/public/components/judgment/__tests__/ubi_judgment_fields.test.tsx
@@ -97,6 +97,20 @@ describe('UBIJudgmentFields', () => {
     expect(screen.getByText('Max Rank')).toBeInTheDocument();
     expect(screen.getByText('Start Date')).toBeInTheDocument();
     expect(screen.getByText('End Date')).toBeInTheDocument();
+    expect(screen.getByText('UBI Events Index (Required)')).toBeInTheDocument();
+  });
+
+  it('labels UBI Events Index as required for the COEC click model', () => {
+    render(<UBIJudgmentFields {...defaultProps} />);
+    expect(screen.getByText('UBI Events Index (Required)')).toBeInTheDocument();
+  });
+
+  it('labels UBI Events Index as optional for non-COEC click models', () => {
+    const props = {
+      ...defaultProps,
+      formData: { ...defaultProps.formData, clickModel: 'other' },
+    };
+    render(<UBIJudgmentFields {...props} />);
     expect(screen.getByText('UBI Events Index (Optional)')).toBeInTheDocument();
   });
 

--- a/public/components/judgment/__tests__/ubi_judgment_fields.test.tsx
+++ b/public/components/judgment/__tests__/ubi_judgment_fields.test.tsx
@@ -97,12 +97,18 @@ describe('UBIJudgmentFields', () => {
     expect(screen.getByText('Max Rank')).toBeInTheDocument();
     expect(screen.getByText('Start Date')).toBeInTheDocument();
     expect(screen.getByText('End Date')).toBeInTheDocument();
-    expect(screen.getByText('UBI Events Index (Required)')).toBeInTheDocument();
+    expect(screen.getByText('UBI Events Index (Optional)')).toBeInTheDocument();
   });
 
-  it('labels UBI Events Index as required for the COEC click model', () => {
+  it('shows an error when COEC is selected but no UBI events data is available', () => {
+    const props = { ...defaultProps, indexOptions: [], isLoadingIndexes: false };
+    render(<UBIJudgmentFields {...props} />);
+    expect(screen.getByText(/no UBI events index was found/i)).toBeInTheDocument();
+  });
+
+  it('does not show the no-data error when UBI events indexes are available', () => {
     render(<UBIJudgmentFields {...defaultProps} />);
-    expect(screen.getByText('UBI Events Index (Required)')).toBeInTheDocument();
+    expect(screen.queryByText(/no UBI events index was found/i)).not.toBeInTheDocument();
   });
 
   it('labels UBI Events Index as optional for non-COEC click models', () => {

--- a/public/components/judgment/__tests__/validation.test.ts
+++ b/public/components/judgment/__tests__/validation.test.ts
@@ -50,53 +50,15 @@ describe('validation', () => {
     expect(result.errors).toEqual({});
   });
 
-  describe('COEC UBI events index requirement', () => {
-    it('should fail validation when COEC is selected and UBI events index is empty', () => {
+  describe('COEC click model', () => {
+    it('does not require a UBI events index (COEC uses the default index)', () => {
       const result = validateJudgmentForm(
         { name: 'test', type: JudgmentType.UBI, clickModel: 'coec', ubiEventsIndex: '' },
         [],
         [],
         []
       );
-      expect(result.isValid).toBe(false);
-      expect(result.errors.ubiEventsIndex).toBe(
-        'UBI Events Index is required when using the COEC click model'
-      );
-    });
-
-    it('should fail validation when COEC is selected and UBI events index is whitespace only', () => {
-      const result = validateJudgmentForm(
-        { name: 'test', type: JudgmentType.UBI, clickModel: 'coec', ubiEventsIndex: '   ' },
-        [],
-        [],
-        []
-      );
-      expect(result.isValid).toBe(false);
-      expect(result.errors.ubiEventsIndex).toBe(
-        'UBI Events Index is required when using the COEC click model'
-      );
-    });
-
-    it('should pass validation when COEC is selected and UBI events index is provided', () => {
-      const result = validateJudgmentForm(
-        { name: 'test', type: JudgmentType.UBI, clickModel: 'coec', ubiEventsIndex: 'ubi_events' },
-        [],
-        [],
-        []
-      );
       expect(result.isValid).toBe(true);
-      expect(result.errors.ubiEventsIndex).toBeUndefined();
-    });
-
-    it('should not require UBI events index for non-COEC click models', () => {
-      const result = validateJudgmentForm(
-        { name: 'test', type: JudgmentType.UBI, clickModel: 'other', ubiEventsIndex: '' },
-        [],
-        [],
-        []
-      );
-      expect(result.isValid).toBe(true);
-      expect(result.errors.ubiEventsIndex).toBeUndefined();
     });
   });
 

--- a/public/components/judgment/__tests__/validation.test.ts
+++ b/public/components/judgment/__tests__/validation.test.ts
@@ -50,6 +50,56 @@ describe('validation', () => {
     expect(result.errors).toEqual({});
   });
 
+  describe('COEC UBI events index requirement', () => {
+    it('should fail validation when COEC is selected and UBI events index is empty', () => {
+      const result = validateJudgmentForm(
+        { name: 'test', type: JudgmentType.UBI, clickModel: 'coec', ubiEventsIndex: '' },
+        [],
+        [],
+        []
+      );
+      expect(result.isValid).toBe(false);
+      expect(result.errors.ubiEventsIndex).toBe(
+        'UBI Events Index is required when using the COEC click model'
+      );
+    });
+
+    it('should fail validation when COEC is selected and UBI events index is whitespace only', () => {
+      const result = validateJudgmentForm(
+        { name: 'test', type: JudgmentType.UBI, clickModel: 'coec', ubiEventsIndex: '   ' },
+        [],
+        [],
+        []
+      );
+      expect(result.isValid).toBe(false);
+      expect(result.errors.ubiEventsIndex).toBe(
+        'UBI Events Index is required when using the COEC click model'
+      );
+    });
+
+    it('should pass validation when COEC is selected and UBI events index is provided', () => {
+      const result = validateJudgmentForm(
+        { name: 'test', type: JudgmentType.UBI, clickModel: 'coec', ubiEventsIndex: 'ubi_events' },
+        [],
+        [],
+        []
+      );
+      expect(result.isValid).toBe(true);
+      expect(result.errors.ubiEventsIndex).toBeUndefined();
+    });
+
+    it('should not require UBI events index for non-COEC click models', () => {
+      const result = validateJudgmentForm(
+        { name: 'test', type: JudgmentType.UBI, clickModel: 'other', ubiEventsIndex: '' },
+        [],
+        [],
+        []
+      );
+      expect(result.isValid).toBe(true);
+      expect(result.errors.ubiEventsIndex).toBeUndefined();
+    });
+  });
+
   describe('date range validation', () => {
     it('should fail validation when end date is before start date', () => {
       const result = validateJudgmentForm(

--- a/public/components/judgment/components/ubi_judgment_fields.tsx
+++ b/public/components/judgment/components/ubi_judgment_fields.tsx
@@ -27,8 +27,8 @@ export const UBIJudgmentFields: React.FC<UBIJudgmentFieldsProps> = ({
     const formattedDate = date ? date.format('YYYY-MM-DD') : '';
     updateFormData({ [fieldName]: formattedDate });
   };
-  const isUbiIndexRequired = formData.clickModel === 'coec';
-  const ubiIndexInvalid = isUbiIndexRequired && !formData.ubiEventsIndex?.trim();
+  const noUbiEventsDataForCoec =
+    formData.clickModel === 'coec' && !isLoadingIndexes && indexOptions?.length === 0;
   return (
     <>
       <EuiCompressedFormRow label="Click Model"
@@ -77,14 +77,14 @@ export const UBIJudgmentFields: React.FC<UBIJudgmentFieldsProps> = ({
         />
       </EuiCompressedFormRow>
       <EuiCompressedFormRow
-        label={`UBI Events Index ${isUbiIndexRequired ? '(Required)' : '(Optional)'}`}
-        helpText={
-          isUbiIndexRequired
-            ? 'Select from UBI events indexes or type a custom index name and press Enter. Required for the COEC click model.'
-            : 'Select from UBI events indexes or type a custom index name and press Enter. Leave empty to use default.'
+        label="UBI Events Index (Optional)"
+        helpText="Select from UBI events indexes or type a custom index name and press Enter. Leave empty to use the default UBI events index."
+        isInvalid={noUbiEventsDataForCoec}
+        error={
+          noUbiEventsDataForCoec
+            ? 'The COEC click model requires UBI events data, but no UBI events index was found. Ingest UBI events data before generating COEC judgments.'
+            : undefined
         }
-        isInvalid={ubiIndexInvalid}
-        error={ubiIndexInvalid ? 'UBI Events Index is required when using the COEC click model' : undefined}
         fullWidth>
         <EuiComboBox
           placeholder="Select or type UBI events index"
@@ -99,7 +99,7 @@ export const UBIJudgmentFields: React.FC<UBIJudgmentFieldsProps> = ({
           }}
           singleSelection={{ asPlainText: true }}
           isLoading={isLoadingIndexes}
-          isInvalid={ubiIndexInvalid}
+          isInvalid={noUbiEventsDataForCoec}
           isClearable={true}
           fullWidth
           customOptionText="Use custom index: {searchValue}"

--- a/public/components/judgment/components/ubi_judgment_fields.tsx
+++ b/public/components/judgment/components/ubi_judgment_fields.tsx
@@ -27,6 +27,8 @@ export const UBIJudgmentFields: React.FC<UBIJudgmentFieldsProps> = ({
     const formattedDate = date ? date.format('YYYY-MM-DD') : '';
     updateFormData({ [fieldName]: formattedDate });
   };
+  const isUbiIndexRequired = formData.clickModel === 'coec';
+  const ubiIndexInvalid = isUbiIndexRequired && !formData.ubiEventsIndex?.trim();
   return (
     <>
       <EuiCompressedFormRow label="Click Model"
@@ -75,8 +77,14 @@ export const UBIJudgmentFields: React.FC<UBIJudgmentFieldsProps> = ({
         />
       </EuiCompressedFormRow>
       <EuiCompressedFormRow
-        label="UBI Events Index (Optional)"
-        helpText="Select from UBI events indexes or type a custom index name and press Enter. Leave empty to use default."
+        label={`UBI Events Index ${isUbiIndexRequired ? '(Required)' : '(Optional)'}`}
+        helpText={
+          isUbiIndexRequired
+            ? 'Select from UBI events indexes or type a custom index name and press Enter. Required for the COEC click model.'
+            : 'Select from UBI events indexes or type a custom index name and press Enter. Leave empty to use default.'
+        }
+        isInvalid={ubiIndexInvalid}
+        error={ubiIndexInvalid ? 'UBI Events Index is required when using the COEC click model' : undefined}
         fullWidth>
         <EuiComboBox
           placeholder="Select or type UBI events index"
@@ -91,6 +99,7 @@ export const UBIJudgmentFields: React.FC<UBIJudgmentFieldsProps> = ({
           }}
           singleSelection={{ asPlainText: true }}
           isLoading={isLoadingIndexes}
+          isInvalid={ubiIndexInvalid}
           isClearable={true}
           fullWidth
           customOptionText="Use custom index: {searchValue}"

--- a/public/components/judgment/utils/validation.ts
+++ b/public/components/judgment/utils/validation.ts
@@ -14,6 +14,7 @@ export interface ValidationResult {
     searchConfigs?: string;
     model?: string;
     dateRange?: string;
+    ubiEventsIndex?: string;
   };
 }
 
@@ -44,6 +45,11 @@ export const validateJudgmentForm = (
       errors.model = 'Please select a model id';
       isValid = false;
     }
+  }
+
+  if (data.type === JudgmentType.UBI && data.clickModel === 'coec' && !data.ubiEventsIndex?.trim()) {
+    errors.ubiEventsIndex = 'UBI Events Index is required when using the COEC click model';
+    isValid = false;
   }
 
   // Date validation: Only validate date range when both dates are provided

--- a/public/components/judgment/utils/validation.ts
+++ b/public/components/judgment/utils/validation.ts
@@ -14,7 +14,6 @@ export interface ValidationResult {
     searchConfigs?: string;
     model?: string;
     dateRange?: string;
-    ubiEventsIndex?: string;
   };
 }
 
@@ -45,11 +44,6 @@ export const validateJudgmentForm = (
       errors.model = 'Please select a model id';
       isValid = false;
     }
-  }
-
-  if (data.type === JudgmentType.UBI && data.clickModel === 'coec' && !data.ubiEventsIndex?.trim()) {
-    errors.ubiEventsIndex = 'UBI Events Index is required when using the COEC click model';
-    isValid = false;
   }
 
   // Date validation: Only validate date range when both dates are provided

--- a/public/components/query_compare/search_result/search_components/search_configs/search_config.tsx
+++ b/public/components/query_compare/search_result/search_components/search_configs/search_config.tsx
@@ -114,12 +114,14 @@ export const SearchConfig: FunctionComponent<SearchConfigProps> = ({
     datasource2,
   } = useSearchRelevanceContext();
 
+  const dataSourceId = queryNumber === 1 ? datasource1 : datasource2;
+
   useEffect(() => {
     let isMounted = true;
     const fetchSearchConfigurations = async () => {
       setIsLoadingConfigs(true);
       try {
-        const data = await searchConfigurationService.getSearchConfigurations();
+        const data = await searchConfigurationService.getSearchConfigurations(dataSourceId);
         if (isMounted) {
           setAllConfigs(data.hits.hits);
           const options = data.hits.hits.map((search_config: any) => ({
@@ -142,7 +144,7 @@ export const SearchConfig: FunctionComponent<SearchConfigProps> = ({
     return () => {
       isMounted = false;
     };
-  }, [searchConfigurationService]);
+  }, [searchConfigurationService, dataSourceId]);
 
   const onSearchConfigChange = (selectedOptions: any[]) => {
     setSelectedSearchConfig(selectedOptions);
@@ -249,6 +251,7 @@ export const SearchConfig: FunctionComponent<SearchConfigProps> = ({
   useEffect(() => {
     setSelectedIndex('');
     setPipeline('');
+    setSelectedSearchConfig([]);
   }, [datasource1, datasource2]);
 
   let DataSourceSelector;


### PR DESCRIPTION
### Description
This PR fixes two independent bugs in the Search Relevance workbench UI.

**#913 — Search Configuration dropdown shows no options in Query Analysis (multi-data-source)**
The "Search Configuration" dropdown fetched saved search configurations without the selected data source id, so the request always went to the default/local cluster. When a remote data source is selected for a setup, its configurations live on that data source's cluster, so the dropdown showed "There aren't any options available".

The dropdown now passes the setup's selected `dataSourceId` when fetching (consistent with how the Search Configurations listing page already works), re-fetches when the data source changes, and clears the previously selected configuration on data source change.
<img width="1512" height="806" alt="913" src="https://github.com/user-attachments/assets/ec95f5ca-e635-45bf-b2d7-5aa900651abe" />

**#914 — UBI Events Index for the COEC click model (Judgments)**

When creating an Implicit (click-based) judgment with the COEC click model, the UBI Events Index is optional: COEC uses the default `ubi_events` index, and this field only overrides that default. The real problem is that when no UBI events data exists, judgment generation fails later without a clear reason.

The field is now labeled "(Optional)" for every click model. When COEC is selected and no UBI events index is available, the form shows a clear inline error instead of blocking on an empty field. Other click models are unaffected.

_UBI events data available — field is optional, submits with the default index:_
<img width="1504" height="702" alt="01-1" src="https://github.com/user-attachments/assets/a186da0f-e98f-4e73-89e3-5af8357914af" />
<img width="1500" height="576" alt="01-2" src="https://github.com/user-attachments/assets/89599aad-65ec-4910-b798-6a14c048889b" />


_No UBI events data — clear error shown (field still optional, not "required"):_
<img width="1496" height="761" alt="01-3" src="https://github.com/user-attachments/assets/4131c562-e2e8-4094-8ddf-f47a86e88a67" />



### Issues Resolved
Fixes #913
Fixes #914

### Check List
- [x] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
