### PR TITLE
Fix delete error messages, search config validation, and dashboard/hybrid views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Bug Fixes
 
 - Pass dataSourceId in Hybrid Optimizer and Pairwise experiment result queries so experiment views render on multi-data-source deployments ([#921](https://github.com/opensearch-project/dashboards-search-relevance/pull/921))
-- Surface the backend reason (e.g. HTTP 409) when deleting a query set, judgment, or search configuration that is still used by an experiment, instead of a generic failure message ([#926](https://github.com/opensearch-project/dashboards-search-relevance/pull/926))
-- Show the actual validation error when creating a search configuration instead of always reporting "Search returned no results" ([#926](https://github.com/opensearch-project/dashboards-search-relevance/pull/926))
-- Fix experiment visualization/deep-dive install detection and Hybrid Optimizer result rendering on multi-data-source (OpenSearch UI) deployments ([#926](https://github.com/opensearch-project/dashboards-search-relevance/pull/926))
+- Fix delete error messages, search config validation, and dashboard/hybrid views ([#926](https://github.com/opensearch-project/dashboards-search-relevance/pull/926))
 
 ### Infrastructure
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Bug Fixes
 
 - Pass dataSourceId in Hybrid Optimizer and Pairwise experiment result queries so experiment views render on multi-data-source deployments ([#921](https://github.com/opensearch-project/dashboards-search-relevance/pull/921))
+- Surface the backend reason (e.g. HTTP 409) when deleting a query set, judgment, or search configuration that is still used by an experiment, instead of a generic failure message ([#926](https://github.com/opensearch-project/dashboards-search-relevance/pull/926))
+- Show the actual validation error when creating a search configuration instead of always reporting "Search returned no results" ([#926](https://github.com/opensearch-project/dashboards-search-relevance/pull/926))
+- Fix experiment visualization/deep-dive install detection and Hybrid Optimizer result rendering on multi-data-source (OpenSearch UI) deployments ([#926](https://github.com/opensearch-project/dashboards-search-relevance/pull/926))
 
 ### Infrastructure
 

--- a/common/index.ts
+++ b/common/index.ts
@@ -85,6 +85,7 @@ export enum Routes {
 
 export enum SavedObjectIds {
   ExperimentDeepDive = '75b6ca00-58af-11f0-a87e-4d769b1dbd6c',
+  DeepDiveSummary = '49898070-5d6a-11f0-997f-d5fd279c0ce1',
   ExperimentVariantComparison = 'fbf11670-58c8-11f0-a340-41deff9f2f7f',
   PointwiseExperimentScheduledRuns = '1edb6ad0-aac9-11f0-83f6-277d0637de48',
   SearchEvaluationIndexPattern = '1f5d2be0-57f1-11f0-8f39-7b4ad0195873',

--- a/public/components/common/dashboard_install_modal.tsx
+++ b/public/components/common/dashboard_install_modal.tsx
@@ -43,10 +43,10 @@ export const DashboardInstallModal: React.FC<DashboardInstallModalProps> = ({
   React.useEffect(() => {
     const checkInstallation = async () => {
       try {
-        const queryParams = dataSourceId ? `?dataSourceId=${dataSourceId}` : '';
-        const _ = await http.get(
-          `/api/saved_objects/dashboard/${SavedObjectIds.ExperimentDeepDive}${queryParams}`
-        );
+        const dashboardObjectId = dataSourceId
+          ? `${dataSourceId}_${SavedObjectIds.ExperimentDeepDive}`
+          : SavedObjectIds.ExperimentDeepDive;
+        const _ = await http.get(`/api/saved_objects/dashboard/${dashboardObjectId}`);
         setDashboardsInstalled(true);
       } catch (error) {
         setDashboardsInstalled(false);

--- a/public/components/common_utils/dashboards.ts
+++ b/public/components/common_utils/dashboards.ts
@@ -100,6 +100,17 @@ export async function dashboardUrl(
  */
 export const checkDashboardsInstalled = async (http: CoreStart['http'], dataSourceId?: string): Promise<boolean> => {
   try {
+    if (dataSourceId) {
+      try {
+        await http.get(
+          `/api/saved_objects/dashboard/${dataSourceId}_${SavedObjectIds.ExperimentDeepDive}`
+        );
+        return true;
+      } catch (error) {
+        return false;
+      }
+    }
+
     // Get datasource name dynamically to create expected suffix
     // This ensures we check for visualizations specific to the current datasource context
     let expectedSuffix = '';

--- a/public/components/experiment/views/experiment_listing.tsx
+++ b/public/components/experiment/views/experiment_listing.tsx
@@ -205,7 +205,12 @@ export const ExperimentListing: React.FC<ExperimentListingProps> = ({
   } = useExperimentPolling();
 
   const openDashboard = async (experiment: any, dashboardId: string, indexPatternId: string) => {
-    const filters = [createPhraseFilter('experimentId', experiment.id, indexPatternId)];
+    const resolvedDashboardId = dataSourceId ? `${dataSourceId}_${dashboardId}` : dashboardId;
+    const resolvedIndexPatternId = dataSourceId
+      ? `${dataSourceId}_${indexPatternId}`
+      : indexPatternId;
+
+    const filters = [createPhraseFilter('experimentId', experiment.id, resolvedIndexPatternId)];
 
     // Create timeRange from experiment timestamp
     const timeRange = {
@@ -213,7 +218,14 @@ export const ExperimentListing: React.FC<ExperimentListingProps> = ({
       to: "now",
     };
 
-    const url = await dashboardUrl(share, dashboardId, indexPatternId, filters, timeRange);
+    const url = await dashboardUrl(
+      share,
+      resolvedDashboardId,
+      resolvedIndexPatternId,
+      filters,
+      timeRange,
+      dataSourceId
+    );
     window.open(url, '_blank');
   };
 
@@ -223,7 +235,7 @@ export const ExperimentListing: React.FC<ExperimentListingProps> = ({
     indexPatternId: string
   ) => {
     try {
-      const dashboardsAreInstalled = await checkDashboardsInstalled(http);
+      const dashboardsAreInstalled = await checkDashboardsInstalled(http, dataSourceId);
       if (!dashboardsAreInstalled) {
         setPendingDashboardAction(() => () =>
           openDashboard(experiment, dashboardId, indexPatternId)

--- a/public/components/experiment/views/hybrid_optimizer_experiment_view.tsx
+++ b/public/components/experiment/views/hybrid_optimizer_experiment_view.tsx
@@ -169,6 +169,11 @@ export const HybridOptimizerExperimentView: React.FC<HybridOptimizerExperimentVi
             }
           }
 
+          setExperiment(_experiment as HybridOptimizerExperiment);
+          setSearchConfiguration(_searchConfiguration);
+          setQuerySet(_querySet);
+          setJudgmentSet(_judgmentSet);
+
           if (!allResults || allResults.length === 0) {
             console.error('No evaluation results found');
             notifications.toasts.addWarning({

--- a/public/components/judgment/hooks/use_judgment_list.ts
+++ b/public/components/judgment/hooks/use_judgment_list.ts
@@ -188,7 +188,7 @@ export const useJudgmentList = (http: CoreStart['http'], dataSourceId?: string |
         return true;
       } catch (err) {
         console.error('Failed to delete judgment', err);
-        setError('Failed to delete judgment');
+        setError(extractUserMessageFromError(err) || 'Failed to delete judgment');
         return false;
       } finally {
         setIsLoading(false);

--- a/public/components/query_set/__tests__/use_query_set_list.test.ts
+++ b/public/components/query_set/__tests__/use_query_set_list.test.ts
@@ -5,6 +5,7 @@
 
 import { renderHook, act } from '@testing-library/react';
 import { useQuerySetList } from '../hooks/use_query_set_list';
+import { extractUserMessageFromError } from '../../../../common';
 
 // Mock the common module
 jest.mock('../../../../common', () => ({
@@ -155,6 +156,7 @@ describe('useQuerySetList', () => {
   });
 
   it('handles delete error', async () => {
+    (extractUserMessageFromError as jest.Mock).mockReturnValueOnce(null);
     const mockError = new Error('Delete failed');
     mockHttp.delete.mockRejectedValue(mockError);
 

--- a/public/components/query_set/hooks/use_query_set_list.ts
+++ b/public/components/query_set/hooks/use_query_set_list.ts
@@ -70,7 +70,7 @@ export const useQuerySetList = (http: CoreStart['http'], dataSourceId?: string |
       setRefreshKey((prev) => prev + 1);
     } catch (err) {
       console.error('Failed to delete query set', err);
-      setError('Failed to delete query set');
+      setError(extractUserMessageFromError(err) || 'Failed to delete query set');
       throw err;
     } finally {
       setIsLoading(false);

--- a/public/components/search_configuration/hooks/use_search_configuration_list.ts
+++ b/public/components/search_configuration/hooks/use_search_configuration_list.ts
@@ -78,7 +78,7 @@ export const useSearchConfigurationList = (http: CoreStart['http'], dataSourceId
         return true;
       } catch (err) {
         console.error('Failed to delete search config', err);
-        setError('Failed to delete search configuration');
+        setError(extractUserMessageFromError(err) || 'Failed to delete search configuration');
         return false;
       } finally {
         setIsLoading(false);

--- a/public/components/search_configuration/services/search_configuration_service.ts
+++ b/public/components/search_configuration/services/search_configuration_service.ts
@@ -74,6 +74,9 @@ export class SearchConfigurationService {
       opts.query = { dataSourceId };
     }
     const response = await this.http.post(ServiceEndpoints.GetSingleSearchResults, opts);
+    if (response.errorMsg) {
+      throw new Error(response.errorMsg.body);
+    }
     return response.result;
   }
 }

--- a/server/routes/dsl_route.ts
+++ b/server/routes/dsl_route.ts
@@ -343,7 +343,9 @@ export function registerDslRoute(router: IRouter, dataSourceEnabled: boolean) {
       } catch (error) {
         if (error.statusCode !== 404) console.error(error);
 
-        const errorMessage = `Error: ${error.body?.error?.type} - ${error.body?.error?.reason}`;
+        const errorMessage = `Error: ${error.body?.error?.type || 'Unknown'} - ${
+          error.body?.error?.reason || 'Unknown reason'
+        }`;
         resBody.errorMsg = {
           statusCode: error.statusCode || 500,
           body: errorMessage,


### PR DESCRIPTION
## Description

Fixes several Search Relevance Workbench issues found during testing.

### Probelm 1 — Deleting a query set that is in use shows a generic failure
**Before:** Deleting a query set (or judgment / search configuration) still used by an experiment showed a generic error and didn't say why.
**After:** The dashboard surfaces the backend reason, e.g. `409: query set cannot be deleted as it is currently used by experiments with ids ...`.

<img width="1487" height="650" alt="12-1" src="https://github.com/user-attachments/assets/3d5521f5-be95-4426-8632-7fdc8429fedc" />
<img width="1477" height="424" alt="12-2" src="https://github.com/user-attachments/assets/9757205b-e4d9-4640-afc9-82f85869e136" />


### Probelm 2 — Creating a search configuration always says "Search returned no results"
**Before:** Validating/creating a search configuration always showed "Search returned no results"; the `single_search` response body was `Error: undefined - undefined`.
**After:** Valid queries validate and return results:
<img width="1495" height="716" alt="16-1" src="https://github.com/user-attachments/assets/c0226d7e-5168-4d50-be21-12dcac639686" />

Invalid queries show the failed reason:
<img width="1492" height="778" alt="16-2" src="https://github.com/user-attachments/assets/fc076550-f14f-4ac6-8f06-0d3c3741904e" />


### Probelm 3 — Experiment visualization / deep dive & "Install dashboards"
**Before:** On multi-data-source deployments, "View Visualization" always re-installed dashboards and the deep-dive page was empty; installing Evaluation dashboards didn't take effect.
**After:** The install check and dashboard open use the data-source-prefixed saved-object id, so the deep dive opens with the correct filters and install is detected correctly.
<img width="1512" height="770" alt="13-1" src="https://github.com/user-attachments/assets/2337d2cb-d6c3-4a10-a0d8-b4d63123d0ef" />

### Probelm 4 — Hybrid Optimizer result view on dashboard
**Before:** The Hybrid Optimizer / variants comparison panel didn't load, and clicking a result showed a blank page.
**After:** The experiment / search config / query set / judgment state is set before the empty-results early return, so the result view renders.
<img width="1500" height="777" alt="20-1" src="https://github.com/user-attachments/assets/2c23b53e-b4d3-4f0d-abc8-8396750673f4" />
<img width="1496" height="786" alt="19-1" src="https://github.com/user-attachments/assets/9221cf28-720d-4211-9719-206bb5ad12c8" />


### Check List
- [x] New functionality has been verified manually on dashboard
- [x] Commits are signed per the DCO
