### PR TITLE
Stabilize /search-relevance chat command unit test (avoid loading @osd/monaco)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Infrastructure
 
+- Stabilize /search-relevance chat command unit test (avoid loading @osd/monaco) ([#927](https://github.com/opensearch-project/dashboards-search-relevance/pull/927))
+
 ### Documentation
 
 ### Maintenance

--- a/public/chat/__tests__/search_relevance_command.test.ts
+++ b/public/chat/__tests__/search_relevance_command.test.ts
@@ -7,6 +7,13 @@ import { registerSearchRelevanceCommand } from '../search_relevance_command';
 import { ChatPluginSetup } from '../../../../../src/plugins/chat/public';
 import { CoreSetup } from '../../../../../src/core/public';
 
+jest.mock('../../../../../src/core/public', () => ({
+  ALL_USE_CASE_ID: 'all',
+  SEARCH_USE_CASE_ID: 'search',
+  isNavGroupInFeatureConfigs: (navGroupId: string, featureConfigs: string[]) =>
+    Array.isArray(featureConfigs) && featureConfigs.includes(`use-case-${navGroupId}`),
+}));
+
 describe('registerSearchRelevanceCommand', () => {
   let mockRegisterCommand: jest.Mock;
   let mockChatSetup: ChatPluginSetup;


### PR DESCRIPTION
## Description

The `/search-relevance` chat command unit test (`public/chat/__tests__/search_relevance_command.test.ts`) intermittently fails to run in CI with:

> TypeError: Cannot convert a BigInt value to a number
>     at Math.pow
>     `const LONG_MIN = -(2n ** 63n);` — `@osd/monaco/.../ppl/lint/explain/explain_quick_fix.ts`

**Root cause:** the test imports the command under test, which imports the `src/core/public` barrel. Loading that barrel transitively loads `@osd/monaco`, whose ppl-lint code evaluates BigInt exponentiation (`2n ** 63n`) at module load. The exponentiation transform rewrites `**` to `Math.pow`, which throws on BigInt under jest, so the whole test suite fails to load. This is unrelated to the command's behavior and can affect other PRs' CI as well.

**Fix:** mock the `src/core/public` barrel in this test with faithful stubs for the only members the command uses (`ALL_USE_CASE_ID`, `SEARCH_USE_CASE_ID`, `isNavGroupInFeatureConfigs`). The real barrel — and therefore `@osd/monaco` — is no longer loaded, so the crash can't be hit. The command's runtime behavior is unchanged (everything else it needs comes in via the `core` argument), and all existing test cases still pass.

### Check List

- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test
  - [ ] Integration tests pass: `yarn cypress:run-without-security --config "baseUrl=http://localhost:5601" --spec "cypress/integration/plugins/search-relevance-dashboards/*.js"` (see [Developer Guide](DEVELOPER_GUIDE.md#integration-tests))
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
