### PR TITLE
fix: scope experiment result dashboards to the active workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Pass dataSourceId in Hybrid Optimizer and Pairwise experiment result queries so experiment views render on multi-data-source deployments ([#921](https://github.com/opensearch-project/dashboards-search-relevance/pull/921))
 - Fix delete error messages, search config validation, and dashboard/hybrid views ([#926](https://github.com/opensearch-project/dashboards-search-relevance/pull/926))
 - fix: scope search config to data source; require UBI index for COEC ([#923](https://github.com/opensearch-project/dashboards-search-relevance/pull/923))
+- Scope experiment result dashboards to the active workspace and data source ([#928](https://github.com/opensearch-project/dashboards-search-relevance/pull/928))
 
 ### Infrastructure
 

--- a/public/components/common/dashboard_install_modal.tsx
+++ b/public/components/common/dashboard_install_modal.tsx
@@ -16,8 +16,7 @@ import {
 } from '@elastic/eui';
 import React, { useState } from 'react';
 import { CoreStart } from '../../../../../src/core/public';
-import { SavedObjectIds } from '../../../common';
-import { escapedDashboardsData } from '../common_utils/dashboards_data';
+import { checkDashboardsInstalled, installDashboards } from '../common_utils/dashboards';
 
 interface DashboardInstallModalProps {
   onClose: () => void;
@@ -25,6 +24,7 @@ interface DashboardInstallModalProps {
   title?: string;
   http: CoreStart['http'];
   setError: (error: string | null) => void;
+  workspaceId?: string;
   dataSourceId?: string;
 }
 
@@ -34,54 +34,30 @@ export const DashboardInstallModal: React.FC<DashboardInstallModalProps> = ({
   title = 'Install Dashboards',
   http,
   setError,
+  workspaceId,
   dataSourceId,
 }) => {
   const [isInstalling, setIsInstalling] = useState(false);
   const [dashboardsInstalled, setDashboardsInstalled] = useState<boolean | null>(null);
 
-  // Check if dashboards are already installed when modal opens
+  // Check if dashboards are already installed for the current workspace/data source when the modal opens
   React.useEffect(() => {
     const checkInstallation = async () => {
-      try {
-        const dashboardObjectId = dataSourceId
-          ? `${dataSourceId}_${SavedObjectIds.ExperimentDeepDive}`
-          : SavedObjectIds.ExperimentDeepDive;
-        const _ = await http.get(`/api/saved_objects/dashboard/${dashboardObjectId}`);
-        setDashboardsInstalled(true);
-      } catch (error) {
-        setDashboardsInstalled(false);
-      }
+      setDashboardsInstalled(await checkDashboardsInstalled(http, workspaceId, dataSourceId));
     };
     checkInstallation();
-  }, [http, dataSourceId]);
+  }, [http, workspaceId, dataSourceId]);
 
   const handleConfirm = async () => {
     setIsInstalling(true);
     setError(null);
-    try {
-      const formData = new FormData();
-      formData.append(
-        'file',
-        new Blob([escapedDashboardsData], { type: 'application/x-ndjson' }),
-        'dashboards.ndjson'
-      );
-      
-      const queryParams = dataSourceId ? { dataSourceId, overwrite: true } : { overwrite: true };
-      
-      await http.post('/api/saved_objects/_import', {
-        body: formData,
-        headers: {
-          'Content-Type': undefined,
-        },
-        query: queryParams,
-      });
+    const success = await installDashboards(http, workspaceId, dataSourceId);
+    setIsInstalling(false);
+    if (success) {
       onSuccess?.();
       onClose();
-    } catch (error) {
-      console.error('Failed to install dashboards:', error);
+    } else {
       setError('Failed to install dashboards');
-    } finally {
-      setIsInstalling(false);
     }
   };
 

--- a/public/components/common_utils/__tests__/dashboards.test.ts
+++ b/public/components/common_utils/__tests__/dashboards.test.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { getScopedSavedObjectId, applyDashboardScope } from '../dashboards';
+import { escapedDashboardsData } from '../dashboards_data';
+
+const parseLines = (ndjson: string) =>
+  ndjson
+    .split('\n')
+    .filter((line) => line.trim())
+    .map((line) => JSON.parse(line));
+
+describe('getScopedSavedObjectId', () => {
+  it('prefixes with data source then workspace, matching the imported id layout', () => {
+    expect(getScopedSavedObjectId('abc', 'ws1', 'ds1')).toBe('ds1_ws1_abc');
+  });
+
+  it('applies only the dimensions that are present', () => {
+    expect(getScopedSavedObjectId('abc', 'ws1')).toBe('ws1_abc');
+    expect(getScopedSavedObjectId('abc', undefined, 'ds1')).toBe('ds1_abc');
+    expect(getScopedSavedObjectId('abc')).toBe('abc');
+    expect(getScopedSavedObjectId('abc', '', '')).toBe('abc');
+  });
+});
+
+describe('applyDashboardScope', () => {
+  it('returns the data unchanged when neither workspace nor data source is provided', () => {
+    expect(applyDashboardScope(escapedDashboardsData)).toBe(escapedDashboardsData);
+    expect(applyDashboardScope(escapedDashboardsData, '', '')).toBe(escapedDashboardsData);
+  });
+
+  it('scopes every saved object id and reference id, keeping references internally consistent', () => {
+    const workspaceId = 'ws1';
+    const dataSourceId = 'ds1';
+    const original = parseLines(escapedDashboardsData);
+    const scoped = parseLines(applyDashboardScope(escapedDashboardsData, workspaceId, dataSourceId));
+
+    expect(scoped.length).toBe(original.length);
+
+    const scopedIds = new Set(
+      scoped.filter((o) => typeof o.id === 'string').map((o) => o.id as string)
+    );
+
+    original.forEach((originalObject, index) => {
+      const scopedObject = scoped[index];
+
+      if (typeof originalObject.id === 'string') {
+        expect(scopedObject.id).toBe(`${dataSourceId}_${workspaceId}_${originalObject.id}`);
+      } else {
+        // The trailing export-summary line has no id and must be preserved as-is.
+        expect(scopedObject).toEqual(originalObject);
+      }
+
+      (scopedObject.references || []).forEach((reference: any) => {
+        expect(reference.id.startsWith(`${dataSourceId}_${workspaceId}_`)).toBe(true);
+        // Every reference still resolves to an object shipped in the same import.
+        expect(scopedIds.has(reference.id)).toBe(true);
+      });
+    });
+  });
+
+  it('scopes by workspace only when no data source is provided', () => {
+    const scoped = parseLines(applyDashboardScope(escapedDashboardsData, 'ws1'));
+    const withId = scoped.find((o) => typeof o.id === 'string');
+    expect(withId.id.startsWith('ws1_')).toBe(true);
+    expect(withId.id.startsWith('ws1_ws1_')).toBe(false);
+  });
+
+  it('produces valid ndjson where every non-empty line still parses', () => {
+    const scoped = applyDashboardScope(escapedDashboardsData, 'ws1', 'ds1');
+    const lines = scoped.split('\n').filter((line) => line.trim());
+
+    expect(lines.length).toBeGreaterThan(0);
+    expect(() => lines.forEach((line) => JSON.parse(line))).not.toThrow();
+  });
+});

--- a/public/components/common_utils/dashboards.ts
+++ b/public/components/common_utils/dashboards.ts
@@ -83,70 +83,101 @@ export async function dashboardUrl(
 }
 
 /**
- * Check if the required dashboards are installed for the specific datasource context
- * 
- * This function determines whether dashboards need to be installed/overwritten based on:
- * 1. Current visualization suffixes vs expected suffixes for the datasource
- * 2. If suffixes don't match, it returns false to trigger installation/overwrite
- * 
- * Overwrite scenarios:
- * - Current: "Deep Dive Summary_remote", Expected: "_test" → Returns false (will overwrite with _test)
- * - Current: "Deep Dive Summary_test", Expected: "_remote" → Returns false (will overwrite with _remote)
- * - Current: "Deep Dive Summary_remote", Expected: "" (local) → Returns false (will overwrite with no suffix)
- * 
- * No installation scenarios:
- * - Current: "Deep Dive Summary_test", Expected: "_test" → Returns true (no installation needed)
- * - Current: "Deep Dive Summary", Expected: "" (local) → Returns true (no installation needed)
+ * Compute the fully scoped saved object id for the current workspace and data source.
+ *
+ * These dashboards ship with fixed, globally unique ids, so they must be scoped to avoid
+ * colliding across workspaces and data sources. Both dimensions are applied as id prefixes
+ * before import (the import binds the data source through an object reference, it does not
+ * prefix ids itself). Missing dimensions are skipped, so single-data-source and non-workspace
+ * deployments keep working with the base ids. The resulting layout is
+ * `${dataSourceId}_${workspaceId}_${baseId}`.
  */
-export const checkDashboardsInstalled = async (http: CoreStart['http'], dataSourceId?: string): Promise<boolean> => {
-  try {
-    if (dataSourceId) {
-      try {
-        await http.get(
-          `/api/saved_objects/dashboard/${dataSourceId}_${SavedObjectIds.ExperimentDeepDive}`
+export const getScopedSavedObjectId = (
+  baseId: string,
+  workspaceId?: string,
+  dataSourceId?: string
+): string => [dataSourceId, workspaceId, baseId].filter(Boolean).join('_');
+
+/**
+ * Rewrite the exported dashboards ndjson so every saved object id, and every reference to it, is
+ * scoped to the current workspace and data source. References are rewritten with the same scheme
+ * so the imported dashboards, visualizations and index pattern keep pointing at each other. The
+ * trailing export-summary line (which has no id) is left untouched. When neither dimension is
+ * active the data is returned unchanged.
+ */
+export const applyDashboardScope = (
+  dashboardsData: string,
+  workspaceId?: string,
+  dataSourceId?: string
+): string => {
+  if (!workspaceId && !dataSourceId) {
+    return dashboardsData;
+  }
+
+  return dashboardsData
+    .split('\n')
+    .map((line) => {
+      if (!line.trim()) {
+        return line;
+      }
+
+      const savedObject = JSON.parse(line);
+
+      if (typeof savedObject.id === 'string') {
+        savedObject.id = getScopedSavedObjectId(savedObject.id, workspaceId, dataSourceId);
+      }
+
+      if (Array.isArray(savedObject.references)) {
+        savedObject.references = savedObject.references.map((reference: any) =>
+          typeof reference.id === 'string'
+            ? { ...reference, id: getScopedSavedObjectId(reference.id, workspaceId, dataSourceId) }
+            : reference
         );
-        return true;
-      } catch (error) {
-        return false;
       }
-    }
 
-    // Get datasource name dynamically to create expected suffix
-    // This ensures we check for visualizations specific to the current datasource context
-    let expectedSuffix = '';
-    if (dataSourceId) {
-      try {
-        const datasourceResponse = await http.get(`/api/saved_objects/data-source/${dataSourceId}`);
-        const datasourceName = datasourceResponse.attributes?.title || dataSourceId;
-        expectedSuffix = `_${datasourceName}`;
-      } catch (error) {
-        // If can't get datasource name, use dataSourceId as fallback
-        expectedSuffix = `_${dataSourceId}`;
-      }
-    }
+      return JSON.stringify(savedObject);
+    })
+    .join('\n');
+};
 
-    try {
-      // Check the "Deep Dive Summary" visualization as a representative test case
-      // All visualizations in a dashboard set should have consistent suffixes
-      const response = await http.get(`/api/saved_objects/visualization/${SavedObjectIds.DeepDiveSummary}`);
-      const title = response.attributes?.title || '';
-      
-      // Check if the visualization title matches the expected suffix
-      // If it doesn't match, return false to trigger installation/overwrite
-      return expectedSuffix === '' ? !title.includes('_') : title.endsWith(expectedSuffix);
-    } catch (error) {
-      // If visualization doesn't exist, dashboards need to be installed
-      return false;
-    }
+/**
+ * Check whether the dashboards are already installed for the current workspace and data source by
+ * looking up the fully scoped "Experiment Deep Dive" dashboard. The request runs through the
+ * workspace-aware http base path, so it only matches dashboards that belong to the current
+ * workspace.
+ */
+export const checkDashboardsInstalled = async (
+  http: CoreStart['http'],
+  workspaceId?: string,
+  dataSourceId?: string
+): Promise<boolean> => {
+  try {
+    await http.get(
+      `/api/saved_objects/dashboard/${getScopedSavedObjectId(
+        SavedObjectIds.ExperimentDeepDive,
+        workspaceId,
+        dataSourceId
+      )}`
+    );
+    return true;
   } catch (error) {
     return false;
   }
 };
 
 /**
- * Install the required dashboards with datasource name as suffix
+ * Install the dashboards for the current workspace and data source.
+ *
+ * The data source name is used as a display suffix (replacing the `_remote` placeholder in the
+ * exported objects' titles), the ids are prefixed with the workspace id, and the import is bound
+ * to the data source. Combined with the data source prefix applied by the import, each
+ * workspace/data source pair gets its own independent, correctly bound copy.
  */
-export const installDashboards = async (http: CoreStart['http'], dataSourceId?: string): Promise<boolean> => {
+export const installDashboards = async (
+  http: CoreStart['http'],
+  workspaceId?: string,
+  dataSourceId?: string
+): Promise<boolean> => {
   try {
     // Get datasource name dynamically
     let suffix = '';
@@ -160,10 +191,10 @@ export const installDashboards = async (http: CoreStart['http'], dataSourceId?: 
         suffix = `_${dataSourceId}`;
       }
     }
-    
+
     // Modify dashboard data to use the datasource name suffix
     let dashboardData = escapedDashboardsData;
-    
+
     if (suffix) {
       // Replace _remote with the datasource name suffix
       dashboardData = dashboardData.replace(/_remote/g, suffix);
@@ -172,15 +203,19 @@ export const installDashboards = async (http: CoreStart['http'], dataSourceId?: 
       dashboardData = dashboardData.replace(/_remote/g, '');
     }
 
+    // Scope every saved object id to the current workspace and data source so each
+    // workspace/data source pair gets its own independent copy.
+    dashboardData = applyDashboardScope(dashboardData, workspaceId, dataSourceId);
+
     const formData = new FormData();
     formData.append(
       'file',
       new Blob([dashboardData], { type: 'application/x-ndjson' }),
       'dashboards.ndjson'
     );
-    
+
     const queryParams = dataSourceId ? { dataSourceId, overwrite: true } : { overwrite: true };
-    
+
     await http.post('/api/saved_objects/_import', {
       body: formData,
       headers: {

--- a/public/components/experiment/views/experiment_listing.tsx
+++ b/public/components/experiment/views/experiment_listing.tsx
@@ -46,6 +46,7 @@ import {
   createPhraseFilter,
   addDaysToTimestamp,
   checkDashboardsInstalled,
+  getScopedSavedObjectId,
 } from '../../common_utils/dashboards';
 import { getStatusColor } from '../../common_utils/status';
 import { ScheduleModal } from './ScheduleModal';
@@ -90,6 +91,7 @@ export const ExperimentListing: React.FC<ExperimentListingProps> = ({
 
   const { services } = useOpenSearchDashboards();
   const share = services.share;
+  const workspaceId = services.workspaces?.currentWorkspaceId$?.getValue();
 
   const [isChatWindowOpen, setIsChatWindowOpen] = useState(
     () => services.chat?.isWindowOpen() ?? false
@@ -205,10 +207,8 @@ export const ExperimentListing: React.FC<ExperimentListingProps> = ({
   } = useExperimentPolling();
 
   const openDashboard = async (experiment: any, dashboardId: string, indexPatternId: string) => {
-    const resolvedDashboardId = dataSourceId ? `${dataSourceId}_${dashboardId}` : dashboardId;
-    const resolvedIndexPatternId = dataSourceId
-      ? `${dataSourceId}_${indexPatternId}`
-      : indexPatternId;
+    const resolvedDashboardId = getScopedSavedObjectId(dashboardId, workspaceId, dataSourceId);
+    const resolvedIndexPatternId = getScopedSavedObjectId(indexPatternId, workspaceId, dataSourceId);
 
     const filters = [createPhraseFilter('experimentId', experiment.id, resolvedIndexPatternId)];
 
@@ -235,7 +235,7 @@ export const ExperimentListing: React.FC<ExperimentListingProps> = ({
     indexPatternId: string
   ) => {
     try {
-      const dashboardsAreInstalled = await checkDashboardsInstalled(http, dataSourceId);
+      const dashboardsAreInstalled = await checkDashboardsInstalled(http, workspaceId, dataSourceId);
       if (!dashboardsAreInstalled) {
         setPendingDashboardAction(() => () =>
           openDashboard(experiment, dashboardId, indexPatternId)
@@ -726,6 +726,8 @@ export const ExperimentListing: React.FC<ExperimentListingProps> = ({
           onSuccess={pendingDashboardAction}
           http={http}
           setError={setError}
+          workspaceId={workspaceId}
+          dataSourceId={dataSourceId}
         />
       )}
 


### PR DESCRIPTION
## Description

When workspaces are enabled, the experiment result dashboards (Experiment Deep Dive, Variants Comparison, Pointwise Scheduled Runs) only worked in the single workspace that installed them first.

The dashboards are installed by importing saved objects that ship with fixed, hardcoded ids. Saved object ids are globally unique, so once the objects were imported into one workspace, importing them into a second workspace could not
create an independent copy — the id already belonged to the first workspace. As a result, in any other workspace:

- the install check never found the dashboards, so the "Install Dashboards" prompt appeared on every attempt, and
- opening a visualization failed with `Could not locate that dashboard (id: ...)`, because the dashboard did not exist in the current workspace.

This was reproducible by installing the dashboards in a "Search" workspace and then trying to view experiment visualizations from an "Analytics" workspace.

**Fix:** scope the dashboards' saved object ids to the active workspace. On install, every imported saved object id (and every reference to it) is prefixed with the current workspace id, so each workspace gets its own independent copy instead of colliding on one shared id. The install check and the "open dashboard" action look up the same workspace-scoped id. The import already runs through the workspace-aware base path, and the dashboard URL is built from `getUrlForApp('dashboards')` which already includes the workspace prefix, so no further URL changes are needed. When no workspace is active the base ids are used unchanged, so non-workspace deployments are unaffected.

## Screenshots
The experiment result dashboards can appear in different workspaces.
Search workspace:
<img width="1503" height="852" alt="t1" src="https://github.com/user-attachments/assets/db15f941-842d-45b3-b3b3-bce2d456e1c0" />
Analytics workspace:
<img width="1500" height="849" alt="t2" src="https://github.com/user-attachments/assets/1cfe688a-a15c-4280-9c92-596956bc7d08" />

### Check List

- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test
  - [ ] Integration tests pass: `yarn cypress:run-without-security --config "baseUrl=http://localhost:5601" --spec "cypress/integration/plugins/search-relevance-dashboards/*.js"` (see [Developer Guide](DEVELOPER_GUIDE.md#integration-tests))
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

