### PR TITLE
fix: read dataSourceId from the query parameter in the single search route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fix delete error messages, search config validation, and dashboard/hybrid views ([#926](https://github.com/opensearch-project/dashboards-search-relevance/pull/926))
 - fix: scope search config to data source; require UBI index for COEC ([#923](https://github.com/opensearch-project/dashboards-search-relevance/pull/923))
 - Scope experiment result dashboards to the active workspace and data source ([#928](https://github.com/opensearch-project/dashboards-search-relevance/pull/928))
+- Read dataSourceId from the query parameter in the single search route so search configuration validation runs against the selected data source ([#929](https://github.com/opensearch-project/dashboards-search-relevance/pull/929))
 
 ### Infrastructure
 

--- a/server/routes/dsl_route.test.ts
+++ b/server/routes/dsl_route.test.ts
@@ -1,0 +1,150 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { IRouter } from '../../../../src/core/server';
+import { ServiceEndpoints } from '../../common';
+import { registerDslRoute } from './dsl_route';
+
+const createMockRouter = () =>
+  ({
+    get: jest.fn(),
+    put: jest.fn(),
+    post: jest.fn(),
+    delete: jest.fn(),
+  } as unknown as IRouter);
+
+const getSingleSearchRoute = (router: IRouter) => {
+  const postCalls = (router.post as jest.Mock).mock.calls;
+  const route = postCalls.find(
+    ([config]) => config.path === ServiceEndpoints.GetSingleSearchResults
+  );
+
+  if (!route) {
+    throw new Error('Single search route was not registered');
+  }
+
+  const [config, handler] = route;
+  return { config, handler };
+};
+
+const searchBody = {
+  query: {
+    index: 'products',
+    size: 5,
+    query: { match: { product_title: 'airpods' } },
+  },
+};
+
+const searchHits = { hits: { total: { value: 2 }, hits: [{ _id: 'a' }, { _id: 'b' }] } };
+
+describe('registerDslRoute — single search', () => {
+  describe('route registration', () => {
+    it('declares a query schema so dataSourceId survives request validation', () => {
+      const router = createMockRouter();
+      registerDslRoute(router, true);
+
+      const { config } = getSingleSearchRoute(router);
+
+      expect(config.validate.query).toBeDefined();
+      expect(config.validate.query.validate({ dataSourceId: 'ds-1' })).toEqual({
+        dataSourceId: 'ds-1',
+      });
+    });
+
+    it('accepts a request with no query parameters', () => {
+      const router = createMockRouter();
+      registerDslRoute(router, true);
+
+      const { config } = getSingleSearchRoute(router);
+
+      expect(() => config.validate.query.validate(undefined)).not.toThrow();
+    });
+
+    it('rejects a repeated dataSourceId parameter', () => {
+      const router = createMockRouter();
+      registerDslRoute(router, true);
+
+      const { config } = getSingleSearchRoute(router);
+
+      expect(() => config.validate.query.validate({ dataSourceId: ['ds-1', 'ds-2'] })).toThrow(
+        /expected value of type \[string\]/
+      );
+    });
+  });
+
+  describe('data source routing', () => {
+    let callAPI: jest.Mock;
+    let callAsCurrentUser: jest.Mock;
+    let getClient: jest.Mock;
+    let mockContext: any;
+    let mockResponse: { ok: jest.Mock };
+
+    beforeEach(() => {
+      callAPI = jest.fn().mockResolvedValue(searchHits);
+      callAsCurrentUser = jest.fn().mockResolvedValue({ hits: { total: { value: 0 }, hits: [] } });
+      getClient = jest.fn().mockReturnValue({ callAPI });
+      mockContext = {
+        dataSource: { opensearch: { legacy: { getClient } } },
+        core: { opensearch: { legacy: { client: { callAsCurrentUser } } } },
+      };
+      mockResponse = { ok: jest.fn() };
+    });
+
+    const invoke = async (
+      dataSourceEnabled: boolean,
+      request: { body: any; query?: any }
+    ) => {
+      const router = createMockRouter();
+      registerDslRoute(router, dataSourceEnabled);
+      const { handler } = getSingleSearchRoute(router);
+      await handler(mockContext, request, mockResponse);
+    };
+
+    it('queries the selected data source when dataSourceId arrives as a query parameter', async () => {
+      await invoke(true, { body: searchBody, query: { dataSourceId: 'ds-1' } });
+
+      expect(getClient).toHaveBeenCalledWith('ds-1');
+      expect(callAPI).toHaveBeenCalledWith('search', {
+        index: 'products',
+        size: 5,
+        body: { query: { match: { product_title: 'airpods' } } },
+      });
+      expect(callAsCurrentUser).not.toHaveBeenCalled();
+      expect(mockResponse.ok).toHaveBeenCalledWith({ body: { result: searchHits } });
+    });
+
+    it('falls back to the local cluster when no dataSourceId is supplied', async () => {
+      await invoke(true, { body: searchBody, query: {} });
+
+      expect(getClient).not.toHaveBeenCalled();
+      expect(callAsCurrentUser).toHaveBeenCalledWith('search', {
+        index: 'products',
+        size: 5,
+        body: { query: { match: { product_title: 'airpods' } } },
+      });
+    });
+
+    it('ignores dataSourceId when multiple data sources are disabled', async () => {
+      await invoke(false, { body: searchBody, query: { dataSourceId: 'ds-1' } });
+
+      expect(getClient).not.toHaveBeenCalled();
+      expect(callAsCurrentUser).toHaveBeenCalled();
+    });
+
+    it('passes search_pipeline through and keeps it out of the search body', async () => {
+      await invoke(true, {
+        body: { query: { ...searchBody.query, search_pipeline: 'hybrid-pipeline' } },
+        query: { dataSourceId: 'ds-1' },
+      });
+
+      expect(callAPI).toHaveBeenCalledWith('search', {
+        index: 'products',
+        size: 5,
+        body: { query: { match: { product_title: 'airpods' } } },
+        search_pipeline: 'hybrid-pipeline',
+      });
+    });
+  });
+});

--- a/server/routes/dsl_route.ts
+++ b/server/routes/dsl_route.ts
@@ -15,6 +15,11 @@ interface SearchResultResponse {
   errorMsg: any;
 }
 
+const queryWithDataSource = schema.object(
+  { dataSourceId: schema.maybe(schema.string()) },
+  { unknowns: 'allow' }
+);
+
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const performance = require('perf_hooks').performance;
 
@@ -311,10 +316,11 @@ export function registerDslRoute(router: IRouter, dataSourceEnabled: boolean) {
   router.post(
     {
       path: ServiceEndpoints.GetSingleSearchResults,
-      validate: { body: schema.any() },
+      validate: { body: schema.any(), query: queryWithDataSource },
     },
     async (context, request, response) => {
-      const { query, dataSourceId } = request.body;
+      const { query } = request.body;
+      const dataSourceId = request.query.dataSourceId;
       const resBody: SearchResultResponse = {};
 
       const { index, size, search_pipeline, ...rest } = query;


### PR DESCRIPTION
### Description

Search configuration validation always queries the local cluster, so it can never return results
on a multi-data-source deployment.

`validateSearchQuery` sends `dataSourceId` as a query parameter, but the `single_search` route
declared only a body schema and read `dataSourceId` from the body, where nothing sets it. It was
therefore always `undefined` and the handler fell through to `callAsCurrentUser` on the local
cluster.

Reading `request.query` is not enough on its own — the router discards request parts with no
validation rule, so `request.query` is `{}` until a `query` schema is declared:

https://github.com/opensearch-project/OpenSearch-Dashboards/blob/5c94cec8a0aaa9c7ea6b4308c65d531458177103/src/core/server/http/router/validator/validator.ts#L211-L219

Symptoms depend on the deployment:

- with a local cluster, the query runs against it and the UI reports "Validation Warning: Search
  returned no results"
- without one, `{"errorMsg":{"statusCode":500,"body":"Error: undefined - undefined"}}`

Query string versus request body:

<img width="900" alt="SRW request" src="https://github.com/user-attachments/assets/26b44d62-fd39-4db9-b9d5-44479ae0661e" />

Response:

<img width="900" alt="SRW response" src="https://github.com/user-attachments/assets/91690b54-0e8f-456b-8814-29a47681711a" />

#### Fix

Declare a `query` schema that types `dataSourceId` as an optional string while still allowing
unknown parameters, and read it from `request.query` — the same place the CRUD routes in
`search_relevance_route_service.ts` read it from. The client is unchanged.

#### Verification

7 new tests in `server/routes/dsl_route.test.ts`, all passing; full suite 1147 passing. As a
sanity check that they actually exercise the fix, temporarily reverting the route change breaks 5
of the 7.

Checked against two OpenSearch 3.5.0 clusters with `data_source.enabled: true`. The local cluster
has no `products` index; a registered data source holds it. Same request, `dataSourceId` in the
query string:

| | result |
|---|---|
| before | `404 index_not_found_exception - no such index [products]` |
| after | 2 hits from the data source |

### Issues Resolved

None filed. Reproduced on Amazon OpenSearch Service 3.5 and locally.

### Check List

- [x] New functionality includes testing.
- [x] All tests pass, including unit test, integration test
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
