### PR TITLE
Refactor search query validation route

### DIFF
--- a/common/index.ts
+++ b/common/index.ts
@@ -17,7 +17,6 @@ export const ServiceEndpoints = Object.freeze({
   GetIndexesByPattern: `${SEARCH_RELEVANCE_WORKBENCH_BASE_PATH}/search/indexes/pattern`,
   GetPipelines: `${SEARCH_RELEVANCE_WORKBENCH_BASE_PATH}/search/pipelines`,
   GetSearchResults: `${SEARCH_RELEVANCE_WORKBENCH_BASE_PATH}/search`,
-  GetSingleSearchResults: `${SEARCH_RELEVANCE_WORKBENCH_BASE_PATH}/single_search`,
   GetStats: `${SEARCH_RELEVANCE_WORKBENCH_BASE_PATH}/stats`,
   GetClusterSettings: `${SEARCH_RELEVANCE_WORKBENCH_BASE_PATH}/cluster_settings`,
   GetModels: `${SEARCH_RELEVANCE_WORKBENCH_BASE_PATH}/models`,

--- a/public/components/search_configuration/__tests__/query_processor.test.ts
+++ b/public/components/search_configuration/__tests__/query_processor.test.ts
@@ -119,7 +119,7 @@ describe('query_processor', () => {
           index: 'test-index',
           size: 5,
           query: { match_all: {} },
-          search_pipeline: 'test-pipeline',
+          pipeline: 'test-pipeline',
         },
       });
     });

--- a/public/components/search_configuration/__tests__/search_configuration_service.test.ts
+++ b/public/components/search_configuration/__tests__/search_configuration_service.test.ts
@@ -91,13 +91,28 @@ describe('SearchConfigurationService', () => {
 
   describe('validateSearchQuery', () => {
     it('should validate search query and return results', async () => {
-      const requestBody = { query: {}, index: 'test-index' };
+      const requestBody = {
+        query: { index: 'test-index', query: { match_all: {} } },
+      };
       const mockResponse = { result: { hits: { hits: [] } } };
       mockHttp.post.mockResolvedValue(mockResponse);
 
       const result = await service.validateSearchQuery(requestBody);
 
       expect(result).toEqual(mockResponse.result);
+      expect(mockHttp.post).toHaveBeenCalledWith('/api/relevancy/search', {
+        body: JSON.stringify(requestBody),
+      });
+    });
+
+    it('should surface search errors', async () => {
+      mockHttp.post.mockResolvedValue({
+        errorMessage: { statusCode: 400, body: 'Invalid Index or missing' },
+      });
+
+      await expect(service.validateSearchQuery({ query: {} })).rejects.toThrow(
+        'Invalid Index or missing'
+      );
     });
   });
 
@@ -152,11 +167,12 @@ describe('SearchConfigurationService', () => {
     it('validateSearchQuery should pass dataSourceId as query param', async () => {
       mockHttp.post.mockResolvedValue({ result: {} });
 
-      await service.validateSearchQuery({ index: 'i' }, 'my-ds');
+      const requestBody = { query: { index: 'i', query: { match_all: {} } } };
 
-      expect(mockHttp.post).toHaveBeenCalledWith(expect.any(String), {
-        body: JSON.stringify({ index: 'i' }),
-        query: { dataSourceId: 'my-ds' },
+      await service.validateSearchQuery(requestBody, 'my-ds');
+
+      expect(mockHttp.post).toHaveBeenCalledWith('/api/relevancy/search', {
+        body: JSON.stringify({ ...requestBody, dataSourceId: 'my-ds' }),
       });
     });
   });

--- a/public/components/search_configuration/services/search_configuration_service.ts
+++ b/public/components/search_configuration/services/search_configuration_service.ts
@@ -69,13 +69,12 @@ export class SearchConfigurationService {
   }
 
   async validateSearchQuery(requestBody: any, dataSourceId?: string | null): Promise<any> {
-    const opts: any = { body: JSON.stringify(requestBody) };
-    if (dataSourceId) {
-      opts.query = { dataSourceId };
-    }
-    const response = await this.http.post(ServiceEndpoints.GetSingleSearchResults, opts);
-    if (response.errorMsg) {
-      throw new Error(response.errorMsg.body);
+    const body = dataSourceId ? { ...requestBody, dataSourceId } : requestBody;
+    const response = await this.http.post(ServiceEndpoints.GetSearchResults, {
+      body: JSON.stringify(body),
+    });
+    if (response.errorMessage) {
+      throw new Error(response.errorMessage.body);
     }
     return response.result;
   }

--- a/public/components/search_configuration/utils/query_processor.ts
+++ b/public/components/search_configuration/utils/query_processor.ts
@@ -51,7 +51,7 @@ export const buildValidationRequestBody = (
   };
 
   if (pipeline) {
-    requestBody.query.search_pipeline = pipeline;
+    requestBody.query.pipeline = pipeline;
   }
 
   return requestBody;

--- a/server/routes/dsl_route.test.ts
+++ b/server/routes/dsl_route.test.ts
@@ -1,0 +1,107 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { IRouter } from '../../../../src/core/server';
+import { ServiceEndpoints } from '../../common';
+import { registerDslRoute } from './dsl_route';
+
+const createMockRouter = () =>
+  ({
+    get: jest.fn(),
+    post: jest.fn(),
+  } as unknown as IRouter);
+
+const getSearchHandler = (router: IRouter) => {
+  const route = (router.post as jest.Mock).mock.calls.find(
+    ([config]) => config.path === ServiceEndpoints.GetSearchResults
+  );
+
+  if (!route) {
+    throw new Error('Search route was not registered');
+  }
+
+  return route[1];
+};
+
+describe('registerDslRoute', () => {
+  let router: IRouter;
+  let callAPI: jest.Mock;
+  let callAsCurrentUser: jest.Mock;
+  let getClient: jest.Mock;
+  let addMetric: jest.Mock;
+  let context: any;
+  let response: { ok: jest.Mock };
+
+  beforeEach(() => {
+    router = createMockRouter();
+    registerDslRoute(router, true);
+
+    callAPI = jest.fn();
+    callAsCurrentUser = jest.fn();
+    getClient = jest.fn().mockReturnValue({ callAPI });
+    addMetric = jest.fn();
+    context = {
+      dataSource: { opensearch: { legacy: { getClient } } },
+      core: { opensearch: { legacy: { client: { callAsCurrentUser } } } },
+      searchRelevance: { metricsService: { addMetric } },
+    };
+    response = { ok: jest.fn() };
+  });
+
+  it('forwards the data source and pipeline through the unified search route', async () => {
+    const result = { hits: { hits: [] } };
+    callAPI.mockResolvedValue(result);
+    const request = {
+      body: {
+        query: {
+          index: 'products',
+          size: 5,
+          pipeline: 'my-pipeline',
+          query: { match_all: {} },
+        },
+        dataSourceId: 'data-source-1',
+      },
+    };
+
+    await getSearchHandler(router)(context, request, response);
+
+    expect(getClient).toHaveBeenCalledWith('data-source-1');
+    expect(callAPI).toHaveBeenCalledWith('search', {
+      index: 'products',
+      size: 5,
+      body: { query: { match_all: {} } },
+      search_pipeline: 'my-pipeline',
+    });
+    expect(callAsCurrentUser).not.toHaveBeenCalled();
+    expect(response.ok).toHaveBeenCalledWith({ body: { result } });
+  });
+
+  it('returns a string error body from search failures', async () => {
+    callAPI.mockRejectedValue({
+      statusCode: 404,
+      body: { error: { type: 'index_not_found_exception', reason: 'missing index' } },
+    });
+
+    await getSearchHandler(router)(
+      context,
+      {
+        body: {
+          query: { index: 'products', query: { match_all: {} } },
+          dataSourceId: 'data-source-1',
+        },
+      },
+      response
+    );
+
+    expect(response.ok).toHaveBeenCalledWith({
+      body: {
+        errorMessage: {
+          statusCode: 404,
+          body: 'Error: index_not_found_exception - missing index',
+        },
+      },
+    });
+  });
+});

--- a/server/routes/dsl_route.ts
+++ b/server/routes/dsl_route.ts
@@ -10,11 +10,6 @@ import { ILegacyScopedClusterClient, IRouter } from '../../../../src/core/server
 import { ServiceEndpoints, SEARCH_API } from '../../common';
 import { METRIC_ACTION, METRIC_NAME } from '../metrics';
 
-interface SearchResultResponse {
-  result: any;
-  errorMsg: any;
-}
-
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const performance = require('perf_hooks').performance;
 
@@ -305,56 +300,6 @@ export function registerDslRoute(router: IRouter, dataSourceEnabled: boolean) {
           body: error,
         });
       }
-    }
-  );
-
-  router.post(
-    {
-      path: ServiceEndpoints.GetSingleSearchResults,
-      validate: { body: schema.any() },
-    },
-    async (context, request, response) => {
-      const { query, dataSourceId } = request.body;
-      const resBody: SearchResultResponse = {};
-
-      const { index, size, search_pipeline, ...rest } = query;
-
-      const params: RequestParams.Search = {
-        index,
-        size,
-        body: rest,
-      };
-
-      if (typeof search_pipeline === 'string' && search_pipeline.trim() !== '') {
-        params.search_pipeline = search_pipeline;
-      }
-
-      try {
-        // Execute search
-        let resp;
-        if (dataSourceEnabled && dataSourceId) {
-          const client = context.dataSource.opensearch.legacy.getClient(dataSourceId);
-          resp = await client.callAPI('search', params);
-        } else {
-          resp = await context.core.opensearch.legacy.client.callAsCurrentUser('search', params);
-        }
-
-        resBody.result = resp;
-      } catch (error) {
-        if (error.statusCode !== 404) console.error(error);
-
-        const errorMessage = `Error: ${error.body?.error?.type || 'Unknown'} - ${
-          error.body?.error?.reason || 'Unknown reason'
-        }`;
-        resBody.errorMsg = {
-          statusCode: error.statusCode || 500,
-          body: errorMessage,
-        };
-      }
-
-      return response.ok({
-        body: resBody,
-      });
     }
   );
 


### PR DESCRIPTION
### Description

- remove the duplicate `GetSingleSearchResults` endpoint and route
- make search configuration validation reuse `GetSearchResults`
- pass `dataSourceId` in the unified request body and handle `errorMessage`
- rename the validation pipeline field to the unified route's `pipeline` input
- add regression coverage for request formatting and error propagation

### Issues Resolved

Fixes #930

### Validation

- focused TypeScript bundling for the changed route, service, utility, and tests
- focused runtime assertions for the validation request, data source, pipeline, and error paths
- `git diff --check`

The full `yarn test` command requires this plugin to be bootstrapped inside an OpenSearch Dashboards checkout, so it is left for CI.

### Check List

- [x] New functionality includes testing.
  - [ ] All tests pass, including unit test, integration test
  - [ ] Integration tests pass: `yarn cypress:run-without-security --config "baseUrl=http://localhost:5601" --spec "cypress/integration/plugins/search-relevance-dashboards/*.js"` (see [Developer Guide](DEVELOPER_GUIDE.md#integration-tests))
- [ ] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).