### PR TITLE
Fix listing search cache so clearing search restores full results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Bug Fixes
 
+- Fix judgment and experiment listing search cache so clearing search restores full results ([#933](https://github.com/opensearch-project/dashboards-search-relevance/pull/933))
 - Pass dataSourceId in Hybrid Optimizer and Pairwise experiment result queries so experiment views render on multi-data-source deployments ([#921](https://github.com/opensearch-project/dashboards-search-relevance/pull/921))
 - Fix delete error messages, search config validation, and dashboard/hybrid views ([#926](https://github.com/opensearch-project/dashboards-search-relevance/pull/926))
 - fix: scope search config to data source; require UBI index for COEC ([#923](https://github.com/opensearch-project/dashboards-search-relevance/pull/923))

--- a/public/components/experiment/__tests__/experiment_listing.test.tsx
+++ b/public/components/experiment/__tests__/experiment_listing.test.tsx
@@ -175,6 +175,51 @@ describe('ExperimentListing', () => {
     expect(result.hits[0].status).toBe("COMPLETED");
   });
 
+  it('restores the full list after a search-filtered fetch on a cold cache', async () => {
+    // Regression: when tableData is empty and findItems is first called with a search term,
+    // the full unfiltered list must still be cached so clearing search restores every row.
+    const mockData = [
+      { id: 'exp-1', type: 'PAIRWISE', status: 'RUNNING' },
+      { id: 'exp-2', type: 'HYBRID', status: 'FAILED' },
+      { id: 'xyz-123', type: 'POINTWISE', status: 'COMPLETED' },
+    ];
+
+    // Mount auto-fetch returns empty so tableData stays empty (still a cold cache).
+    mockGetExperiments
+      .mockResolvedValueOnce({ success: true, data: [] })
+      .mockResolvedValue({ success: true, data: mockData });
+
+    render(<ExperimentListing http={mockHttp} history={mockHistory} />);
+
+    await waitFor(() => expect(capturedFindItems).toBeDefined());
+
+    // Allow the TableListView mount fetch (empty list) to settle.
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // Cold network fetch with an active search term — return filtered hits, cache all rows.
+    let result: any;
+    await act(async () => {
+      result = await capturedFindItems('xyz');
+    });
+    expect(result.hits).toHaveLength(1);
+    expect(result.hits[0].id).toBe('xyz-123');
+
+    // Clearing search uses the full cache (no extra fetch) and restores all experiments.
+    const fetchCountAfterSearch = mockGetExperiments.mock.calls.length;
+    await act(async () => {
+      result = await capturedFindItems('');
+    });
+    expect(result.hits).toHaveLength(3);
+    expect(result.hits.map((h: { id: string }) => h.id)).toEqual([
+      'exp-1',
+      'exp-2',
+      'xyz-123',
+    ]);
+    expect(mockGetExperiments.mock.calls.length).toBe(fetchCountAfterSearch);
+  });
+
   it('renders correct tooltips for experiment actions', async () => {
     const mockData = [
       { id: "exp-1", type: "POINTWISE_EVALUATION", status: "COMPLETED", isScheduled: false }

--- a/public/components/experiment/views/experiment_listing.tsx
+++ b/public/components/experiment/views/experiment_listing.tsx
@@ -562,7 +562,8 @@ export const ExperimentListing: React.FC<ExperimentListingProps> = ({
 
   // Data fetching function
   const findExperiments = async (search: any) => {
-    // Use tableData if available (from polling or previous fetch)
+    // Use tableData if available (from polling or previous fetch). Always filter from the
+    // full cached list so search never permanently shrinks the cache.
     if (tableData.length > 0) {
       const filteredList = search
         ? tableData.filter((item) => experimentMatchesSearch(item, search))
@@ -589,10 +590,15 @@ export const ExperimentListing: React.FC<ExperimentListingProps> = ({
       }
 
       const list = parseResults.data;
-      const filteredList = search ? list.filter((item) => experimentMatchesSearch(item, search)) : list;
+      // Always cache the full unfiltered list. Search only affects the returned hits so
+      // clearing the search box (or remounting after delete/refresh with an empty term)
+      // restores all rows. Keeping the full list also preserves hasProcessing for polling.
+      setExperiments(list);
+      setTableData(list);
 
-      setExperiments(filteredList);
-      setTableData(filteredList);
+      const filteredList = search
+        ? list.filter((item) => experimentMatchesSearch(item, search))
+        : list;
 
       return {
         total: filteredList.length,

--- a/public/components/judgment/__tests__/use_judgment_list.test.ts
+++ b/public/components/judgment/__tests__/use_judgment_list.test.ts
@@ -143,6 +143,97 @@ describe('useJudgmentList', () => {
     });
   });
 
+  it('should restore the full list after an initial search-filtered fetch', async () => {
+    // Regression: first findJudgments(search) used to cache only the filtered hits, so
+    // clearing search could never show the non-matching rows without a full page reload.
+    const mockResponse = {
+      hits: {
+        hits: [
+          {
+            _source: {
+              id: '1',
+              name: 'Test Judgment',
+              type: 'LLM',
+              status: 'COMPLETED',
+              timestamp: '2023-01-01T00:00:00Z',
+            },
+          },
+          {
+            _source: {
+              id: '2',
+              name: 'Another Judgment',
+              type: 'UBI',
+              status: 'COMPLETED',
+              timestamp: '2023-01-01T00:00:00Z',
+            },
+          },
+        ],
+      },
+    };
+
+    mockHttp.get.mockResolvedValue(mockResponse);
+
+    const { result } = renderHook(() => useJudgmentList(mockHttp as any));
+
+    await act(async () => {
+      const filtered = await result.current.findJudgments('test');
+      expect(filtered.total).toBe(1);
+      expect(filtered.hits[0].name).toBe('Test Judgment');
+    });
+
+    // Cache should still hold the full list; no second HTTP call.
+    expect(mockHttp.get).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      const restored = await result.current.findJudgments('');
+      expect(restored.total).toBe(2);
+      expect(restored.hits.map((h: { id: string }) => h.id)).toEqual(['1', '2']);
+    });
+
+    expect(mockHttp.get).toHaveBeenCalledTimes(1);
+  });
+
+  it('should keep PROCESSING judgments in cache when first fetch uses a non-matching search', async () => {
+    // If the full list is not cached, hasProcessing would go false and polling would stop.
+    const mockResponse = {
+      hits: {
+        hits: [
+          {
+            _source: {
+              id: 'proc-1',
+              name: 'Processing Judgment',
+              type: 'LLM',
+              status: 'PROCESSING',
+              timestamp: '2023-01-01T00:00:00Z',
+            },
+          },
+          {
+            _source: {
+              id: 'done-1',
+              name: 'Done Judgment',
+              type: 'LLM',
+              status: 'COMPLETED',
+              timestamp: '2023-01-02T00:00:00Z',
+            },
+          },
+        ],
+      },
+    };
+
+    mockHttp.get.mockResolvedValue(mockResponse);
+
+    const { result } = renderHook(() => useJudgmentList(mockHttp as any));
+
+    await act(async () => {
+      const response = await result.current.findJudgments('done');
+      expect(response.total).toBe(1);
+      expect(response.hits[0].id).toBe('done-1');
+    });
+
+    expect(result.current.hasProcessing).toBe(true);
+    expect(result.current.judgments).toHaveLength(2);
+  });
+
   it('should handle fetch error', async () => {
     mockHttp.get.mockRejectedValue(new Error('Fetch failed'));
 

--- a/public/components/judgment/hooks/use_judgment_list.ts
+++ b/public/components/judgment/hooks/use_judgment_list.ts
@@ -65,6 +65,19 @@ export const useJudgmentList = (http: CoreStart['http'], dataSourceId?: string |
     };
   };
 
+  // Filter a full list for display only — never use the result to overwrite the cache.
+  // Caching a search-filtered subset would drop rows (and can stop PROCESSING polling)
+  // when the user clears the search box.
+  const filterJudgments = (items: JudgmentItem[], search?: string): JudgmentItem[] => {
+    const term = search?.trim().toLowerCase();
+    if (!term) {
+      return items;
+    }
+    return items.filter(
+      (item) => item.name.toLowerCase().includes(term) || item.id.toLowerCase().includes(term)
+    );
+  };
+
   const startPolling = useCallback(() => {
     if (intervalRef.current) return;
     pollingStartTime.current = Date.now();
@@ -141,14 +154,10 @@ export const useJudgmentList = (http: CoreStart['http'], dataSourceId?: string |
 
   const findJudgments = useCallback(
     async (search?: string) => {
-      // Use tableData if available (from polling or previous fetch)
+      // Use tableData if available (from polling or previous fetch). Always filter from the
+      // full cached list so search never permanently shrinks the cache.
       if (tableData.length > 0) {
-        const filteredList = search
-          ? tableData.filter((item) => {
-            const q = search.toLowerCase();
-            return item.name.toLowerCase().includes(q) || item.id.toLowerCase().includes(q);
-          })
-          : tableData;
+        const filteredList = filterJudgments(tableData, search);
         return {
           total: filteredList.length,
           hits: filteredList,
@@ -160,16 +169,13 @@ export const useJudgmentList = (http: CoreStart['http'], dataSourceId?: string |
       try {
         const response = await http.get(ServiceEndpoints.Judgments, queryParams);
         const list = response ? response.hits.hits.map(mapJudgmentFields) : [];
-        const filteredList = search
-          ? list.filter((item: JudgmentItem) => {
-            const q = search.toLowerCase();
-            return item.name.toLowerCase().includes(q) || item.id.toLowerCase().includes(q);
-          })
-          : list;
+        // Always cache the full unfiltered list. Search only affects the returned hits so
+        // clearing the search box (or remounting with an empty term) restores all rows.
+        // Keeping the full list also preserves hasProcessing for background polling.
+        setJudgments(list);
+        setTableData(list);
 
-        setJudgments(filteredList);
-        setTableData(filteredList);
-
+        const filteredList = filterJudgments(list, search);
         return {
           total: filteredList.length,
           hits: filteredList,


### PR DESCRIPTION
Judgment and experiment list views were caching **search-filtered** hits on the first network fetch. That meant:

1. Clearing the search box (or remounting after delete / data-source switch with a search term active) could permanently hide non-matching rows until a full page reload.
2. For judgments, non-matching `PROCESSING` / `RETRYING` items could drop out of cached state, which could stop background polling early (`hasProcessing` became false).

This change always caches the **full** unfiltered list after a network fetch and applies search only when building the returned hits for the table.