### PR TITLE
Optimize experiment detail lookups from O(n²) to O(n)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Enhancements
 
+* Speed up pairwise and evaluation experiment detail views with Map-based id lookups (document resolve, query snapshots, judgment ratings) and parallel related-resource loading ([#934](https://github.com/opensearch-project/dashboards-search-relevance/pull/934))
+
 ### Bug Fixes
 
 - Pass dataSourceId in Hybrid Optimizer and Pairwise experiment result queries so experiment views render on multi-data-source deployments ([#921](https://github.com/opensearch-project/dashboards-search-relevance/pull/921))

--- a/public/components/experiment/utils/__tests__/document_lookup.test.ts
+++ b/public/components/experiment/utils/__tests__/document_lookup.test.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  buildDocumentScores,
+  buildFirstWinMap,
+  buildJudgmentRatingsByQuery,
+  buildSnapshotIdsByQueryText,
+  resolveAttributesById,
+} from '../document_lookup';
+
+describe('document_lookup', () => {
+  describe('buildFirstWinMap', () => {
+    it('keeps the first item when keys collide', () => {
+      const map = buildFirstWinMap(
+        [
+          { id: 'a', v: 1 },
+          { id: 'a', v: 2 },
+          { id: 'b', v: 3 },
+        ],
+        (item) => item.id
+      );
+      expect(map.get('a')).toEqual({ id: 'a', v: 1 });
+      expect(map.get('b')).toEqual({ id: 'b', v: 3 });
+      expect(map.size).toBe(2);
+    });
+
+    it('returns an empty map for non-arrays', () => {
+      expect(buildFirstWinMap(null, (x: any) => x.id).size).toBe(0);
+      expect(buildFirstWinMap(undefined, (x: any) => x.id).size).toBe(0);
+    });
+  });
+
+  describe('resolveAttributesById', () => {
+    it('orders hits by the id list and assigns 1-based ranks', () => {
+      const hits = [
+        { _id: 'c', title: 'C' },
+        { _id: 'a', title: 'A' },
+        { _id: 'b', title: 'B' },
+      ];
+      const resolved = resolveAttributesById(['a', 'b', 'c'], hits);
+      expect(resolved).toEqual([
+        { _id: 'a', title: 'A', rank: 1 },
+        { _id: 'b', title: 'B', rank: 2 },
+        { _id: 'c', title: 'C', rank: 3 },
+      ]);
+    });
+
+    it('stubs missing ids so rank order is preserved', () => {
+      const resolved = resolveAttributesById(['x', 'y'], [{ _id: 'y', title: 'Y' }]);
+      expect(resolved).toEqual([
+        { _id: 'x', rank: 1 },
+        { _id: 'y', title: 'Y', rank: 2 },
+      ]);
+    });
+
+    it('uses the first hit when duplicate _ids are present (find semantics)', () => {
+      const hits = [
+        { _id: 'a', title: 'first' },
+        { _id: 'a', title: 'second' },
+      ];
+      const resolved = resolveAttributesById(['a'], hits);
+      expect(resolved[0]).toMatchObject({ _id: 'a', title: 'first', rank: 1 });
+    });
+  });
+
+  describe('buildSnapshotIdsByQueryText', () => {
+    it('maps queryText to documentIds with first-occurrence wins', () => {
+      const map = buildSnapshotIdsByQueryText([
+        { queryText: 'q1', documentIds: ['d1'] },
+        { queryText: 'q1', documentIds: ['d-later'] },
+        { queryText: 'q2', documentIds: ['d2', 'd3'] },
+      ]);
+      expect(map.get('q1')).toEqual(['d1']);
+      expect(map.get('q2')).toEqual(['d2', 'd3']);
+    });
+  });
+
+  describe('buildJudgmentRatingsByQuery + buildDocumentScores', () => {
+    it('builds nested maps and scores docs in O(1) lookups', () => {
+      const byQuery = buildJudgmentRatingsByQuery([
+        {
+          query: 'shoes',
+          ratings: [
+            { docId: '1', rating: '1.0' },
+            { docId: '2', rating: '0.0' },
+            { docId: '1', rating: '0.5' }, // ignored (first wins)
+          ],
+        },
+        {
+          query: 'shoes',
+          ratings: [{ docId: '99', rating: '1.0' }], // ignored (first query wins)
+        },
+      ]);
+
+      expect(byQuery.get('shoes')?.get('1')).toBe('1.0');
+      expect(byQuery.get('shoes')?.get('2')).toBe('0.0');
+      expect(byQuery.get('shoes')?.has('99')).toBe(false);
+
+      expect(buildDocumentScores(['1', '2', 'missing'], byQuery.get('shoes'))).toEqual([
+        { docId: '1', rating: '1.0' },
+        { docId: '2', rating: '0.0' },
+        { docId: 'missing', rating: 'N/A' },
+      ]);
+    });
+  });
+});

--- a/public/components/experiment/utils/document_lookup.ts
+++ b/public/components/experiment/utils/document_lookup.ts
@@ -1,0 +1,109 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Shared O(1) id / key lookup helpers for experiment detail views.
+ * Replaces nested Array.prototype.find scans that scale as O(n²) over
+ * result docs, query snapshots, and judgment ratings.
+ * "First occurrence wins" matches prior .find() semantics for duplicate keys.
+ */
+
+/** Build a Map with first-occurrence-wins semantics (mirrors Array.prototype.find). */
+export const buildFirstWinMap = <T>(
+  items: T[] | null | undefined,
+  getKey: (item: T) => string | undefined | null
+): Map<string, T> => {
+  const map = new Map<string, T>();
+  if (!Array.isArray(items)) {
+    return map;
+  }
+  for (const item of items) {
+    const key = getKey(item);
+    if (key == null || key === '' || map.has(key)) {
+      continue;
+    }
+    map.set(key, item);
+  }
+  return map;
+};
+
+/**
+ * Resolve hit attributes for an ordered list of document ids using a single
+ * O(n) Map build instead of ids.map(id => hits.find(...)).
+ * Missing ids produce a stub `{ _id, rank }` so rank order is preserved.
+ */
+export const resolveAttributesById = <T extends { _id: string }>(
+  ids: string[],
+  hits: T[] | null | undefined
+): Array<T | { _id: string; rank: number }> => {
+  const byId = buildFirstWinMap(hits ?? [], (hit) => hit._id);
+  return ids.map((id, index) => {
+    const hit = byId.get(id);
+    if (hit) {
+      return { ...hit, rank: index + 1 };
+    }
+    return { _id: id, rank: index + 1 };
+  });
+};
+
+/**
+ * Map queryText → documentIds from snapshot rows (first occurrence wins).
+ */
+export const buildSnapshotIdsByQueryText = (
+  snapshots: Array<{ queryText: string; documentIds: string[] }> | null | undefined
+): Map<string, string[]> => {
+  const map = new Map<string, string[]>();
+  if (!Array.isArray(snapshots)) {
+    return map;
+  }
+  for (const snapshot of snapshots) {
+    if (!snapshot?.queryText || map.has(snapshot.queryText)) {
+      continue;
+    }
+    map.set(snapshot.queryText, snapshot.documentIds ?? []);
+  }
+  return map;
+};
+
+/**
+ * Nested map queryText → (docId → rating) from judgmentRatings list shape.
+ * First query entry and first doc rating for a given id win.
+ */
+export const buildJudgmentRatingsByQuery = (
+  judgmentRatings: Array<{ query?: string; ratings?: Array<{ docId?: string; rating?: any }> }> | null | undefined
+): Map<string, Map<string, string>> => {
+  const byQuery = new Map<string, Map<string, string>>();
+  if (!Array.isArray(judgmentRatings)) {
+    return byQuery;
+  }
+  for (const entry of judgmentRatings) {
+    if (!entry?.query || byQuery.has(entry.query)) {
+      continue;
+    }
+    const byDoc = new Map<string, string>();
+    for (const rating of entry.ratings || []) {
+      if (rating?.docId == null || rating.docId === '' || byDoc.has(rating.docId)) {
+        continue;
+      }
+      byDoc.set(rating.docId, rating.rating != null ? String(rating.rating) : 'N/A');
+    }
+    byQuery.set(entry.query, byDoc);
+  }
+  return byQuery;
+};
+
+/**
+ * Build document score rows for an evaluation's documentIds using a prebuilt
+ * ratings map for that query. O(n) in documentIds length.
+ */
+export const buildDocumentScores = (
+  documentIds: string[],
+  ratingsByDoc: Map<string, string> | undefined
+): Array<{ docId: string; rating: string }> => {
+  return documentIds.map((docId) => ({
+    docId,
+    rating: ratingsByDoc?.get(docId) ?? 'N/A',
+  }));
+};

--- a/public/components/experiment/views/evaluation_experiment_view.tsx
+++ b/public/components/experiment/views/evaluation_experiment_view.tsx
@@ -15,7 +15,7 @@ import {
   EuiSpacer,
   EuiToolTip,
 } from '@elastic/eui';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import {
   TableListView,
@@ -57,6 +57,11 @@ import {
   QueryEvaluationRow,
   QueryEvaluationStatus,
 } from '../utils/query_evaluation_builder';
+import {
+  buildDocumentScores,
+  buildFirstWinMap,
+  buildJudgmentRatingsByQuery,
+} from '../utils/document_lookup';
 import { loadExperimentResourcesParallel } from '../services/experiment_resource_loader';
 
 interface EvaluationExperimentViewProps extends RouteComponentProps<{ id: string }> {
@@ -91,11 +96,21 @@ export const EvaluationExperimentView: React.FC<EvaluationExperimentViewProps> =
     Array<{ docId: string; rating: string }>
   >([]);
 
+  // Precompute O(1) lookups so opening a query is linear in documentIds, not
+  // nested finds over evaluations / judgmentRatings / ratings arrays.
+  const evaluationByQueryText = useMemo(
+    () => buildFirstWinMap(queryEvaluations, (q) => q.queryText),
+    [queryEvaluations]
+  );
+  const judgmentRatingsByQuery = useMemo(
+    () => buildJudgmentRatingsByQuery(judgmentSet?.judgmentRatings),
+    [judgmentSet]
+  );
+
   const handleQueryClick = useCallback(
     (queryText: string) => {
       try {
-        // Find the evaluation from already fetched queryEvaluations
-        const evaluation = queryEvaluations.find((q) => q.queryText === queryText);
+        const evaluation = evaluationByQueryText.get(queryText);
 
         if (evaluation?.status && evaluation.status !== 'success') {
           notifications.toasts.addWarning({
@@ -113,20 +128,10 @@ export const EvaluationExperimentView: React.FC<EvaluationExperimentViewProps> =
           return;
         }
 
-        // Get ratings from the already fetched judgment set
-        const judgmentEntry = judgmentSet?.judgmentRatings?.find(
-          (entry: any) => entry.query === queryText
+        const documentScores = buildDocumentScores(
+          evaluation.documentIds,
+          judgmentRatingsByQuery.get(queryText)
         );
-        const judgments = judgmentEntry?.ratings || [];
-
-        // Create document scores by matching evaluation documentIds with judgments
-        const documentScores = evaluation.documentIds.map((docId) => {
-          const judgment = judgments.find((j: any) => j.docId === docId);
-          return {
-            docId,
-            rating: judgment ? judgment.rating : 'N/A',
-          };
-        });
 
         setSelectedQuery(queryText);
         setSelectedQueryScores(documentScores);
@@ -137,7 +142,7 @@ export const EvaluationExperimentView: React.FC<EvaluationExperimentViewProps> =
         });
       }
     },
-    [queryEvaluations, judgmentSet, notifications]
+    [evaluationByQueryText, judgmentRatingsByQuery, notifications]
   );
 
   useEffect(() => {

--- a/public/components/experiment/views/pairwise_experiment_view.tsx
+++ b/public/components/experiment/views/pairwise_experiment_view.tsx
@@ -14,7 +14,7 @@ import {
   EuiSpacer,
   EuiToolTip,
 } from '@elastic/eui';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import {
   TableListView,
@@ -42,6 +42,10 @@ import {
   RBO90_TOOL_TIP,
   FREQUENCY_WEIGHTED_TOOL_TIP,
 } from '../../../../common';
+import {
+  buildSnapshotIdsByQueryText,
+  resolveAttributesById,
+} from '../utils/document_lookup';
 
 interface PairwiseExperimentViewProps extends RouteComponentProps<{ id: string }> {
   http: CoreStart['http'];
@@ -86,18 +90,21 @@ export const PairwiseExperimentView: React.FC<PairwiseExperimentViewProps> = ({
       try {
         setLoading(true);
         const options = dataSourceId ? { query: { dataSourceId } } : {};
-        
+
         const _experiment = await http
           .get(ServiceEndpoints.Experiments + '/' + inputExperiment.id, options)
           .then(sanitizeResponse);
-        const _searchConfigurations = _experiment
-          ? await loadSearchConfigurations(_experiment.searchConfigurationList)
-          : [];
-        const _querySet = _experiment
-          ? await http
-              .get(ServiceEndpoints.QuerySets + '/' + _experiment.querySetId, options)
-              .then(sanitizeResponse)
-          : null;
+
+        // Configs and query set only depend on the experiment, so load them in
+        // parallel instead of waiting for configs before starting the query-set GET.
+        const [_searchConfigurations, _querySet] = _experiment
+          ? await Promise.all([
+              loadSearchConfigurations(_experiment.searchConfigurationList),
+              http
+                .get(ServiceEndpoints.QuerySets + '/' + _experiment.querySetId, options)
+                .then(sanitizeResponse),
+            ])
+          : [[], null];
 
         if (
           _experiment &&
@@ -205,54 +212,78 @@ export const PairwiseExperimentView: React.FC<PairwiseExperimentViewProps> = ({
     }
   }, [experiment, queryEvaluations]);
 
-  function resolve_attributes(ids, hits) {
-    const res = ids.map((id) => hits.find((hit) => hit._id === id) || { _id: id });
-    return res.map((x, index) => ({ ...x, rank: index + 1 }));
-  }
+  // O(1) snapshot lookups by queryText (built once when snapshot lists change).
+  const snapshot1ByQueryText = useMemo(
+    () => buildSnapshotIdsByQueryText(querySnapshots[0]),
+    [querySnapshots]
+  );
+  const snapshot2ByQueryText = useMemo(
+    () => buildSnapshotIdsByQueryText(querySnapshots[1]),
+    [querySnapshots]
+  );
 
   useEffect(() => {
-    if (selectedQuery != null) {
-      const queryText = queryEvaluations[selectedQuery].queryText;
-      const snapshot1 = querySnapshots[0].find((s) => s.queryText === queryText).documentIds;
-      const snapshot2 = querySnapshots[1].find((s) => s.queryText === queryText).documentIds;
-      const query1 = {
-        index: searchConfigurations[0].index,
-        size: snapshot1.length,
-        query: {
-          terms: {
-            _id: snapshot1,
-          },
-        },
-      };
-      const query2 = {
-        index: searchConfigurations[1].index,
-        size: snapshot2.length,
-        query: {
-          terms: {
-            _id: snapshot2,
-          },
-        },
-      };
-
-      const requestBase = dataSourceId ? { dataSourceId } : {};
-
-      Promise.all([
-        http.post(ServiceEndpoints.GetSearchResults, {
-          body: JSON.stringify({ query: query1, ...requestBase }),
-        }),
-        http.post(ServiceEndpoints.GetSearchResults, {
-          body: JSON.stringify({ query: query2, ...requestBase }),
-        }),
-      ])
-        .then(([res1, res2]) => {
-          setQueryResult1(resolve_attributes(snapshot1, convertFromSearchResult(res1.result)));
-          setQueryResult2(resolve_attributes(snapshot2, convertFromSearchResult(res2.result)));
-        })
-        .catch((error: Error) => {
-          console.error(error);
-        });
+    if (selectedQuery == null) {
+      return;
     }
-  }, [selectedQuery]);
+    const queryText = queryEvaluations[selectedQuery]?.queryText;
+    if (!queryText) {
+      return;
+    }
+    const snapshot1 = snapshot1ByQueryText.get(queryText);
+    const snapshot2 = snapshot2ByQueryText.get(queryText);
+    if (!snapshot1 || !snapshot2) {
+      return;
+    }
+    const query1 = {
+      index: searchConfigurations[0].index,
+      size: snapshot1.length,
+      query: {
+        terms: {
+          _id: snapshot1,
+        },
+      },
+    };
+    const query2 = {
+      index: searchConfigurations[1].index,
+      size: snapshot2.length,
+      query: {
+        terms: {
+          _id: snapshot2,
+        },
+      },
+    };
+
+    const requestBase = dataSourceId ? { dataSourceId } : {};
+
+    Promise.all([
+      http.post(ServiceEndpoints.GetSearchResults, {
+        body: JSON.stringify({ query: query1, ...requestBase }),
+      }),
+      http.post(ServiceEndpoints.GetSearchResults, {
+        body: JSON.stringify({ query: query2, ...requestBase }),
+      }),
+    ])
+      .then(([res1, res2]) => {
+        setQueryResult1(
+          resolveAttributesById(snapshot1, convertFromSearchResult(res1.result)) as any
+        );
+        setQueryResult2(
+          resolveAttributesById(snapshot2, convertFromSearchResult(res2.result)) as any
+        );
+      })
+      .catch((error: Error) => {
+        console.error(error);
+      });
+  }, [
+    selectedQuery,
+    queryEvaluations,
+    snapshot1ByQueryText,
+    snapshot2ByQueryText,
+    searchConfigurations,
+    dataSourceId,
+    http,
+  ]);
 
   const findQueries = useCallback(
     async (search: any) => {

--- a/public/types/experiment_parse.test.ts
+++ b/public/types/experiment_parse.test.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ExperimentType, ExperimentStatus, toExperiment } from './index';
+import { ExperimentType, ExperimentStatus, toExperiment, toQuerySnapshots } from './index';
 
 const hybridBase = {
   id: 'exp-1',
@@ -48,5 +48,68 @@ describe('toExperiment metadata', () => {
     }
     expect(result.data.name).toBeUndefined();
     expect(result.data.description).toBeUndefined();
+  });
+});
+
+describe('toQuerySnapshots', () => {
+  it('extracts docIds for the matching search configuration via id lookup', () => {
+    const source = {
+      status: ExperimentStatus.COMPLETED,
+      results: [
+        {
+          query_text: 'q1',
+          snapshots: [
+            { searchConfigurationId: 'sc-a', docIds: ['a1', 'a2'] },
+            { searchConfigurationId: 'sc-b', docIds: ['b1'] },
+          ],
+        },
+        {
+          query_text: 'q2',
+          snapshots: [
+            { searchConfigurationId: 'sc-b', docIds: ['b2', 'b3'] },
+            { searchConfigurationId: 'sc-a', docIds: ['a3'] },
+          ],
+        },
+      ],
+    };
+
+    const forA = toQuerySnapshots(source, 'sc-a');
+    const forB = toQuerySnapshots(source, 'sc-b');
+
+    expect(forA.success).toBe(true);
+    expect(forB.success).toBe(true);
+    if (!forA.success || !forB.success) {
+      return;
+    }
+    expect(forA.data).toEqual([
+      { queryText: 'q1', documentIds: ['a1', 'a2'] },
+      { queryText: 'q2', documentIds: ['a3'] },
+    ]);
+    expect(forB.data).toEqual([
+      { queryText: 'q1', documentIds: ['b1'] },
+      { queryText: 'q2', documentIds: ['b2', 'b3'] },
+    ]);
+  });
+
+  it('uses the first snapshot when a config id is duplicated in a result', () => {
+    const source = {
+      status: ExperimentStatus.COMPLETED,
+      results: [
+        {
+          query_text: 'q1',
+          snapshots: [
+            { searchConfigurationId: 'sc-a', docIds: ['first'] },
+            { searchConfigurationId: 'sc-a', docIds: ['second'] },
+          ],
+        },
+      ],
+    };
+
+    const result = toQuerySnapshots(source, 'sc-a');
+    expect(result.success).toBe(true);
+    if (!result.success) {
+      return;
+    }
+    expect(result.data).toEqual([{ queryText: 'q1', documentIds: ['first'] }]);
   });
 });

--- a/public/types/index.ts
+++ b/public/types/index.ts
@@ -287,8 +287,22 @@ export const toQuerySnapshots = (source: any, queryName: string): ParseResult<Qu
   }
 
   const data: QuerySnapshot[] = [];
-  source.results.forEach((result: any) => {
-    const snapshot = result.snapshots.find((s: any) => s.searchConfigurationId === queryName);
+  // Prefer O(1) lookup of the matching search-configuration snapshot per result
+  // row (avoids .find() over snapshots for every query in the experiment).
+  (source.results || []).forEach((result: any) => {
+    const snapshots = result.snapshots;
+    if (!Array.isArray(snapshots) || snapshots.length === 0) {
+      return;
+    }
+    // First-occurrence-wins Map matches prior Array.prototype.find semantics.
+    const byConfigId = new Map<string, any>();
+    for (const snapshot of snapshots) {
+      const configId = snapshot?.searchConfigurationId;
+      if (configId != null && !byConfigId.has(configId)) {
+        byConfigId.set(configId, snapshot);
+      }
+    }
+    const snapshot = byConfigId.get(queryName);
     if (snapshot) {
       data.push({
         queryText: result.query_text,


### PR DESCRIPTION
Pairwise and evaluation experiment detail views used nested `Array.prototype.find` scans for:

1. Resolving document hits by `_id` when opening a pairwise query (`ids.map` + `hits.find`)
2. Locating query snapshots by `queryText` / `searchConfigurationId`
3. Matching judgment ratings to evaluation `documentIds` on query click

That is O(n²) in result / rating size.  This switches those paths to Map-based O(1) lookups (O(n) overall), loads pairwise related resources (search configs + query set) in parallel after the experiment fetch, preserves first-occurrence-wins semantics matching prior `.find()`, and unit-tests the helpers and `toQuerySnapshots`.