### PR TITLE
Merge single_search route into search and read dataSourceId from query param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Fix delete error messages, search config validation, and dashboard/hybrid views ([#926](https://github.com/opensearch-project/dashboards-search-relevance/pull/926))
 - fix: scope search config to data source; require UBI index for COEC ([#923](https://github.com/opensearch-project/dashboards-search-relevance/pull/923))
 - Scope experiment result dashboards to the active workspace and data source ([#928](https://github.com/opensearch-project/dashboards-search-relevance/pull/928))
+- Merge the `single_search` route into `search` and read `dataSourceId` from the query parameter, so search configuration validation runs against the selected data source ([#930](https://github.com/opensearch-project/dashboards-search-relevance/issues/930))
 
 ### Infrastructure
 

--- a/common/index.ts
+++ b/common/index.ts
@@ -17,7 +17,6 @@ export const ServiceEndpoints = Object.freeze({
   GetIndexesByPattern: `${SEARCH_RELEVANCE_WORKBENCH_BASE_PATH}/search/indexes/pattern`,
   GetPipelines: `${SEARCH_RELEVANCE_WORKBENCH_BASE_PATH}/search/pipelines`,
   GetSearchResults: `${SEARCH_RELEVANCE_WORKBENCH_BASE_PATH}/search`,
-  GetSingleSearchResults: `${SEARCH_RELEVANCE_WORKBENCH_BASE_PATH}/single_search`,
   GetStats: `${SEARCH_RELEVANCE_WORKBENCH_BASE_PATH}/stats`,
   GetClusterSettings: `${SEARCH_RELEVANCE_WORKBENCH_BASE_PATH}/cluster_settings`,
   GetModels: `${SEARCH_RELEVANCE_WORKBENCH_BASE_PATH}/models`,

--- a/public/components/experiment/views/evaluation_experiment_view.tsx
+++ b/public/components/experiment/views/evaluation_experiment_view.tsx
@@ -187,14 +187,16 @@ export const EvaluationExperimentView: React.FC<EvaluationExperimentViewProps> =
           size: Math.max(querySetSize, 1),
         };
 
-        const requestBase = dataSourceId ? { dataSourceId } : {};
+        const dsQuery = dataSourceId ? { query: { dataSourceId } } : {};
 
         const [evaluationSearchResult, variantSearchResult] = await Promise.all([
           http.post(ServiceEndpoints.GetSearchResults, {
-            body: JSON.stringify({ query: evaluationQuery, ...requestBase }),
+            body: JSON.stringify({ query: evaluationQuery }),
+            ...dsQuery,
           }),
           http.post(ServiceEndpoints.GetSearchResults, {
-            body: JSON.stringify({ query: variantQuery, ...requestBase }),
+            body: JSON.stringify({ query: variantQuery }),
+            ...dsQuery,
           }),
         ]);
 

--- a/public/components/experiment/views/hybrid_optimizer_experiment_view.tsx
+++ b/public/components/experiment/views/hybrid_optimizer_experiment_view.tsx
@@ -96,7 +96,7 @@ export const HybridOptimizerExperimentView: React.FC<HybridOptimizerExperimentVi
         const _judgmentSet = resources?.judgmentSet;
         const _scheduledExperimentJob = resources?.scheduledExperimentJob;
 
-        const requestBase = dataSourceId ? { dataSourceId } : {};
+        const dsQuery = dataSourceId ? { query: { dataSourceId } } : {};
 
         if (_experiment && _searchConfiguration && _querySet && _judgmentSet) {
           const querySetSize = _querySet && Object.keys(_querySet.querySetQueries).length;
@@ -126,7 +126,8 @@ export const HybridOptimizerExperimentView: React.FC<HybridOptimizerExperimentVi
                 size: batchSize,
               };
               const result = await http.post(ServiceEndpoints.GetSearchResults, {
-                body: JSON.stringify({ query, ...requestBase }),
+                body: JSON.stringify({ query }),
+                ...dsQuery,
               });
 
               if (result?.result?.hits?.hits && result.result.hits.hits.length > 0) {
@@ -161,7 +162,8 @@ export const HybridOptimizerExperimentView: React.FC<HybridOptimizerExperimentVi
           };
 
           const result = await http.post(ServiceEndpoints.GetSearchResults, {
-            body: JSON.stringify({ query, ...requestBase }),
+            body: JSON.stringify({ query }),
+            ...dsQuery,
           });
 
           if (result?.result?.hits?.hits) {
@@ -229,7 +231,8 @@ export const HybridOptimizerExperimentView: React.FC<HybridOptimizerExperimentVi
       };
 
       const result = await http.post(ServiceEndpoints.GetSearchResults, {
-        body: JSON.stringify({ query, ...(dataSourceId ? { dataSourceId } : {}) }),
+        body: JSON.stringify({ query }),
+        ...(dataSourceId ? { query: { dataSourceId } } : {}),
       });
 
       const variantDetails = result?.result?.hits?.hits?.[0]?._source;

--- a/public/components/experiment/views/pairwise_experiment_view.tsx
+++ b/public/components/experiment/views/pairwise_experiment_view.tsx
@@ -234,14 +234,16 @@ export const PairwiseExperimentView: React.FC<PairwiseExperimentViewProps> = ({
         },
       };
 
-      const requestBase = dataSourceId ? { dataSourceId } : {};
+      const dsQuery = dataSourceId ? { query: { dataSourceId } } : {};
 
       Promise.all([
         http.post(ServiceEndpoints.GetSearchResults, {
-          body: JSON.stringify({ query: query1, ...requestBase }),
+          body: JSON.stringify({ query: query1 }),
+          ...dsQuery,
         }),
         http.post(ServiceEndpoints.GetSearchResults, {
-          body: JSON.stringify({ query: query2, ...requestBase }),
+          body: JSON.stringify({ query: query2 }),
+          ...dsQuery,
         }),
       ])
         .then(([res1, res2]) => {

--- a/public/components/query_compare/search_result/agent/__tests__/agent_handler.test.ts
+++ b/public/components/query_compare/search_result/agent/__tests__/agent_handler.test.ts
@@ -5,6 +5,7 @@
 
 import { AgentHandler } from '../agent_handler';
 import { SearchResults } from '../../../../../types/index';
+import { ServiceEndpoints } from '../../../../../../common';
 
 describe('AgentHandler', () => {
   let agentHandler: AgentHandler;
@@ -41,6 +42,31 @@ describe('AgentHandler', () => {
     it('should return false for null/undefined query', () => {
       expect(agentHandler.isAgenticQuery(null)).toBe(false);
       expect(agentHandler.isAgenticQuery(undefined)).toBe(false);
+    });
+  });
+
+  describe('performAgenticSearch', () => {
+    it('should send dataSourceId as a query parameter, not in the body', async () => {
+      const requestBody = { query: { agentic: { query_text: 'white shoes' } } };
+      mockHttp.post.mockResolvedValue({ result: {} });
+
+      await agentHandler.performAgenticSearch(requestBody, 'ds-1');
+
+      expect(mockHttp.post).toHaveBeenCalledWith(ServiceEndpoints.GetSearchResults, {
+        body: JSON.stringify({ query: requestBody }),
+        query: { dataSourceId: 'ds-1' },
+      });
+    });
+
+    it('should omit the query param when no dataSourceId is given', async () => {
+      const requestBody = { query: { agentic: { query_text: 'white shoes' } } };
+      mockHttp.post.mockResolvedValue({ result: {} });
+
+      await agentHandler.performAgenticSearch(requestBody, '');
+
+      expect(mockHttp.post).toHaveBeenCalledWith(ServiceEndpoints.GetSearchResults, {
+        body: JSON.stringify({ query: requestBody }),
+      });
     });
   });
 

--- a/public/components/query_compare/search_result/agent/agent_handler.ts
+++ b/public/components/query_compare/search_result/agent/agent_handler.ts
@@ -20,10 +20,8 @@ export class AgentHandler {
 
   async performAgenticSearch(requestBody: any, dataSourceId: string): Promise<any> {
     return await this.http.post(ServiceEndpoints.GetSearchResults, {
-      body: JSON.stringify({
-        query: requestBody,
-        dataSourceId,
-      }),
+      body: JSON.stringify({ query: requestBody }),
+      ...(dataSourceId ? { query: { dataSourceId } } : {}),
     });
   }
 

--- a/public/components/query_compare/search_result/search/__tests__/search_handler.test.ts
+++ b/public/components/query_compare/search_result/search/__tests__/search_handler.test.ts
@@ -28,10 +28,18 @@ describe('SearchHandler', () => {
       await searchHandler.performSearch(requestBody, dataSourceId);
 
       expect(mockHttp.post).toHaveBeenCalledWith(ServiceEndpoints.GetSearchResults, {
-        body: JSON.stringify({
-          query: requestBody,
-          dataSourceId,
-        }),
+        body: JSON.stringify({ query: requestBody }),
+        query: { dataSourceId },
+      });
+    });
+
+    it('should omit the query param when no dataSourceId is given', async () => {
+      mockHttp.post.mockResolvedValue({ hits: { hits: [] } });
+
+      await searchHandler.performSearch({ query: 'test' }, '');
+
+      expect(mockHttp.post).toHaveBeenCalledWith(ServiceEndpoints.GetSearchResults, {
+        body: JSON.stringify({ query: { query: 'test' } }),
       });
     });
   });
@@ -49,16 +57,12 @@ describe('SearchHandler', () => {
 
       expect(mockHttp.post).toHaveBeenCalledTimes(2);
       expect(mockHttp.post).toHaveBeenNthCalledWith(1, ServiceEndpoints.GetSearchResults, {
-        body: JSON.stringify({
-          query: requestBody1,
-          dataSourceId: dataSourceId1,
-        }),
+        body: JSON.stringify({ query: requestBody1 }),
+        query: { dataSourceId: dataSourceId1 },
       });
       expect(mockHttp.post).toHaveBeenNthCalledWith(2, ServiceEndpoints.GetSearchResults, {
-        body: JSON.stringify({
-          query: requestBody2,
-          dataSourceId: dataSourceId2,
-        }),
+        body: JSON.stringify({ query: requestBody2 }),
+        query: { dataSourceId: dataSourceId2 },
       });
     });
   });

--- a/public/components/query_compare/search_result/search/search_handler.test.ts
+++ b/public/components/query_compare/search_result/search/search_handler.test.ts
@@ -25,10 +25,8 @@ describe('SearchHandler', () => {
       await searchHandler.performSearch(requestBody, dataSourceId);
 
       expect(mockHttp.post).toHaveBeenCalledWith(ServiceEndpoints.GetSearchResults, {
-        body: JSON.stringify({
-          query: requestBody,
-          dataSourceId,
-        }),
+        body: JSON.stringify({ query: requestBody }),
+        query: { dataSourceId },
       });
     });
 
@@ -57,16 +55,12 @@ describe('SearchHandler', () => {
 
       expect(mockHttp.post).toHaveBeenCalledTimes(2);
       expect(mockHttp.post).toHaveBeenNthCalledWith(1, ServiceEndpoints.GetSearchResults, {
-        body: JSON.stringify({
-          query: requestBody1,
-          dataSourceId: dataSourceId1,
-        }),
+        body: JSON.stringify({ query: requestBody1 }),
+        query: { dataSourceId: dataSourceId1 },
       });
       expect(mockHttp.post).toHaveBeenNthCalledWith(2, ServiceEndpoints.GetSearchResults, {
-        body: JSON.stringify({
-          query: requestBody2,
-          dataSourceId: dataSourceId2,
-        }),
+        body: JSON.stringify({ query: requestBody2 }),
+        query: { dataSourceId: dataSourceId2 },
       });
     });
 

--- a/public/components/query_compare/search_result/search/search_handler.ts
+++ b/public/components/query_compare/search_result/search/search_handler.ts
@@ -11,10 +11,8 @@ export class SearchHandler {
 
   async performSearch(requestBody: any, dataSourceId: string) {
     return this.http.post(ServiceEndpoints.GetSearchResults, {
-      body: JSON.stringify({
-        query: requestBody,
-        dataSourceId,
-      }),
+      body: JSON.stringify({ query: requestBody }),
+      ...(dataSourceId ? { query: { dataSourceId } } : {}),
     });
   }
 

--- a/public/components/search_configuration/__tests__/query_processor.test.ts
+++ b/public/components/search_configuration/__tests__/query_processor.test.ts
@@ -119,7 +119,7 @@ describe('query_processor', () => {
           index: 'test-index',
           size: 5,
           query: { match_all: {} },
-          search_pipeline: 'test-pipeline',
+          pipeline: 'test-pipeline',
         },
       });
     });

--- a/public/components/search_configuration/__tests__/search_configuration_service.test.ts
+++ b/public/components/search_configuration/__tests__/search_configuration_service.test.ts
@@ -99,6 +99,27 @@ describe('SearchConfigurationService', () => {
 
       expect(result).toEqual(mockResponse.result);
     });
+
+    it('should post to the shared search endpoint', async () => {
+      mockHttp.post.mockResolvedValue({ result: {} });
+
+      await service.validateSearchQuery({ index: 'test-index' });
+
+      expect(mockHttp.post).toHaveBeenCalledWith(
+        '/api/relevancy/search',
+        expect.any(Object)
+      );
+    });
+
+    it('should throw when the route reports an errorMessage', async () => {
+      mockHttp.post.mockResolvedValue({
+        errorMessage: { statusCode: 400, body: 'Invalid Index or missing' },
+      });
+
+      await expect(service.validateSearchQuery({ index: '' })).rejects.toThrow(
+        'Invalid Index or missing'
+      );
+    });
   });
 
   describe('with dataSourceId', () => {

--- a/public/components/search_configuration/services/search_configuration_service.ts
+++ b/public/components/search_configuration/services/search_configuration_service.ts
@@ -73,9 +73,9 @@ export class SearchConfigurationService {
     if (dataSourceId) {
       opts.query = { dataSourceId };
     }
-    const response = await this.http.post(ServiceEndpoints.GetSingleSearchResults, opts);
-    if (response.errorMsg) {
-      throw new Error(response.errorMsg.body);
+    const response = await this.http.post(ServiceEndpoints.GetSearchResults, opts);
+    if (response.errorMessage) {
+      throw new Error(response.errorMessage.body);
     }
     return response.result;
   }

--- a/public/components/search_configuration/utils/query_processor.ts
+++ b/public/components/search_configuration/utils/query_processor.ts
@@ -51,7 +51,7 @@ export const buildValidationRequestBody = (
   };
 
   if (pipeline) {
-    requestBody.query.search_pipeline = pipeline;
+    requestBody.query.pipeline = pipeline;
   }
 
   return requestBody;

--- a/server/routes/dsl_route.test.ts
+++ b/server/routes/dsl_route.test.ts
@@ -1,0 +1,214 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { IRouter } from '../../../../src/core/server';
+import { ServiceEndpoints } from '../../common';
+import { registerDslRoute } from './dsl_route';
+
+const createMockRouter = () =>
+  ({
+    get: jest.fn(),
+    put: jest.fn(),
+    post: jest.fn(),
+    delete: jest.fn(),
+  } as unknown as IRouter);
+
+// Pull the handler and route config registered for POST at `path`.
+const getPostRoute = (router: IRouter, path: string) => {
+  const calls = (router.post as jest.Mock).mock.calls;
+  const route = calls.find(([config]) => config.path === path);
+
+  if (!route) {
+    throw new Error(`Route not registered: POST ${path}`);
+  }
+
+  return { config: route[0], handler: route[1] };
+};
+
+const createMockContext = () => {
+  const callAsCurrentUser = jest.fn().mockResolvedValue({ hits: { hits: [] } });
+  const callAPI = jest.fn().mockResolvedValue({ hits: { hits: [] } });
+  const addMetric = jest.fn();
+
+  return {
+    context: {
+      core: { opensearch: { legacy: { client: { callAsCurrentUser } } } },
+      dataSource: { opensearch: { legacy: { getClient: jest.fn(() => ({ callAPI })) } } },
+      searchRelevance: { metricsService: { addMetric } },
+    } as any,
+    callAsCurrentUser,
+    callAPI,
+    addMetric,
+  };
+};
+
+const mockResponse = {
+  ok: jest.fn((payload) => payload),
+  custom: jest.fn((payload) => payload),
+  customError: jest.fn((payload) => payload),
+} as any;
+
+describe('registerDslRoute', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('does not register a separate single_search route', () => {
+    const router = createMockRouter();
+    registerDslRoute(router, false);
+
+    const paths = (router.post as jest.Mock).mock.calls.map(([config]) => config.path);
+
+    expect(paths).toEqual([ServiceEndpoints.GetSearchResults]);
+    expect(paths).not.toContain('/api/relevancy/single_search');
+  });
+
+  describe('search route', () => {
+    it('declares a query schema so dataSourceId survives validation', () => {
+      const router = createMockRouter();
+      registerDslRoute(router, true);
+
+      const { config } = getPostRoute(router, ServiceEndpoints.GetSearchResults);
+
+      expect(config.validate.query).toBeDefined();
+      expect(config.validate.query.validate({ dataSourceId: 'ds-1' })).toEqual({
+        dataSourceId: 'ds-1',
+      });
+    });
+
+    it('routes to the data source client using dataSourceId from the query parameter', async () => {
+      const router = createMockRouter();
+      registerDslRoute(router, true);
+      const { handler } = getPostRoute(router, ServiceEndpoints.GetSearchResults);
+      const { context, callAPI, callAsCurrentUser } = createMockContext();
+
+      await handler(
+        context,
+        { body: { query: { index: 'test-index' } }, query: { dataSourceId: 'ds-1' } } as any,
+        mockResponse
+      );
+
+      expect(context.dataSource.opensearch.legacy.getClient).toHaveBeenCalledWith('ds-1');
+      expect(callAPI).toHaveBeenCalledWith('search', {
+        index: 'test-index',
+        size: 10,
+        body: {},
+      });
+      expect(callAsCurrentUser).not.toHaveBeenCalled();
+    });
+
+    it('falls back to the local cluster when no dataSourceId is supplied', async () => {
+      const router = createMockRouter();
+      registerDslRoute(router, true);
+      const { handler } = getPostRoute(router, ServiceEndpoints.GetSearchResults);
+      const { context, callAPI, callAsCurrentUser } = createMockContext();
+
+      await handler(context, { body: { query: { index: 'test-index' } }, query: {} } as any, mockResponse);
+
+      expect(callAsCurrentUser).toHaveBeenCalledWith('search', {
+        index: 'test-index',
+        size: 10,
+        body: {},
+      });
+      expect(callAPI).not.toHaveBeenCalled();
+    });
+
+    it('ignores dataSourceId when the data source feature is disabled', async () => {
+      const router = createMockRouter();
+      registerDslRoute(router, false);
+      const { handler } = getPostRoute(router, ServiceEndpoints.GetSearchResults);
+      const { context, callAPI, callAsCurrentUser } = createMockContext();
+
+      await handler(
+        context,
+        { body: { query: { index: 'test-index' } }, query: { dataSourceId: 'ds-1' } } as any,
+        mockResponse
+      );
+
+      expect(callAsCurrentUser).toHaveBeenCalled();
+      expect(callAPI).not.toHaveBeenCalled();
+    });
+
+    it('forwards the pipeline as search_pipeline when one is given', async () => {
+      const router = createMockRouter();
+      registerDslRoute(router, false);
+      const { handler } = getPostRoute(router, ServiceEndpoints.GetSearchResults);
+      const { context, callAsCurrentUser } = createMockContext();
+
+      await handler(
+        context,
+        {
+          body: { query: { index: 'test-index', size: 5, pipeline: 'my-pipeline', query: { match_all: {} } } },
+          query: {},
+        } as any,
+        mockResponse
+      );
+
+      expect(callAsCurrentUser).toHaveBeenCalledWith('search', {
+        index: 'test-index',
+        size: 5,
+        body: { query: { match_all: {} } },
+        search_pipeline: 'my-pipeline',
+      });
+    });
+
+    it('rejects an invalid index without calling OpenSearch', async () => {
+      const router = createMockRouter();
+      registerDslRoute(router, false);
+      const { handler } = getPostRoute(router, ServiceEndpoints.GetSearchResults);
+      const { context, callAsCurrentUser } = createMockContext();
+
+      const result = await handler(
+        context,
+        { body: { query: { index: 'Invalid Index' } }, query: {} } as any,
+        mockResponse
+      );
+
+      expect(result.body.errorMessage).toEqual({
+        statusCode: 400,
+        body: 'Invalid Index or missing',
+      });
+      expect(callAsCurrentUser).not.toHaveBeenCalled();
+    });
+
+    it('rejects an invalid pipeline without calling OpenSearch', async () => {
+      const router = createMockRouter();
+      registerDslRoute(router, false);
+      const { handler } = getPostRoute(router, ServiceEndpoints.GetSearchResults);
+      const { context, callAsCurrentUser } = createMockContext();
+
+      const result = await handler(
+        context,
+        { body: { query: { index: 'test-index', pipeline: 'bad pipeline!' } }, query: {} } as any,
+        mockResponse
+      );
+
+      expect(result.body.errorMessage).toEqual({ statusCode: 400, body: 'Invalid Pipeline' });
+      expect(callAsCurrentUser).not.toHaveBeenCalled();
+    });
+
+    it('reports search failures as an errorMessage', async () => {
+      const router = createMockRouter();
+      registerDslRoute(router, false);
+      const { handler } = getPostRoute(router, ServiceEndpoints.GetSearchResults);
+      const { context, callAsCurrentUser } = createMockContext();
+      callAsCurrentUser.mockRejectedValue({
+        statusCode: 404,
+        body: { error: { type: 'index_not_found_exception', reason: 'no such index' } },
+      });
+
+      const result = await handler(
+        context,
+        { body: { query: { index: 'missing-index' } }, query: {} } as any,
+        mockResponse
+      );
+
+      expect(result.body.errorMessage).toEqual({
+        statusCode: 404,
+        body: 'Error: index_not_found_exception - no such index',
+      });
+    });
+  });
+});

--- a/server/routes/dsl_route.ts
+++ b/server/routes/dsl_route.ts
@@ -9,11 +9,7 @@ import { schema } from '@osd/config-schema';
 import { ILegacyScopedClusterClient, IRouter } from '../../../../src/core/server';
 import { ServiceEndpoints, SEARCH_API } from '../../common';
 import { METRIC_ACTION, METRIC_NAME } from '../metrics';
-
-interface SearchResultResponse {
-  result: any;
-  errorMsg: any;
-}
+import { queryWithDataSource } from './search_relevance_route_service';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const performance = require('perf_hooks').performance;
@@ -22,10 +18,11 @@ export function registerDslRoute(router: IRouter, dataSourceEnabled: boolean) {
   router.post(
     {
       path: ServiceEndpoints.GetSearchResults,
-      validate: { body: schema.any() },
+      validate: { body: schema.any(), query: queryWithDataSource },
     },
     async (context, request, response) => {
-      const { query, dataSourceId = '' } = request.body;
+      const dataSourceId = (request.query as any)?.dataSourceId ?? '';
+      const { query } = request.body;
       const { index, pipeline = '', size = 10, ...rest } = query ?? {};
 
       const invalidCharactersPattern = /[\s,\"*+\/\\|?#><]/;
@@ -305,56 +302,6 @@ export function registerDslRoute(router: IRouter, dataSourceEnabled: boolean) {
           body: error,
         });
       }
-    }
-  );
-
-  router.post(
-    {
-      path: ServiceEndpoints.GetSingleSearchResults,
-      validate: { body: schema.any() },
-    },
-    async (context, request, response) => {
-      const { query, dataSourceId } = request.body;
-      const resBody: SearchResultResponse = {};
-
-      const { index, size, search_pipeline, ...rest } = query;
-
-      const params: RequestParams.Search = {
-        index,
-        size,
-        body: rest,
-      };
-
-      if (typeof search_pipeline === 'string' && search_pipeline.trim() !== '') {
-        params.search_pipeline = search_pipeline;
-      }
-
-      try {
-        // Execute search
-        let resp;
-        if (dataSourceEnabled && dataSourceId) {
-          const client = context.dataSource.opensearch.legacy.getClient(dataSourceId);
-          resp = await client.callAPI('search', params);
-        } else {
-          resp = await context.core.opensearch.legacy.client.callAsCurrentUser('search', params);
-        }
-
-        resBody.result = resp;
-      } catch (error) {
-        if (error.statusCode !== 404) console.error(error);
-
-        const errorMessage = `Error: ${error.body?.error?.type || 'Unknown'} - ${
-          error.body?.error?.reason || 'Unknown reason'
-        }`;
-        resBody.errorMsg = {
-          statusCode: error.statusCode || 500,
-          body: errorMessage,
-        };
-      }
-
-      return response.ok({
-        body: resBody,
-      });
     }
   );
 

--- a/server/routes/search_relevance_route_service.ts
+++ b/server/routes/search_relevance_route_service.ts
@@ -14,7 +14,7 @@ import {
 } from '../../../../src/core/server';
 import { ServiceEndpoints, BackendEndpoints, DISABLED_BACKEND_PLUGIN_MESSAGE } from '../../common';
 
-const queryWithDataSource = schema.maybe(schema.object({}, { unknowns: 'allow' }));
+export const queryWithDataSource = schema.maybe(schema.object({}, { unknowns: 'allow' }));
 
 // Resource ids are interpolated straight into the backend transport.request path, so constrain
 // them to the shape the backend actually generates (UUIDs / URL-safe Base64 ids). This rejects


### PR DESCRIPTION
### Description

`/single_search` existed only to validate a search configuration's query. It read `dataSourceId` from the **request body**, but its only caller ([`search_configuration_service.ts`](https://github.com/opensearch-project/dashboards-search-relevance/blob/main/public/components/search_configuration/services/search_configuration_service.ts)) sent it as a **query parameter**. The value never arrived, so validation always ran against the local cluster and failed on multi-data-source deployments.

Rather than teach the duplicate route to read the query parameter, this deletes it and routes validation through `/search`, which already performs the same search plus index-name validation, pipeline validation, and metrics.

`dataSourceId` now comes from the query parameter **only**, matching the convention used by every route in `search_relevance_route_service.ts`, and the shared `queryWithDataSource` schema is reused rather than redefined.

This supersedes #929 and #931, which fixed the same bug by opposite means (#929 taught `/single_search` to read the query parameter; #931 deleted the route in favour of `/search`). Credit to both authors. Closes #930.

### Changes

**Server**
- Delete the `/single_search` route and its `SearchResultResponse` interface (`dsl_route.ts`).
- `/search` declares `query: queryWithDataSource` and reads `dataSourceId` from `request.query`. The schema is required: without one, the OSD router discards unvalidated request parts and `request.query` is always `{}`.
- Export `queryWithDataSource` from `search_relevance_route_service.ts` for reuse.

**Client**
- Remove `GetSingleSearchResults` from `common/index.ts`.
- `validateSearchQuery` posts to `GetSearchResults` and reads `errorMessage` (the shape `/search` returns) instead of `errorMsg`.
- `buildValidationRequestBody` emits `pipeline` instead of `search_pipeline`, matching what `/search` destructures.
- Move `dataSourceId` out of the request body into the query parameter at all **9** call sites, across `hybrid_optimizer_experiment_view.tsx` (3), `evaluation_experiment_view.tsx` (2), `pairwise_experiment_view.tsx` (2), `agent_handler.ts`, and `search_handler.ts`.

### Behaviour changes

Two follow from reusing `/search`, both intentional but worth flagging:

1. **Stricter validation.** Validation now applies `/search`'s index-name checks (rejects uppercase, leading `_`/`-`, and `\s , " * + / \ | ? # > <`) and pipeline-format checks. A configuration with an unusual index name that previously validated may now be rejected — arguably a fix, since such a name would fail at search time anyway.
2. **Metrics.** Validation requests now record `METRIC_ACTION.SINGLE_SEARCH`.

There is deliberately **no body fallback**, per review guidance on #929. That means the server and all 9 callers must ship together; a missed caller would silently fall back to the local cluster rather than erroring. I enumerated the call sites by grepping `GetSearchResults` and the tests pin the behaviour, but reviewers may want to double-check that list.

### Testing

New `server/routes/dsl_route.test.ts` (9 cases):
- routes to the data source client using `dataSourceId` from the query parameter
- falls back to the local cluster when absent
- ignores `dataSourceId` when `dataSourceEnabled` is false
- declares a query schema so the value survives validation
- forwards `pipeline` as `search_pipeline`
- rejects invalid index and invalid pipeline without calling OpenSearch
- reports failures as `errorMessage`
- asserts no separate `single_search` route is registered

Also updated the two duplicate `search_handler` test files and added coverage for `performAgenticSearch`, which previously had none.

**Full suite: 114 suites / 1154 tests pass.**

On typecheck: the toolchain available to me is tsc 6.0.2, which reports ~13.4k pre-existing errors against this repo's React/EUI types, so a raw pass/fail is not a usable signal. I instead diffed per-file error counts against a pristine `main` checkout. Exactly one file differs — `dsl_route.ts`, 7 → 5, the two removed errors belonging to the deleted route. Every other file is unchanged. That comparison caught a real regression during development (an `opts: any` in `search_handler.ts` broke `http.post` overload inference and made `res1.result` a type error), which is fixed.

**Not verified:** I have not exercised this against a live cluster with a configured data source, so the full browser → router → data-source round trip — the exact scenario #930 describes — is covered only at the unit level.

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/dashboards-search-relevance/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
