### PR TITLE
Gate workbench on data source readiness and warn on data sources without the Search Relevance plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - fix: scope search config to data source; require UBI index for COEC ([#923](https://github.com/opensearch-project/dashboards-search-relevance/pull/923))
 - Scope experiment result dashboards to the active workspace and data source ([#928](https://github.com/opensearch-project/dashboards-search-relevance/pull/928))
 - Merge the `single_search` route into `search` and read `dataSourceId` from the query parameter, so search configuration validation runs against the selected data source ([#930](https://github.com/opensearch-project/dashboards-search-relevance/issues/930))
+- Gate workbench on data source readiness and warn on data sources without the Search Relevance plugin ([#940](https://github.com/opensearch-project/dashboards-search-relevance/pull/940))
 
 ### Infrastructure
 

--- a/public/components/app.tsx
+++ b/public/components/app.tsx
@@ -104,7 +104,7 @@ const SearchRelevancePage = ({
     location
   );
 
-  const isDataSourceUnsupported = useDataSourceSupportsSearchRelevance(
+  const supportsSearchRelevance = useDataSourceSupportsSearchRelevance(
     dataSourceEnabled,
     dataSourceId,
     savedObjects
@@ -215,7 +215,7 @@ const SearchRelevancePage = ({
         data-test-subj="searchRelevanceSelectDataSourcePrompt"
       />
     );
-  } else if (isDataSourceUnsupported) {
+  } else if (!supportsSearchRelevance) {
     dataSourceGate = (
       <EuiEmptyPrompt
         iconType="alert"

--- a/public/components/app.tsx
+++ b/public/components/app.tsx
@@ -15,6 +15,7 @@ import {
   EuiPage,
   EuiPageBody,
   EuiLoadingSpinner,
+  EuiEmptyPrompt,
 } from '@elastic/eui';
 import { CoreStart, MountPoint, Toast, ReactChild } from '../../../../src/core/public';
 import { DataSourceManagementPluginSetup } from '../../../../src/plugins/data_source_management/public';
@@ -41,7 +42,12 @@ import { QuerySetView } from './query_set';
 import { QuerySetCreate } from './query_set';
 import { TemplateType, routeToTemplateType } from './experiment/configuration/types';
 import { TemplateConfigurationWithRouter } from './experiment/configuration/template_configuration';
-import { parseEntityParams, useDataSourceUrlSync } from './common/datasource_utils';
+import {
+  parseEntityParams,
+  useDataSourceUrlSync,
+  isAwaitingDataSourceSelection,
+  useDataSourceSupportsSearchRelevance,
+} from './common/datasource_utils';
 import { DataSourceMenu } from './common/data_source_menu';
 
 enum Navigation {
@@ -96,6 +102,12 @@ const SearchRelevancePage = ({
     dataSourceEnabled,
     history,
     location
+  );
+
+  const isDataSourceUnsupported = useDataSourceSupportsSearchRelevance(
+    dataSourceEnabled,
+    dataSourceId,
+    savedObjects
   );
 
   const getNavGroupEnabled = chrome.navGroup.getNavGroupEnabled();
@@ -193,6 +205,32 @@ const SearchRelevancePage = ({
     },
   ];
 
+  let dataSourceGate: React.ReactNode = null;
+  if (isAwaitingDataSourceSelection(dataSourceEnabled, dataSourceId)) {
+    dataSourceGate = (
+      <EuiEmptyPrompt
+        iconType="database"
+        title={<h2>Select a data source</h2>}
+        body={<p>Choose a data source to get started.</p>}
+        data-test-subj="searchRelevanceSelectDataSourcePrompt"
+      />
+    );
+  } else if (isDataSourceUnsupported) {
+    dataSourceGate = (
+      <EuiEmptyPrompt
+        iconType="alert"
+        title={<h2>Search Relevance is not available on this data source</h2>}
+        body={
+          <p>
+            The selected data source does not have the Search Relevance plugin installed. Choose a
+            different data source to continue.
+          </p>
+        }
+        data-test-subj="searchRelevanceUnsupportedDataSourcePrompt"
+      />
+    );
+  }
+
   return (
     <EuiPage restrictWidth={'100%'}>
       <DataSourceMenu
@@ -208,6 +246,7 @@ const SearchRelevancePage = ({
         <EuiSideNav style={{ width: 200 }} items={sideNavItems} />
       </EuiPageSideBar>
       <EuiPageBody>
+        {dataSourceGate || (
         <Switch>
           <Route
             path="/"
@@ -406,6 +445,7 @@ const SearchRelevancePage = ({
             }}
           />
         </Switch>
+        )}
       </EuiPageBody>
     </EuiPage>
   );

--- a/public/components/common/__tests__/datasource_utils.test.ts
+++ b/public/components/common/__tests__/datasource_utils.test.ts
@@ -33,31 +33,29 @@ describe('isAwaitingDataSourceSelection', () => {
 describe('useDataSourceSupportsSearchRelevance', () => {
   afterEach(() => jest.clearAllMocks());
 
-  it('does not query and reports supported when data sources are disabled', async () => {
+  it('reports supported and does not query when data sources are disabled', async () => {
     const get = jest.fn();
     const savedObjects = makeSavedObjects(get);
     const { result } = renderHook(() =>
       useDataSourceSupportsSearchRelevance(false, 'ds-1', savedObjects)
     );
-    expect(result.current).toBe(false);
+    expect(result.current).toBe(true);
     expect(get).not.toHaveBeenCalled();
   });
 
-  it('does not query for the local/default cluster (undefined or empty id)', async () => {
+  it('reports supported and does not query for the local/default cluster (undefined or empty id)', async () => {
     const get = jest.fn();
     const savedObjects = makeSavedObjects(get);
     const undefinedId = renderHook(() =>
       useDataSourceSupportsSearchRelevance(true, undefined, savedObjects)
     );
-    const emptyId = renderHook(() =>
-      useDataSourceSupportsSearchRelevance(true, '', savedObjects)
-    );
-    expect(undefinedId.result.current).toBe(false);
-    expect(emptyId.result.current).toBe(false);
+    const emptyId = renderHook(() => useDataSourceSupportsSearchRelevance(true, '', savedObjects));
+    expect(undefinedId.result.current).toBe(true);
+    expect(emptyId.result.current).toBe(true);
     expect(get).not.toHaveBeenCalled();
   });
 
-  it('reports unsupported when the data source lacks the search-relevance plugin', async () => {
+  it('reports NOT supported when the data source lacks the search-relevance plugin', async () => {
     const get = jest.fn().mockResolvedValue({
       attributes: { installedPlugins: ['opensearch-ml', 'opensearch-sql'] },
     });
@@ -65,17 +63,17 @@ describe('useDataSourceSupportsSearchRelevance', () => {
     const { result } = renderHook(() =>
       useDataSourceSupportsSearchRelevance(true, 'ds-1', savedObjects)
     );
-    await waitFor(() => expect(result.current).toBe(true));
+    await waitFor(() => expect(result.current).toBe(false));
     expect(get).toHaveBeenCalledWith('data-source', 'ds-1');
   });
 
-  it('reports unsupported when installedPlugins is empty (e.g. serverless)', async () => {
+  it('reports NOT supported when installedPlugins is empty (e.g. serverless)', async () => {
     const get = jest.fn().mockResolvedValue({ attributes: { installedPlugins: [] } });
     const savedObjects = makeSavedObjects(get);
     const { result } = renderHook(() =>
       useDataSourceSupportsSearchRelevance(true, 'ds-1', savedObjects)
     );
-    await waitFor(() => expect(result.current).toBe(true));
+    await waitFor(() => expect(result.current).toBe(false));
   });
 
   it('reports supported when the search-relevance plugin is installed', async () => {
@@ -87,7 +85,7 @@ describe('useDataSourceSupportsSearchRelevance', () => {
       useDataSourceSupportsSearchRelevance(true, 'ds-1', savedObjects)
     );
     await waitFor(() => expect(get).toHaveBeenCalled());
-    expect(result.current).toBe(false);
+    expect(result.current).toBe(true);
   });
 
   it('reports supported when installedPlugins is unknown (undefined)', async () => {
@@ -97,7 +95,7 @@ describe('useDataSourceSupportsSearchRelevance', () => {
       useDataSourceSupportsSearchRelevance(true, 'ds-1', savedObjects)
     );
     await waitFor(() => expect(get).toHaveBeenCalled());
-    expect(result.current).toBe(false);
+    expect(result.current).toBe(true);
   });
 
   it('falls back to supported when the saved object lookup fails', async () => {
@@ -107,6 +105,6 @@ describe('useDataSourceSupportsSearchRelevance', () => {
       useDataSourceSupportsSearchRelevance(true, 'ds-1', savedObjects)
     );
     await waitFor(() => expect(get).toHaveBeenCalled());
-    expect(result.current).toBe(false);
+    expect(result.current).toBe(true);
   });
 });

--- a/public/components/common/__tests__/datasource_utils.test.ts
+++ b/public/components/common/__tests__/datasource_utils.test.ts
@@ -1,0 +1,112 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { renderHook, waitFor } from '@testing-library/react';
+import {
+  isAwaitingDataSourceSelection,
+  useDataSourceSupportsSearchRelevance,
+  SEARCH_RELEVANCE_DATA_SOURCE_PLUGIN,
+} from '../datasource_utils';
+
+const makeSavedObjects = (get: jest.Mock) => (({ client: { get } } as unknown) as any);
+
+describe('isAwaitingDataSourceSelection', () => {
+  it('is pending when data sources are enabled but none is resolved yet', () => {
+    expect(isAwaitingDataSourceSelection(true, undefined)).toBe(true);
+  });
+
+  it('is not pending on single-cluster deployments (data sources disabled)', () => {
+    expect(isAwaitingDataSourceSelection(false, undefined)).toBe(false);
+  });
+
+  it('is not pending once a data source id is resolved', () => {
+    expect(isAwaitingDataSourceSelection(true, 'ds-1')).toBe(false);
+  });
+
+  it('treats the explicit local/default cluster (empty id) as selected, not pending', () => {
+    expect(isAwaitingDataSourceSelection(true, '')).toBe(false);
+  });
+});
+
+describe('useDataSourceSupportsSearchRelevance', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  it('does not query and reports supported when data sources are disabled', async () => {
+    const get = jest.fn();
+    const savedObjects = makeSavedObjects(get);
+    const { result } = renderHook(() =>
+      useDataSourceSupportsSearchRelevance(false, 'ds-1', savedObjects)
+    );
+    expect(result.current).toBe(false);
+    expect(get).not.toHaveBeenCalled();
+  });
+
+  it('does not query for the local/default cluster (undefined or empty id)', async () => {
+    const get = jest.fn();
+    const savedObjects = makeSavedObjects(get);
+    const undefinedId = renderHook(() =>
+      useDataSourceSupportsSearchRelevance(true, undefined, savedObjects)
+    );
+    const emptyId = renderHook(() =>
+      useDataSourceSupportsSearchRelevance(true, '', savedObjects)
+    );
+    expect(undefinedId.result.current).toBe(false);
+    expect(emptyId.result.current).toBe(false);
+    expect(get).not.toHaveBeenCalled();
+  });
+
+  it('reports unsupported when the data source lacks the search-relevance plugin', async () => {
+    const get = jest.fn().mockResolvedValue({
+      attributes: { installedPlugins: ['opensearch-ml', 'opensearch-sql'] },
+    });
+    const savedObjects = makeSavedObjects(get);
+    const { result } = renderHook(() =>
+      useDataSourceSupportsSearchRelevance(true, 'ds-1', savedObjects)
+    );
+    await waitFor(() => expect(result.current).toBe(true));
+    expect(get).toHaveBeenCalledWith('data-source', 'ds-1');
+  });
+
+  it('reports unsupported when installedPlugins is empty (e.g. serverless)', async () => {
+    const get = jest.fn().mockResolvedValue({ attributes: { installedPlugins: [] } });
+    const savedObjects = makeSavedObjects(get);
+    const { result } = renderHook(() =>
+      useDataSourceSupportsSearchRelevance(true, 'ds-1', savedObjects)
+    );
+    await waitFor(() => expect(result.current).toBe(true));
+  });
+
+  it('reports supported when the search-relevance plugin is installed', async () => {
+    const get = jest.fn().mockResolvedValue({
+      attributes: { installedPlugins: ['opensearch-ml', SEARCH_RELEVANCE_DATA_SOURCE_PLUGIN] },
+    });
+    const savedObjects = makeSavedObjects(get);
+    const { result } = renderHook(() =>
+      useDataSourceSupportsSearchRelevance(true, 'ds-1', savedObjects)
+    );
+    await waitFor(() => expect(get).toHaveBeenCalled());
+    expect(result.current).toBe(false);
+  });
+
+  it('reports supported when installedPlugins is unknown (undefined)', async () => {
+    const get = jest.fn().mockResolvedValue({ attributes: {} });
+    const savedObjects = makeSavedObjects(get);
+    const { result } = renderHook(() =>
+      useDataSourceSupportsSearchRelevance(true, 'ds-1', savedObjects)
+    );
+    await waitFor(() => expect(get).toHaveBeenCalled());
+    expect(result.current).toBe(false);
+  });
+
+  it('falls back to supported when the saved object lookup fails', async () => {
+    const get = jest.fn().mockRejectedValue(new Error('not found'));
+    const savedObjects = makeSavedObjects(get);
+    const { result } = renderHook(() =>
+      useDataSourceSupportsSearchRelevance(true, 'ds-1', savedObjects)
+    );
+    await waitFor(() => expect(get).toHaveBeenCalled());
+    expect(result.current).toBe(false);
+  });
+});

--- a/public/components/common/datasource_utils.ts
+++ b/public/components/common/datasource_utils.ts
@@ -116,28 +116,30 @@ export const useDataSourceSupportsSearchRelevance = (
   dataSourceId: string | undefined,
   savedObjects: CoreStart['savedObjects']
 ): boolean => {
-  const [isUnsupported, setIsUnsupported] = useState(false);
+  const [supportsSearchRelevance, setSupportsSearchRelevance] = useState(true);
 
   useEffect(() => {
     let cancelled = false;
 
     if (!dataSourceEnabled || dataSourceId === undefined || dataSourceId === '') {
-      setIsUnsupported(false);
+      setSupportsSearchRelevance(true);
       return;
     }
+
+    setSupportsSearchRelevance(true);
 
     savedObjects.client
       .get<DataSourceAttributes>('data-source', dataSourceId)
       .then((dataSource) => {
         if (cancelled) return;
         const installedPlugins = dataSource?.attributes?.installedPlugins;
-        setIsUnsupported(
-          Array.isArray(installedPlugins) &&
-            !installedPlugins.includes(SEARCH_RELEVANCE_DATA_SOURCE_PLUGIN)
+        setSupportsSearchRelevance(
+          !Array.isArray(installedPlugins) ||
+            installedPlugins.includes(SEARCH_RELEVANCE_DATA_SOURCE_PLUGIN)
         );
       })
       .catch(() => {
-        if (!cancelled) setIsUnsupported(false);
+        if (!cancelled) setSupportsSearchRelevance(true);
       });
 
     return () => {
@@ -145,5 +147,5 @@ export const useDataSourceSupportsSearchRelevance = (
     };
   }, [dataSourceEnabled, dataSourceId, savedObjects]);
 
-  return isUnsupported;
+  return supportsSearchRelevance;
 };

--- a/public/components/common/datasource_utils.ts
+++ b/public/components/common/datasource_utils.ts
@@ -4,10 +4,12 @@
  */
 
 import { useCallback, useEffect, useState } from 'react';
-import { SavedObject } from '../../../../../src/core/public';
+import { CoreStart, SavedObject } from '../../../../../src/core/public';
 import { DataSourceAttributes } from '../../../../../src/plugins/data_source/common/data_sources';
 import semver from 'semver';
 import * as pluginManifest from '../../../opensearch_dashboards.json';
+
+export const SEARCH_RELEVANCE_DATA_SOURCE_PLUGIN = 'opensearch-search-relevance';
 
 /**
  * Parse dataSourceId from URL search parameters
@@ -102,4 +104,46 @@ export const useDataSourceFilter = (excludeEngineTypes?: string[]) => {
     },
     [excludeEngineTypes]
   );
+};
+
+export const isAwaitingDataSourceSelection = (
+  dataSourceEnabled: boolean,
+  dataSourceId: string | undefined
+): boolean => dataSourceEnabled && dataSourceId === undefined;
+
+export const useDataSourceSupportsSearchRelevance = (
+  dataSourceEnabled: boolean,
+  dataSourceId: string | undefined,
+  savedObjects: CoreStart['savedObjects']
+): boolean => {
+  const [isUnsupported, setIsUnsupported] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    if (!dataSourceEnabled || dataSourceId === undefined || dataSourceId === '') {
+      setIsUnsupported(false);
+      return;
+    }
+
+    savedObjects.client
+      .get<DataSourceAttributes>('data-source', dataSourceId)
+      .then((dataSource) => {
+        if (cancelled) return;
+        const installedPlugins = dataSource?.attributes?.installedPlugins;
+        setIsUnsupported(
+          Array.isArray(installedPlugins) &&
+            !installedPlugins.includes(SEARCH_RELEVANCE_DATA_SOURCE_PLUGIN)
+        );
+      })
+      .catch(() => {
+        if (!cancelled) setIsUnsupported(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [dataSourceEnabled, dataSourceId, savedObjects]);
+
+  return isUnsupported;
 };


### PR DESCRIPTION
### Overview

On multi-data-source (MDS) deployments the Search Relevance workbench talks to the OpenSearch cluster behind the **selected data source**. This PR fixes two problems that appear when that selection isn't ready yet, or when the selected data source can't run Search Relevance.

### Problem 1 — Workbench pages fail with "No Living connections" until a hard refresh

**What happens:** When the workbench first opens, the listing pages (Experiments, Query Sets, Search Configurations, Judgments) fetch on mount using the selected `dataSourceId`. That id resolves asynchronously — first from the URL, then from the data source menu — so it is briefly `undefined` on the first render. A request sent during that window carries no `dataSourceId`, so the backend falls back to the local cluster; on managed deployments that cluster has no reachable node and the request fails with `No Living connections`. The page then stores that error and renders an error callout in place of the list. The list would normally recover by remounting when `dataSourceId` changes, but that remount is tied to the list component, which is no longer rendered — so once the data source menu resolves a default, nothing re-triggers the fetch and the error stays. Only a full page reload clears it, because by then the id is already in the URL and the first request succeeds.
<img width="1511" height="763" alt="t-2" src="https://github.com/user-attachments/assets/ef1d0bba-f8a9-4336-9714-0af0925f4246" />

**Fix:** Add a readiness gate in `SearchRelevancePage`. While data sources are enabled and no `dataSourceId` has resolved yet, render a "Select a data source" prompt and hold off rendering the routed pages (and their fetches), so no request is ever sent with an undefined `dataSourceId` and no error state is set. When the data source menu resolves the default on mount (OpenSearch Dashboards' `DataSourceSelectable` picks a default and fires its selection callback) and sets `dataSourceId`, the gate opens and the pages mount and fetch with a valid id — recovery is automatic, with no hard refresh. The prompt only stays visible when the cluster has no connected data source. Because the gate is central, all four listing pages are covered at once.

### Problem 2 — A data source that can't run Search Relevance shows a confusing "No result"

**What happens:** If the selected data source doesn't have the Search Relevance plugin installed (for example OpenSearch Serverless), the pages still call the relevance APIs against it. Those APIs don't exist there, so the UI surfaces an unhelpful "No result" with no explanation of why.

**Fix:** Detect unsupported data sources up front and show an explanatory prompt instead of calling the APIs. The check reads the data source's `installedPlugins` (the plugin metadata OpenSearch Dashboards already stores per data source) and treats the data source as unsupported when `opensearch-search-relevance` is absent. This is engine-agnostic which covers Serverless and any cluster that simply doesn't have the plugin.


data source supporting search-relevance:
<img width="1512" height="743" alt="t-1" src="https://github.com/user-attachments/assets/31db2b7d-17a6-4d89-af49-0f19460e7a30" />

data source not supporting search-relevance:
<img width="1512" height="762" alt="t-5" src="https://github.com/user-attachments/assets/c33b4911-9d34-4c45-8c8c-7e8b874b656e" />



### Implementation

- Both helpers live in the existing `public/components/common/datasource_utils.ts`:
  - `isAwaitingDataSourceSelection(dataSourceEnabled, dataSourceId)` — true only while MDS is enabled and no data source has resolved.
  - `useDataSourceSupportsSearchRelevance(dataSourceEnabled, dataSourceId, savedObjects)` — reads `installedPlugins` and returns whether the data source is unsupported.
- `SearchRelevancePage` renders one of: the "select a data source" prompt, the "unsupported" prompt, or the normal routes — no existing route or page logic is changed.

### Testing

- Unit tests for both helpers in `public/components/common/__tests__/datasource_utils.test.ts` (all passing).
- Manually verified on a local MDS stack: workbench pages load on first navigation without errors, and selecting a data source without the plugin shows the prompt.

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented (CHANGELOG.md updated).
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


