### PR TITLE
Add read-only LTR model registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 - Add "Reuse Existing Judgments" option in LLM judgment Advanced Settings to reuse ratings from up to 5 existing judgments, and add a retry action for failed documents in the judgment listing ([#525](https://github.com/opensearch-project/dashboards-search-relevance/issues/525))
 - Allow ratings on a completed LLM judgment to be edited in place, including assigning ratings to previously failed documents ([#525](https://github.com/opensearch-project/dashboards-search-relevance/issues/525))
+- Add a read-only Learning to Rank model registry listing ([#943](https://github.com/opensearch-project/dashboards-search-relevance/pull/943))
 
 ### Enhancements
 

--- a/common/index.ts
+++ b/common/index.ts
@@ -29,6 +29,9 @@ export const ServiceEndpoints = Object.freeze({
   Experiments: `${SEARCH_RELEVANCE_WORKBENCH_BASE_PATH}/experiments`,
   ScheduledExperiments: `${SEARCH_RELEVANCE_WORKBENCH_BASE_PATH}/experiments/schedule`,
   ValidatePrompt: `${SEARCH_RELEVANCE_WORKBENCH_BASE_PATH}/judgments/validate_prompt`,
+
+  // Learning to Rank node APIs
+  LtrModels: `${SEARCH_RELEVANCE_WORKBENCH_BASE_PATH}/ltr/models`,
 } as const);
 
 const SEARCH_RELEVANCE_PLUGIN_BASE_PATH = '/_plugins/_search_relevance';
@@ -39,6 +42,18 @@ export const BackendEndpoints = Object.freeze({
   Experiments: `${SEARCH_RELEVANCE_PLUGIN_BASE_PATH}/experiments`,
   ScheduledExperiments: `${SEARCH_RELEVANCE_PLUGIN_BASE_PATH}/experiments/schedule`,
 } as const);
+
+// The Learning to Rank plugin owns its own REST namespace, separate from
+// _plugins/_search_relevance. The `.ltrstore*` indices are system indices, so these
+// plugin endpoints are the only supported way to read them.
+const LTR_PLUGIN_BASE_PATH = '/_ltr';
+export const LtrBackendEndpoints = Object.freeze({
+  Models: `${LTR_PLUGIN_BASE_PATH}/_model`,
+} as const);
+
+// `GET /_ltr/_model` defaults to size=20, which silently truncates the listing. We always
+// request explicitly and warn the user when the store holds more than we fetched.
+export const LTR_MODEL_FETCH_SIZE = 1000;
 
 const ML_COMMON_PLUGIN_BASE_PATH = '_plugins/_ml';
 export const ML_MODEL_ROUTE_PREFIX = `${ML_COMMON_PLUGIN_BASE_PATH}/models`;
@@ -81,6 +96,9 @@ export enum Routes {
   JudgmentView = '/judgment/view/:entityId',
   JudgmentViewPrefix = '/judgment/view',
   JudgmentCreate = '/judgment/create',
+  LtrModelListing = '/ltrModel',
+  LtrModelView = '/ltrModel/view/:entityId',
+  LtrModelViewPrefix = '/ltrModel/view',
 }
 
 export enum SavedObjectIds {

--- a/public/components/app.tsx
+++ b/public/components/app.tsx
@@ -38,6 +38,7 @@ import {
   SearchConfigurationCreate,
 } from './search_configuration';
 import { JudgmentListing, JudgmentView, JudgmentCreate } from './judgment';
+import { LtrModelListing, LtrModelView } from './ltr_model';
 import { QuerySetView } from './query_set';
 import { QuerySetCreate } from './query_set';
 import { TemplateType, routeToTemplateType } from './experiment/configuration/types';
@@ -61,6 +62,7 @@ enum Navigation {
   QuerySets = 'Query Sets',
   SearchConfigurations = 'Search Configurations',
   Judgments = 'Judgments',
+  LtrModels = 'LTR Models',
 }
 
 interface SearchRelevanceAppDeps {
@@ -201,6 +203,14 @@ const SearchRelevancePage = ({
           },
           isSelected: location.pathname.startsWith(Routes.JudgmentListing),
         },
+        {
+          name: Navigation.LtrModels,
+          id: Navigation.LtrModels,
+          onClick: () => {
+            history.push(Routes.LtrModelListing);
+          },
+          isSelected: location.pathname.startsWith(Routes.LtrModelListing),
+        },
       ],
     },
   ];
@@ -311,6 +321,21 @@ const SearchRelevancePage = ({
             exact
             render={() => {
               return <JudgmentListing http={http} dataSourceId={dataSourceId} />;
+            }}
+          />
+          <Route
+            path={Routes.LtrModelListing}
+            exact
+            render={() => {
+              return <LtrModelListing http={http} />;
+            }}
+          />
+          <Route
+            path={Routes.LtrModelView}
+            exact
+            render={(props) => {
+              const { entityId } = props.match.params;
+              return <LtrModelView http={http} id={decodeURIComponent(entityId)} />;
             }}
           />
           <Route

--- a/public/components/ltr_model/__tests__/ltr_model_definition.test.tsx
+++ b/public/components/ltr_model/__tests__/ltr_model_definition.test.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { LtrModelDefinition, formatDefinition } from '../components/ltr_model_definition';
+
+describe('formatDefinition', () => {
+  it('shows a RankLib definition verbatim as text', () => {
+    const ranklib = '## LambdaMART\n## No. of trees = 1\n<ensemble>\n</ensemble>';
+    expect(formatDefinition(ranklib)).toEqual({ body: ranklib, language: 'text' });
+  });
+
+  it('pretty-prints a definition stored as embedded JSON', () => {
+    expect(formatDefinition({ feature1: 1.2 })).toEqual({
+      body: '{\n  "feature1": 1.2\n}',
+      language: 'json',
+    });
+  });
+
+  it('pretty-prints a JSON definition that arrives as a string', () => {
+    expect(formatDefinition('{"feature1":1.2}')).toEqual({
+      body: '{\n  "feature1": 1.2\n}',
+      language: 'json',
+    });
+  });
+
+  it('treats a bare numeric string as text rather than JSON', () => {
+    expect(formatDefinition('42')).toEqual({ body: '42', language: 'text' });
+  });
+
+  it('handles an absent definition', () => {
+    expect(formatDefinition(undefined)).toEqual({ body: '', language: 'text' });
+    expect(formatDefinition(null)).toEqual({ body: '', language: 'text' });
+  });
+});
+
+describe('LtrModelDefinition', () => {
+  it('renders a large definition without truncating it', () => {
+    // 500 trees worth of lines; the whole thing must survive to the DOM.
+    const lines = Array.from({ length: 500 }, (_, i) => `${i}:${i * 1.5}`);
+    const definition = `## LambdaMART\n${lines.join('\n')}`;
+
+    render(<LtrModelDefinition definition={definition} />);
+
+    const block = screen.getByTestId('ltrModelDefinition');
+    expect(block.textContent).toContain('0:0');
+    expect(block.textContent).toContain('499:748.5');
+    expect(block.textContent).toBe(definition);
+  });
+
+  it('explains an empty definition', () => {
+    render(<LtrModelDefinition definition={undefined} />);
+    expect(screen.getByText('This model has no stored definition.')).toBeInTheDocument();
+  });
+});

--- a/public/components/ltr_model/__tests__/ltr_model_listing.test.tsx
+++ b/public/components/ltr_model/__tests__/ltr_model_listing.test.tsx
@@ -1,0 +1,100 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { LtrModelListing } from '../views/ltr_model_listing';
+import { useLtrModelList } from '../hooks/use_ltr_model_list';
+
+jest.mock('../hooks/use_ltr_model_list');
+jest.mock('../components/ltr_model_table', () => ({
+  LtrModelTable: ({ isLoading, history }: any) => (
+    <div data-test-subj="ltr-model-table">
+      {isLoading ? 'loading' : 'loaded'}
+      <span data-test-subj="table-has-history">{history ? 'yes' : 'no'}</span>
+    </div>
+  ),
+}));
+
+const mockUseLtrModelList = useLtrModelList as jest.MockedFunction<typeof useLtrModelList>;
+
+const mockHttp = { get: jest.fn() } as any;
+
+const routeProps: any = {
+  history: { push: jest.fn() },
+  location: { pathname: '/ltrModel', search: '', hash: '', state: undefined },
+  match: { params: {}, isExact: true, path: '/ltrModel', url: '/ltrModel' },
+};
+
+const hookState = (overrides: any = {}) => ({
+  isLoading: false,
+  error: null,
+  unavailableReason: null,
+  truncatedTotal: null,
+  findLtrModels: jest.fn(),
+  setError: jest.fn(),
+  ...overrides,
+});
+
+describe('LtrModelListing', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('renders the table by default', () => {
+    mockUseLtrModelList.mockReturnValue(hookState() as any);
+
+    render(<LtrModelListing http={mockHttp} {...routeProps} />);
+
+    expect(screen.getByText('LTR Models')).toBeInTheDocument();
+    expect(screen.getByTestId('ltr-model-table')).toBeInTheDocument();
+    // The table needs history to link names through to the detail view.
+    expect(screen.getByTestId('table-has-history')).toHaveTextContent('yes');
+  });
+
+  it('renders an error callout instead of the table when the fetch fails', () => {
+    mockUseLtrModelList.mockReturnValue(hookState({ error: 'cluster is on fire' }) as any);
+
+    render(<LtrModelListing http={mockHttp} {...routeProps} />);
+
+    expect(screen.getByText('cluster is on fire')).toBeInTheDocument();
+    expect(screen.queryByTestId('ltr-model-table')).not.toBeInTheDocument();
+  });
+
+  it('explains a missing feature store rather than showing an empty table', () => {
+    mockUseLtrModelList.mockReturnValue(hookState({ unavailableReason: 'store_not_found' }) as any);
+
+    render(<LtrModelListing http={mockHttp} {...routeProps} />);
+
+    expect(screen.getByText('No feature store found')).toBeInTheDocument();
+    expect(screen.queryByTestId('ltr-model-table')).not.toBeInTheDocument();
+  });
+
+  it('explains a disabled LTR plugin', () => {
+    mockUseLtrModelList.mockReturnValue(hookState({ unavailableReason: 'plugin_disabled' }) as any);
+
+    render(<LtrModelListing http={mockHttp} {...routeProps} />);
+
+    expect(screen.getByText('Learning to Rank is disabled')).toBeInTheDocument();
+  });
+
+  it('explains an uninstalled LTR plugin', () => {
+    mockUseLtrModelList.mockReturnValue(
+      hookState({ unavailableReason: 'plugin_not_installed' }) as any
+    );
+
+    render(<LtrModelListing http={mockHttp} {...routeProps} />);
+
+    expect(screen.getByText('Learning to Rank is not installed')).toBeInTheDocument();
+  });
+
+  it('warns alongside the table when the registry was truncated', () => {
+    mockUseLtrModelList.mockReturnValue(hookState({ truncatedTotal: 4200 }) as any);
+
+    render(<LtrModelListing http={mockHttp} {...routeProps} />);
+
+    expect(screen.getByText('Showing part of the registry')).toBeInTheDocument();
+    expect(screen.getByText(/4200 models/)).toBeInTheDocument();
+    expect(screen.getByTestId('ltr-model-table')).toBeInTheDocument();
+  });
+});

--- a/public/components/ltr_model/__tests__/ltr_model_table.test.tsx
+++ b/public/components/ltr_model/__tests__/ltr_model_table.test.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { LtrModelTable, shortModelType } from '../components/ltr_model_table';
+
+describe('shortModelType', () => {
+  it('drops the model/ prefix', () => {
+    expect(shortModelType('model/xgboost+json')).toBe('xgboost+json');
+  });
+
+  it('leaves an unprefixed type alone', () => {
+    expect(shortModelType('ranklib')).toBe('ranklib');
+  });
+});
+
+const mockHistory = {
+  push: jest.fn(),
+  createHref: jest.fn((location: any) => location.pathname),
+  location: { pathname: '/ltrModel', search: '', hash: '', state: undefined },
+} as any;
+
+describe('LtrModelTable', () => {
+  const items = [
+    { name: 'my_model', featureSetName: 'my_set', modelType: 'model/ranklib', featureCount: 2 },
+    {
+      name: 'other_model',
+      featureSetName: 'other_set',
+      modelType: 'model/xgboost+json',
+      featureCount: 7,
+    },
+  ];
+
+  it('renders a row per model with its feature set, type, and feature count', async () => {
+    const findItems = jest.fn().mockResolvedValue({ total: items.length, hits: items });
+
+    render(<LtrModelTable isLoading={false} findItems={findItems} history={mockHistory} />);
+
+    await waitFor(() => expect(screen.getByText('my_model')).toBeInTheDocument());
+    expect(screen.getByText('my_set')).toBeInTheDocument();
+    expect(screen.getByText('ranklib')).toBeInTheDocument();
+    expect(screen.getByText('other_model')).toBeInTheDocument();
+    expect(screen.getByText('xgboost+json')).toBeInTheDocument();
+    expect(screen.getByText('7')).toBeInTheDocument();
+  });
+
+  it('links each model name to its detail view', async () => {
+    const findItems = jest.fn().mockResolvedValue({ total: items.length, hits: items });
+
+    render(<LtrModelTable isLoading={false} findItems={findItems} history={mockHistory} />);
+
+    await waitFor(() => expect(screen.getByText('my_model')).toBeInTheDocument());
+    expect(screen.getByText('my_model').closest('a')).toHaveAttribute(
+      'href',
+      '/ltrModel/view/my_model'
+    );
+  });
+});

--- a/public/components/ltr_model/__tests__/ltr_model_view.test.tsx
+++ b/public/components/ltr_model/__tests__/ltr_model_view.test.tsx
@@ -1,0 +1,98 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { LtrModelView } from '../views/ltr_model_view';
+import { useLtrModelView } from '../hooks/use_ltr_model_view';
+
+jest.mock('../hooks/use_ltr_model_view');
+
+const mockUseLtrModelView = useLtrModelView as jest.MockedFunction<typeof useLtrModelView>;
+const mockHttp = { get: jest.fn() } as any;
+
+const model = {
+  name: 'my_model',
+  featureSetName: 'my_set',
+  modelType: 'model/ranklib',
+  featureCount: 1,
+  features: [
+    {
+      name: 'feature1',
+      params: ['query_string'],
+      templateLanguage: 'mustache',
+      template: { match: { field_test: '{{query_string}}' } },
+    },
+  ],
+  definition: '## LambdaMART',
+};
+
+const hookState = (overrides: any = {}) => ({
+  model: null,
+  isLoading: false,
+  error: null,
+  notFound: false,
+  unavailableReason: null,
+  ...overrides,
+});
+
+describe('LtrModelView', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('renders the model metadata, its feature set, and its definition', () => {
+    mockUseLtrModelView.mockReturnValue(hookState({ model }) as any);
+
+    render(<LtrModelView http={mockHttp} id="my_model" />);
+
+    expect(screen.getByText('my_set')).toBeInTheDocument();
+    expect(screen.getByText('ranklib')).toBeInTheDocument();
+    // The feature set renders a real feature with its template.
+    expect(screen.getByText('feature1')).toBeInTheDocument();
+    expect(screen.getByText('query_string')).toBeInTheDocument();
+    expect(screen.getByTestId('ltrModelDefinition').textContent).toBe('## LambdaMART');
+  });
+
+  it('shows a spinner while loading', () => {
+    mockUseLtrModelView.mockReturnValue(hookState({ isLoading: true }) as any);
+
+    render(<LtrModelView http={mockHttp} id="my_model" />);
+
+    expect(screen.getByTestId('ltrModelViewLoading')).toBeInTheDocument();
+  });
+
+  it('distinguishes a missing model from a broken registry', () => {
+    mockUseLtrModelView.mockReturnValue(hookState({ notFound: true }) as any);
+
+    render(<LtrModelView http={mockHttp} id="ghost" />);
+
+    expect(screen.getByText('Model not found')).toBeInTheDocument();
+  });
+
+  it('explains a registry-level failure', () => {
+    mockUseLtrModelView.mockReturnValue(hookState({ unavailableReason: 'plugin_disabled' }) as any);
+
+    render(<LtrModelView http={mockHttp} id="my_model" />);
+
+    expect(screen.getByText('Learning to Rank is disabled')).toBeInTheDocument();
+  });
+
+  it('reports an unexpected error', () => {
+    mockUseLtrModelView.mockReturnValue(hookState({ error: 'cluster is on fire' }) as any);
+
+    render(<LtrModelView http={mockHttp} id="my_model" />);
+
+    expect(screen.getByText('cluster is on fire')).toBeInTheDocument();
+  });
+
+  it('renders a model whose feature set is empty', () => {
+    mockUseLtrModelView.mockReturnValue(
+      hookState({ model: { ...model, features: [], featureCount: 0 } }) as any
+    );
+
+    render(<LtrModelView http={mockHttp} id="my_model" />);
+
+    expect(screen.getByText("This model's feature set has no features.")).toBeInTheDocument();
+  });
+});

--- a/public/components/ltr_model/__tests__/use_ltr_model_list.test.ts
+++ b/public/components/ltr_model/__tests__/use_ltr_model_list.test.ts
@@ -1,0 +1,203 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { renderHook, act } from '@testing-library/react-hooks';
+import { mapLtrModelFields, useLtrModelList } from '../hooks/use_ltr_model_list';
+
+jest.mock('../../../../common', () => ({
+  ServiceEndpoints: {
+    LtrModels: '/api/relevancy/ltr/models',
+  },
+  LTR_MODEL_FETCH_SIZE: 1000,
+}));
+
+const mockHttp = {
+  get: jest.fn(),
+} as any;
+
+const hit = (name: string, overrides: any = {}) => ({
+  _source: {
+    name,
+    type: 'model',
+    model: {
+      feature_set: {
+        name: 'my_set',
+        features: [{ name: 'feature1' }, { name: 'feature2' }],
+      },
+      model: {
+        type: 'model/ranklib',
+        definition: '## LambdaMART',
+      },
+      ...overrides,
+    },
+  },
+});
+
+const searchResponse = (hits: any[], total?: number) => ({
+  hits: {
+    total: { value: total ?? hits.length },
+    hits,
+  },
+});
+
+describe('mapLtrModelFields', () => {
+  it('unwraps _source into a flat registry entry', () => {
+    expect(mapLtrModelFields(hit('my_model'))).toEqual({
+      name: 'my_model',
+      featureSetName: 'my_set',
+      modelType: 'model/ranklib',
+      featureCount: 2,
+    });
+  });
+
+  it('tolerates a model document missing its feature set', () => {
+    expect(mapLtrModelFields({ _source: { name: 'bare' } })).toEqual({
+      name: 'bare',
+      featureSetName: '',
+      modelType: '',
+      featureCount: 0,
+    });
+  });
+});
+
+describe('useLtrModelList', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('initializes with default state', () => {
+    const { result } = renderHook(() => useLtrModelList(mockHttp));
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBe(null);
+    expect(result.current.unavailableReason).toBe(null);
+    expect(result.current.truncatedTotal).toBe(null);
+  });
+
+  it('fetches models successfully', async () => {
+    mockHttp.get.mockResolvedValue(searchResponse([hit('my_model')]));
+
+    const { result } = renderHook(() => useLtrModelList(mockHttp));
+
+    let listResult;
+    await act(async () => {
+      listResult = await result.current.findLtrModels('');
+    });
+
+    expect(listResult).toEqual({
+      total: 1,
+      hits: [
+        {
+          name: 'my_model',
+          featureSetName: 'my_set',
+          modelType: 'model/ranklib',
+          featureCount: 2,
+        },
+      ],
+    });
+  });
+
+  it('requests an explicit size so the endpoint does not silently truncate at 20', async () => {
+    mockHttp.get.mockResolvedValue(searchResponse([]));
+
+    const { result } = renderHook(() => useLtrModelList(mockHttp));
+    await act(async () => {
+      await result.current.findLtrModels('');
+    });
+
+    expect(mockHttp.get).toHaveBeenCalledWith('/api/relevancy/ltr/models', {
+      query: { size: 1000 },
+    });
+  });
+
+  it('flags truncation when the store holds more models than were fetched', async () => {
+    mockHttp.get.mockResolvedValue(searchResponse([hit('a'), hit('b')], 4200));
+
+    const { result } = renderHook(() => useLtrModelList(mockHttp));
+    await act(async () => {
+      await result.current.findLtrModels('');
+    });
+
+    expect(result.current.truncatedTotal).toBe(4200);
+  });
+
+  // A cluster running with `rest_total_hits_as_int` returns `hits.total` as a bare number.
+  it('flags truncation when total comes back as a bare number', async () => {
+    mockHttp.get.mockResolvedValue({ hits: { hits: [hit('a'), hit('b')], total: 4200 } });
+
+    const { result } = renderHook(() => useLtrModelList(mockHttp));
+    await act(async () => {
+      await result.current.findLtrModels('');
+    });
+
+    expect(result.current.truncatedTotal).toBe(4200);
+  });
+
+  it('does not flag truncation when the whole store was returned', async () => {
+    mockHttp.get.mockResolvedValue(searchResponse([hit('a'), hit('b')]));
+
+    const { result } = renderHook(() => useLtrModelList(mockHttp));
+    await act(async () => {
+      await result.current.findLtrModels('');
+    });
+
+    expect(result.current.truncatedTotal).toBe(null);
+  });
+
+  it('filters by name', async () => {
+    mockHttp.get.mockResolvedValue(searchResponse([hit('alpha_model'), hit('beta_model')]));
+
+    const { result } = renderHook(() => useLtrModelList(mockHttp));
+
+    let listResult: any;
+    await act(async () => {
+      listResult = await result.current.findLtrModels('ALPHA');
+    });
+
+    expect(listResult.total).toBe(1);
+    expect(listResult.hits[0].name).toBe('alpha_model');
+  });
+
+  it.each([['store_not_found'], ['plugin_disabled'], ['plugin_not_installed']])(
+    'surfaces %s as an unavailable reason rather than an error',
+    async (reason) => {
+      mockHttp.get.mockRejectedValue({ body: { attributes: { ltrErrorType: reason } } });
+
+      const { result } = renderHook(() => useLtrModelList(mockHttp));
+
+      let listResult: any;
+      await act(async () => {
+        listResult = await result.current.findLtrModels('');
+      });
+
+      expect(result.current.unavailableReason).toBe(reason);
+      expect(result.current.error).toBe(null);
+      expect(listResult).toEqual({ total: 0, hits: [] });
+    }
+  );
+
+  it('reports an unexpected failure as an error', async () => {
+    mockHttp.get.mockRejectedValue({ body: { message: 'cluster is on fire' } });
+
+    const { result } = renderHook(() => useLtrModelList(mockHttp));
+    await act(async () => {
+      await result.current.findLtrModels('');
+    });
+
+    expect(result.current.error).toBe('cluster is on fire');
+    expect(result.current.unavailableReason).toBe(null);
+  });
+
+  it('falls back to a generic message when the failure carries no detail', async () => {
+    mockHttp.get.mockRejectedValue({});
+
+    const { result } = renderHook(() => useLtrModelList(mockHttp));
+    await act(async () => {
+      await result.current.findLtrModels('');
+    });
+
+    expect(result.current.error).toBe('Failed to load LTR models due to an unknown error.');
+  });
+});

--- a/public/components/ltr_model/__tests__/use_ltr_model_view.test.ts
+++ b/public/components/ltr_model/__tests__/use_ltr_model_view.test.ts
@@ -1,0 +1,121 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { renderHook } from '@testing-library/react-hooks';
+import { mapLtrModelDetail, useLtrModelView } from '../hooks/use_ltr_model_view';
+
+jest.mock('../../../../common', () => ({
+  ServiceEndpoints: {
+    LtrModels: '/api/relevancy/ltr/models',
+  },
+  LTR_MODEL_FETCH_SIZE: 1000,
+}));
+
+const mockHttp = { get: jest.fn() } as any;
+
+const documentResponse = {
+  _id: 'model-my_model',
+  found: true,
+  _source: {
+    name: 'my_model',
+    type: 'model',
+    model: {
+      feature_set: {
+        name: 'my_set',
+        features: [
+          {
+            name: 'feature1',
+            params: ['query_string'],
+            template_language: 'mustache',
+            template: { match: { field_test: '{{query_string}}' } },
+          },
+        ],
+      },
+      model: { type: 'model/ranklib', definition: '## LambdaMART\n0:1.2' },
+    },
+  },
+};
+
+describe('mapLtrModelDetail', () => {
+  it('maps shared fields, features, and the definition', () => {
+    expect(mapLtrModelDetail(documentResponse)).toEqual({
+      name: 'my_model',
+      featureSetName: 'my_set',
+      modelType: 'model/ranklib',
+      featureCount: 1,
+      features: [
+        {
+          name: 'feature1',
+          params: ['query_string'],
+          templateLanguage: 'mustache',
+          template: { match: { field_test: '{{query_string}}' } },
+        },
+      ],
+      definition: '## LambdaMART\n0:1.2',
+    });
+  });
+
+  it('tolerates a model with no feature set', () => {
+    const detail = mapLtrModelDetail({ _source: { name: 'bare' } });
+    expect(detail.features).toEqual([]);
+    expect(detail.definition).toBeUndefined();
+  });
+});
+
+describe('useLtrModelView', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('fetches the model by name', async () => {
+    mockHttp.get.mockResolvedValue(documentResponse);
+
+    const { result, waitForNextUpdate } = renderHook(() => useLtrModelView(mockHttp, 'my_model'));
+    await waitForNextUpdate();
+
+    expect(mockHttp.get).toHaveBeenCalledWith('/api/relevancy/ltr/models/my_model');
+    expect(result.current.model?.name).toBe('my_model');
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBe(null);
+  });
+
+  it('encodes a name that needs escaping', async () => {
+    mockHttp.get.mockResolvedValue(documentResponse);
+
+    const { waitForNextUpdate } = renderHook(() => useLtrModelView(mockHttp, 'my model/v2'));
+    await waitForNextUpdate();
+
+    expect(mockHttp.get).toHaveBeenCalledWith('/api/relevancy/ltr/models/my%20model%2Fv2');
+  });
+
+  it('reports a missing model separately from a broken registry', async () => {
+    mockHttp.get.mockRejectedValue({ body: { attributes: { ltrErrorType: 'model_not_found' } } });
+
+    const { result, waitForNextUpdate } = renderHook(() => useLtrModelView(mockHttp, 'ghost'));
+    await waitForNextUpdate();
+
+    expect(result.current.notFound).toBe(true);
+    expect(result.current.unavailableReason).toBe(null);
+    expect(result.current.error).toBe(null);
+    expect(result.current.model).toBe(null);
+  });
+
+  it('surfaces a registry-level reason', async () => {
+    mockHttp.get.mockRejectedValue({ body: { attributes: { ltrErrorType: 'plugin_disabled' } } });
+
+    const { result, waitForNextUpdate } = renderHook(() => useLtrModelView(mockHttp, 'my_model'));
+    await waitForNextUpdate();
+
+    expect(result.current.unavailableReason).toBe('plugin_disabled');
+    expect(result.current.notFound).toBe(false);
+  });
+
+  it('reports an unexpected failure as an error', async () => {
+    mockHttp.get.mockRejectedValue({ body: { message: 'cluster is on fire' } });
+
+    const { result, waitForNextUpdate } = renderHook(() => useLtrModelView(mockHttp, 'my_model'));
+    await waitForNextUpdate();
+
+    expect(result.current.error).toBe('cluster is on fire');
+  });
+});

--- a/public/components/ltr_model/components/ltr_feature_table.tsx
+++ b/public/components/ltr_model/components/ltr_feature_table.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { EuiBasicTable, EuiCode, EuiCodeBlock, EuiText } from '@elastic/eui';
+import { LtrFeature } from '../types';
+
+interface LtrFeatureTableProps {
+  features: LtrFeature[];
+}
+
+/**
+ * The feature set a model was built from. Templates are shown in full rather than
+ * summarized — knowing which query a feature actually runs is the reason to open this view.
+ */
+export const LtrFeatureTable: React.FC<LtrFeatureTableProps> = ({ features }) => {
+  if (!features.length) {
+    return <EuiText size="s">This model&apos;s feature set has no features.</EuiText>;
+  }
+
+  const columns = [
+    {
+      field: 'name',
+      name: 'Feature',
+      width: '25%',
+      render: (name: string) => <EuiText size="s">{name}</EuiText>,
+    },
+    {
+      field: 'params',
+      name: 'Parameters',
+      width: '20%',
+      render: (params: string[]) =>
+        params.length ? (
+          <EuiText size="s">
+            {params.map((param) => (
+              <EuiCode key={param}>{param}</EuiCode>
+            ))}
+          </EuiText>
+        ) : (
+          <EuiText size="s">&mdash;</EuiText>
+        ),
+    },
+    {
+      field: 'template',
+      name: 'Template',
+      render: (template: any) => (
+        <EuiCodeBlock language="json" fontSize="s" paddingSize="s" isCopyable={true}>
+          {JSON.stringify(template, null, 2)}
+        </EuiCodeBlock>
+      ),
+    },
+  ];
+
+  return (
+    <EuiBasicTable
+      items={features}
+      columns={columns}
+      tableLayout="auto"
+      data-test-subj="ltrFeatureTable"
+    />
+  );
+};

--- a/public/components/ltr_model/components/ltr_model_definition.tsx
+++ b/public/components/ltr_model/components/ltr_model_definition.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { EuiCodeBlock, EuiText } from '@elastic/eui';
+
+/**
+ * The LTR store writes a model definition either as a raw string (RankLib) or as embedded
+ * JSON (linear, XGBoost), so the detail view has to render both without mangling either.
+ * A string that happens to hold JSON is pretty-printed; anything else is shown verbatim.
+ */
+export const formatDefinition = (definition: any): { body: string; language: 'json' | 'text' } => {
+  if (definition === null || definition === undefined) {
+    return { body: '', language: 'text' };
+  }
+
+  if (typeof definition === 'string') {
+    try {
+      const parsed = JSON.parse(definition);
+      if (parsed !== null && typeof parsed === 'object') {
+        return { body: JSON.stringify(parsed, null, 2), language: 'json' };
+      }
+    } catch (e) {
+      // Not JSON — a RankLib definition, which must be shown exactly as stored.
+    }
+    return { body: definition, language: 'text' };
+  }
+
+  return { body: JSON.stringify(definition, null, 2), language: 'json' };
+};
+
+interface LtrModelDefinitionProps {
+  definition: any;
+}
+
+export const LtrModelDefinition: React.FC<LtrModelDefinitionProps> = ({ definition }) => {
+  const { body, language } = formatDefinition(definition);
+
+  if (!body) {
+    return <EuiText size="s">This model has no stored definition.</EuiText>;
+  }
+
+  return (
+    // No overflowHeight: the definition is the point of this view, so it is never truncated.
+    <EuiCodeBlock
+      language={language}
+      fontSize="m"
+      paddingSize="m"
+      isCopyable={true}
+      whiteSpace="pre"
+      data-test-subj="ltrModelDefinition"
+    >
+      {body}
+    </EuiCodeBlock>
+  );
+};

--- a/public/components/ltr_model/components/ltr_model_table.tsx
+++ b/public/components/ltr_model/components/ltr_model_table.tsx
@@ -1,0 +1,95 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { EuiBadge, EuiButtonEmpty, EuiText } from '@elastic/eui';
+import { RouteComponentProps } from 'react-router-dom';
+import {
+  reactRouterNavigate,
+  TableListView,
+} from '../../../../../../src/plugins/opensearch_dashboards_react/public';
+import { Routes } from '../../../../common';
+import { LtrModelListItem } from '../types';
+
+interface LtrModelTableProps {
+  isLoading: boolean;
+  findItems: (search: any) => Promise<{ total: number; hits: LtrModelListItem[] }>;
+  history: RouteComponentProps['history'];
+}
+
+/** `model/xgboost+json` reads better in a table as `xgboost+json`. */
+export const shortModelType = (modelType: string): string =>
+  modelType?.startsWith('model/') ? modelType.slice('model/'.length) : modelType;
+
+export const LtrModelTable: React.FC<LtrModelTableProps> = ({ isLoading, findItems, history }) => {
+  const tableColumns = [
+    {
+      field: 'name',
+      name: 'Name',
+      dataType: 'string',
+      sortable: true,
+      // Model names are unique per store, so the name is the detail view's identifier.
+      render: (name: string) => (
+        <EuiButtonEmpty
+          size="xs"
+          {...reactRouterNavigate(
+            history,
+            `${Routes.LtrModelViewPrefix}/${encodeURIComponent(name)}`
+          )}
+        >
+          {name}
+        </EuiButtonEmpty>
+      ),
+    },
+    {
+      field: 'featureSetName',
+      name: 'Feature Set',
+      dataType: 'string',
+      sortable: true,
+      render: (featureSetName: string) => <EuiText size="s">{featureSetName}</EuiText>,
+    },
+    {
+      field: 'modelType',
+      name: 'Type',
+      dataType: 'string',
+      sortable: true,
+      render: (modelType: string) =>
+        modelType ? <EuiBadge color="hollow">{shortModelType(modelType)}</EuiBadge> : null,
+    },
+    {
+      field: 'featureCount',
+      name: 'Features',
+      dataType: 'number',
+      width: '15%',
+      sortable: true,
+      render: (featureCount: number) => <EuiText size="s">{featureCount}</EuiText>,
+    },
+  ];
+
+  return (
+    <TableListView
+      headingId="ltrModelListingHeading"
+      entityName="Model"
+      entityNamePlural="Models"
+      tableColumns={tableColumns}
+      findItems={findItems}
+      loading={isLoading}
+      initialPageSize={10}
+      search={{
+        box: {
+          incremental: true,
+          placeholder: 'Search models...',
+          schema: true,
+        },
+      }}
+      sorting={{
+        sort: {
+          field: 'name',
+          direction: 'asc',
+        },
+      }}
+    />
+  );
+};

--- a/public/components/ltr_model/hooks/use_ltr_model_list.ts
+++ b/public/components/ltr_model/hooks/use_ltr_model_list.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useState } from 'react';
+import { CoreStart } from '../../../../../../src/core/public';
+import { LTR_MODEL_FETCH_SIZE, ServiceEndpoints } from '../../../../common';
+import { LtrModelListItem, LtrUnavailableReason } from '../types';
+
+/**
+ * `GET /_ltr/_model` returns a raw OpenSearch search response rather than the flat list the
+ * neighbouring Search Relevance resources return, so entries are unwrapped from
+ * `hits.hits[]._source`.
+ */
+export const mapLtrModelFields = (hit: any): LtrModelListItem => {
+  const source = hit?._source ?? {};
+  const featureSet = source.model?.feature_set ?? {};
+  return {
+    name: source.name,
+    featureSetName: featureSet.name ?? '',
+    modelType: source.model?.model?.type ?? '',
+    featureCount: Array.isArray(featureSet.features) ? featureSet.features.length : 0,
+  };
+};
+
+export const useLtrModelList = (http: CoreStart['http']) => {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [unavailableReason, setUnavailableReason] = useState<LtrUnavailableReason | null>(null);
+  // Set when the store holds more models than a single fetch returned, so the listing can say
+  // so rather than silently showing a partial registry.
+  const [truncatedTotal, setTruncatedTotal] = useState<number | null>(null);
+
+  const findLtrModels = async (search?: string) => {
+    setIsLoading(true);
+    setError(null);
+    setUnavailableReason(null);
+    setTruncatedTotal(null);
+    try {
+      const response = await http.get(ServiceEndpoints.LtrModels, {
+        query: { size: LTR_MODEL_FETCH_SIZE },
+      });
+
+      const hits = response?.hits?.hits ?? [];
+      const list = hits.map(mapLtrModelFields);
+
+      // `hits.total` is an object on a normal response but a bare number when the cluster
+      // runs with `rest_total_hits_as_int`; reading only `.value` would miss truncation there.
+      const rawTotal = response?.hits?.total;
+      const total = (typeof rawTotal === 'number' ? rawTotal : rawTotal?.value) ?? list.length;
+      if (total > list.length) {
+        setTruncatedTotal(total);
+      }
+
+      const filteredList = search
+        ? list.filter((item: LtrModelListItem) =>
+            item.name?.toLowerCase().includes(search.toLowerCase())
+          )
+        : list;
+
+      return {
+        total: filteredList.length,
+        hits: filteredList,
+      };
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error('Failed to load LTR models', err);
+      const reason = err?.body?.attributes?.ltrErrorType as LtrUnavailableReason | undefined;
+      if (reason) {
+        // Not an error the user needs to debug — the registry just has nothing to show yet.
+        setUnavailableReason(reason);
+      } else {
+        setError(err?.body?.message || 'Failed to load LTR models due to an unknown error.');
+      }
+      return {
+        total: 0,
+        hits: [],
+      };
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return {
+    isLoading,
+    error,
+    unavailableReason,
+    truncatedTotal,
+    findLtrModels,
+    setError,
+  };
+};

--- a/public/components/ltr_model/hooks/use_ltr_model_view.ts
+++ b/public/components/ltr_model/hooks/use_ltr_model_view.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { CoreStart } from '../../../../../../src/core/public';
+import { ServiceEndpoints } from '../../../../common';
+import { LtrFeature, LtrModelDetail, LtrUnavailableReason } from '../types';
+import { mapLtrModelFields } from './use_ltr_model_list';
+
+const mapFeature = (feature: any): LtrFeature => ({
+  name: feature?.name ?? '',
+  params: Array.isArray(feature?.params) ? feature.params : [],
+  templateLanguage: feature?.template_language ?? '',
+  template: feature?.template,
+});
+
+/**
+ * `GET /_ltr/_model/{name}` returns a document response, so the model itself is under
+ * `_source` exactly as it is in a listing hit — the listing mapper is reused for the shared
+ * fields.
+ */
+export const mapLtrModelDetail = (response: any): LtrModelDetail => {
+  const source = response?._source ?? {};
+  const features = source.model?.feature_set?.features;
+  return {
+    ...mapLtrModelFields(response),
+    features: Array.isArray(features) ? features.map(mapFeature) : [],
+    definition: source.model?.model?.definition,
+  };
+};
+
+export const useLtrModelView = (http: CoreStart['http'], name: string) => {
+  const [model, setModel] = useState<LtrModelDetail | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [notFound, setNotFound] = useState(false);
+  const [unavailableReason, setUnavailableReason] = useState<LtrUnavailableReason | null>(null);
+
+  const fetchModel = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    setNotFound(false);
+    setUnavailableReason(null);
+    try {
+      const response = await http.get(`${ServiceEndpoints.LtrModels}/${encodeURIComponent(name)}`);
+      setModel(mapLtrModelDetail(response));
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error('Failed to load LTR model', err);
+      setModel(null);
+      const reason = err?.body?.attributes?.ltrErrorType;
+      if (reason === 'model_not_found') {
+        setNotFound(true);
+      } else if (reason) {
+        setUnavailableReason(reason as LtrUnavailableReason);
+      } else {
+        setError(err?.body?.message || 'Failed to load the model due to an unknown error.');
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }, [http, name]);
+
+  useEffect(() => {
+    fetchModel();
+  }, [fetchModel]);
+
+  return { model, isLoading, error, notFound, unavailableReason };
+};

--- a/public/components/ltr_model/index.ts
+++ b/public/components/ltr_model/index.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { LtrModelListingWithRoute as LtrModelListing } from './views/ltr_model_listing';
+export { LtrModelView } from './views/ltr_model_view';
+export { LtrModelTable } from './components/ltr_model_table';
+export { LtrModelDefinition, formatDefinition } from './components/ltr_model_definition';
+export { LtrFeatureTable } from './components/ltr_feature_table';
+export { useLtrModelList } from './hooks/use_ltr_model_list';
+export { useLtrModelView } from './hooks/use_ltr_model_view';
+export * from './types';

--- a/public/components/ltr_model/types.ts
+++ b/public/components/ltr_model/types.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * A registry entry as it exists in the LTR feature store today.
+ *
+ * The store's index mapping is `dynamic: strict` and holds only name, type, feature,
+ * featureset, and model — there is no creation timestamp to show, so the registry does not
+ * claim one. Versioning and lineage are likewise absent by design until the training and
+ * A/B stages put real requirements on the schema.
+ */
+export interface LtrModelListItem {
+  /** Store document name; unique per store and immutable once created. */
+  name: string;
+  /** The feature set the model was built from. */
+  featureSetName: string;
+  /** Parser type, e.g. model/ranklib, model/linear, model/xgboost+json. */
+  modelType: string;
+  /** Number of features in the attached feature set. */
+  featureCount: number;
+}
+
+/** Why a listing came back empty, when the reason is actionable. */
+export type LtrUnavailableReason = 'store_not_found' | 'plugin_disabled' | 'plugin_not_installed';
+
+/** A single feature in the feature set a model was built from. */
+export interface LtrFeature {
+  name: string;
+  params: string[];
+  templateLanguage: string;
+  template: any;
+}
+
+/**
+ * A model as shown on the detail view.
+ *
+ * `definition` is deliberately left as `any`: the LTR store writes it either as a raw string
+ * (RankLib) or as embedded JSON (linear, XGBoost), depending on how the model was created.
+ * See StoredLtrModel#toXContent.
+ */
+export interface LtrModelDetail extends LtrModelListItem {
+  features: LtrFeature[];
+  definition: any;
+}

--- a/public/components/ltr_model/unavailable_copy.ts
+++ b/public/components/ltr_model/unavailable_copy.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { LtrUnavailableReason } from './types';
+
+/**
+ * The registry is only as available as the LTR plugin behind it, and this plugin ships
+ * independently of it. Each reason gets its own next step instead of a generic failure.
+ */
+export const LTR_UNAVAILABLE_COPY: Record<LtrUnavailableReason, { title: string; body: string }> = {
+  store_not_found: {
+    title: 'No feature store found',
+    body:
+      'The Learning to Rank plugin is running, but no feature store exists yet. Create one with ' +
+      'PUT _ltr, then add a feature set and a model.',
+  },
+  plugin_disabled: {
+    title: 'Learning to Rank is disabled',
+    body:
+      'The Learning to Rank plugin is installed but turned off. Set ltr.plugin.enabled to true in ' +
+      'the cluster settings to use the model registry.',
+  },
+  plugin_not_installed: {
+    title: 'Learning to Rank is not installed',
+    body:
+      'This cluster has no Learning to Rank plugin, so there are no models to show. Install ' +
+      'opensearch-learning-to-rank-base to use the model registry.',
+  },
+};

--- a/public/components/ltr_model/views/ltr_model_listing.tsx
+++ b/public/components/ltr_model/views/ltr_model_listing.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { EuiCallOut, EuiFlexItem, EuiPageHeader, EuiPageTemplate, EuiSpacer } from '@elastic/eui';
+import { RouteComponentProps, withRouter } from 'react-router-dom';
+import { CoreStart } from '../../../../../../src/core/public';
+import { LTR_MODEL_FETCH_SIZE } from '../../../../common';
+import { LtrModelTable } from '../components/ltr_model_table';
+import { useLtrModelList } from '../hooks/use_ltr_model_list';
+import { LTR_UNAVAILABLE_COPY } from '../unavailable_copy';
+
+interface LtrModelListingProps extends RouteComponentProps {
+  http: CoreStart['http'];
+}
+
+export const LtrModelListing: React.FC<LtrModelListingProps> = ({ http, history }) => {
+  const { isLoading, error, unavailableReason, truncatedTotal, findLtrModels } = useLtrModelList(
+    http
+  );
+
+  const renderBody = () => {
+    if (error) {
+      return (
+        <EuiCallOut title="Error" color="danger">
+          <p>{error}</p>
+        </EuiCallOut>
+      );
+    }
+
+    if (unavailableReason) {
+      const { title, body } = LTR_UNAVAILABLE_COPY[unavailableReason];
+      return (
+        <EuiCallOut title={title} color="primary" iconType="iInCircle">
+          <p>{body}</p>
+        </EuiCallOut>
+      );
+    }
+
+    return (
+      <>
+        {truncatedTotal !== null && (
+          <>
+            <EuiCallOut title="Showing part of the registry" color="warning" iconType="alert">
+              <p>
+                This store holds {truncatedTotal} models. Showing the first {LTR_MODEL_FETCH_SIZE}.
+              </p>
+            </EuiCallOut>
+            <EuiSpacer size="m" />
+          </>
+        )}
+        <LtrModelTable isLoading={isLoading} findItems={findLtrModels} history={history} />
+      </>
+    );
+  };
+
+  return (
+    <EuiPageTemplate paddingSize="l" restrictWidth="100%">
+      <EuiPageHeader
+        pageTitle="LTR Models"
+        description="Learning to Rank models stored in this cluster's feature store."
+      />
+      <EuiFlexItem>{renderBody()}</EuiFlexItem>
+    </EuiPageTemplate>
+  );
+};
+
+export const LtrModelListingWithRoute = withRouter(LtrModelListing);

--- a/public/components/ltr_model/views/ltr_model_view.tsx
+++ b/public/components/ltr_model/views/ltr_model_view.tsx
@@ -1,0 +1,123 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import {
+  EuiBadge,
+  EuiCallOut,
+  EuiDescriptionList,
+  EuiDescriptionListDescription,
+  EuiDescriptionListTitle,
+  EuiLoadingSpinner,
+  EuiPageHeader,
+  EuiPageTemplate,
+  EuiPanel,
+  EuiSpacer,
+  EuiTitle,
+} from '@elastic/eui';
+import { CoreStart } from '../../../../../../src/core/public';
+import { LtrFeatureTable } from '../components/ltr_feature_table';
+import { LtrModelDefinition } from '../components/ltr_model_definition';
+import { shortModelType } from '../components/ltr_model_table';
+import { useLtrModelView } from '../hooks/use_ltr_model_view';
+import { LTR_UNAVAILABLE_COPY } from '../unavailable_copy';
+
+interface LtrModelViewProps {
+  http: CoreStart['http'];
+  id: string;
+}
+
+export const LtrModelView: React.FC<LtrModelViewProps> = ({ http, id }) => {
+  const { model, isLoading, error, notFound, unavailableReason } = useLtrModelView(http, id);
+
+  const renderBody = () => {
+    if (isLoading) {
+      return <EuiLoadingSpinner size="xl" data-test-subj="ltrModelViewLoading" />;
+    }
+
+    if (notFound) {
+      return (
+        <EuiCallOut title="Model not found" color="warning" iconType="alert">
+          <p>
+            No model named <strong>{id}</strong> exists in the feature store. It may have been
+            deleted.
+          </p>
+        </EuiCallOut>
+      );
+    }
+
+    if (unavailableReason) {
+      const { title, body } = LTR_UNAVAILABLE_COPY[unavailableReason];
+      return (
+        <EuiCallOut title={title} color="primary" iconType="iInCircle">
+          <p>{body}</p>
+        </EuiCallOut>
+      );
+    }
+
+    if (error || !model) {
+      return (
+        <EuiCallOut title="Error" color="danger">
+          <p>{error || 'Failed to load the model.'}</p>
+        </EuiCallOut>
+      );
+    }
+
+    return (
+      <>
+        <EuiPanel>
+          <EuiDescriptionList type="column" compressed>
+            <EuiDescriptionListTitle>Feature Set</EuiDescriptionListTitle>
+            <EuiDescriptionListDescription>
+              {model.featureSetName || <>&mdash;</>}
+            </EuiDescriptionListDescription>
+
+            <EuiDescriptionListTitle>Model Type</EuiDescriptionListTitle>
+            <EuiDescriptionListDescription>
+              {model.modelType ? (
+                <EuiBadge color="hollow">{shortModelType(model.modelType)}</EuiBadge>
+              ) : (
+                <>&mdash;</>
+              )}
+            </EuiDescriptionListDescription>
+
+            <EuiDescriptionListTitle>Features</EuiDescriptionListTitle>
+            <EuiDescriptionListDescription>{model.featureCount}</EuiDescriptionListDescription>
+          </EuiDescriptionList>
+        </EuiPanel>
+
+        <EuiSpacer size="l" />
+
+        <EuiPanel>
+          <EuiTitle size="s">
+            <h2>Feature Set</h2>
+          </EuiTitle>
+          <EuiSpacer size="m" />
+          <LtrFeatureTable features={model.features} />
+        </EuiPanel>
+
+        <EuiSpacer size="l" />
+
+        <EuiPanel>
+          <EuiTitle size="s">
+            <h2>Model Definition</h2>
+          </EuiTitle>
+          <EuiSpacer size="m" />
+          <LtrModelDefinition definition={model.definition} />
+        </EuiPanel>
+      </>
+    );
+  };
+
+  return (
+    <EuiPageTemplate paddingSize="l" restrictWidth="100%">
+      <EuiPageHeader
+        pageTitle={id}
+        description="A Learning to Rank model stored in this cluster's feature store."
+      />
+      {renderBody()}
+    </EuiPageTemplate>
+  );
+};

--- a/server/plugin.test.ts
+++ b/server/plugin.test.ts
@@ -9,6 +9,7 @@ import { SearchRelevancePlugin } from './plugin';
 jest.mock('./routes', () => ({
   defineRoutes: jest.fn(),
   registerSearchRelevanceRoutes: jest.fn(),
+  registerLtrRoutes: jest.fn(),
 }));
 
 jest.mock('./routes/ml_route_service', () => ({

--- a/server/plugin.ts
+++ b/server/plugin.ts
@@ -15,7 +15,7 @@ import {
   Plugin,
   PluginInitializerContext,
 } from '../../../src/core/server';
-import { defineRoutes, registerSearchRelevanceRoutes } from './routes';
+import { defineRoutes, registerLtrRoutes, registerSearchRelevanceRoutes } from './routes';
 
 import { DataSourcePluginSetup } from '../../../src/plugins/data_source/server/types';
 import { DataSourceManagementPlugin } from '../../../src/plugins/data_source_management/public/plugin';
@@ -134,6 +134,7 @@ export class SearchRelevancePlugin
     // Register server side APIs
     defineRoutes(router, core.opensearch, dataSourceEnabled);
     registerSearchRelevanceRoutes(router, dataSourceEnabled);
+    registerLtrRoutes(router);
     registerMLRoutes(router, dataSourceEnabled);
 
     // Add UBI sample data if home plugin is available

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -17,3 +17,4 @@ export function defineRoutes(
 }
 
 export * from './search_relevance_route_service';
+export * from './ltr_route_service';

--- a/server/routes/ltr_route_service.test.ts
+++ b/server/routes/ltr_route_service.test.ts
@@ -1,0 +1,122 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ltrError, registerLtrRoutes, storePath } from './ltr_route_service';
+
+describe('storePath', () => {
+  it('reads the default store when no store is named', () => {
+    expect(storePath('/_ltr/_model')).toBe('/_ltr/_model');
+  });
+
+  it('qualifies the path with a named store', () => {
+    expect(storePath('/_ltr/_model', 'my_store')).toBe('/_ltr/my_store/_model');
+  });
+
+  it('keeps the deeper feature set paths intact', () => {
+    expect(storePath('/_ltr/_featureset', 'my_store')).toBe('/_ltr/my_store/_featureset');
+    expect(storePath('/_ltr/_featureset/movies', 'my_store')).toBe(
+      '/_ltr/my_store/_featureset/movies'
+    );
+  });
+
+  it('encodes a store name so it cannot traverse out of the _ltr namespace', () => {
+    expect(storePath('/_ltr/_model', '../../_cluster/settings')).toBe(
+      '/_ltr/..%2F..%2F_cluster%2Fsettings/_model'
+    );
+  });
+});
+
+describe('ltrError', () => {
+  const response = { customError: jest.fn((arg) => arg) } as any;
+
+  beforeEach(() => jest.clearAllMocks());
+
+  const attributesOf = (err: any) => ltrError(response, err).body.attributes;
+
+  // Bodies below are verbatim from OpenSearch 3.3.0 / opensearch-ltr 3.3.0.0.
+  it('classifies a missing model separately from a missing store', () => {
+    const err = {
+      statusCode: 404,
+      body: { _index: '.ltrstore', _id: 'model-ghost', found: false },
+    };
+    expect(attributesOf(err).ltrErrorType).toBe('model_not_found');
+  });
+
+  it('classifies a missing feature store', () => {
+    const err = {
+      statusCode: 404,
+      body: {
+        error: {
+          type: 'index_not_found_exception',
+          reason: 'no such index [.ltrstore_nosuchstore]',
+        },
+      },
+    };
+    expect(attributesOf(err).ltrErrorType).toBe('store_not_found');
+  });
+
+  // A disabled plugin is an illegal_state_exception, which surfaces as 500 rather than the
+  // 4xx the other cases use -- hence classification on the body rather than the status.
+  it('classifies a disabled LTR plugin despite its 500 status', () => {
+    const err = {
+      statusCode: 500,
+      body: {
+        error: {
+          type: 'illegal_state_exception',
+          reason: 'LTR plugin is disabled. To enable, update ltr.plugin.enabled to true',
+        },
+        status: 500,
+      },
+    };
+    expect(attributesOf(err).ltrErrorType).toBe('plugin_disabled');
+  });
+
+  // An unknown route returns error as a bare string, not an object.
+  it('classifies an uninstalled LTR plugin from a string error body', () => {
+    const err = {
+      statusCode: 400,
+      body: { error: 'no handler found for uri [/_ltr/_model] and method [GET]' },
+    };
+    expect(attributesOf(err).ltrErrorType).toBe('plugin_not_installed');
+  });
+
+  it('leaves an unrecognized failure unclassified', () => {
+    const err = { statusCode: 500, body: { error: { reason: 'circuit_breaking_exception' } } };
+    const attributes = attributesOf(err);
+    expect(attributes.ltrErrorType).toBeUndefined();
+    expect(attributes.error).toBe('circuit_breaking_exception');
+  });
+
+  it('falls back to the raw message when there is no structured error body', () => {
+    expect(ltrError(response, { message: 'socket hang up' }).body.message).toBe('socket hang up');
+  });
+
+  it('passes a real error status through', () => {
+    expect(ltrError(response, { statusCode: 404, body: { found: false } }).statusCode).toBe(404);
+  });
+
+  // `response.customError` throws outside 400-599, which would replace the classified error
+  // with an unhandled exception.
+  it.each([[0], [200], [302], [600], [undefined], ['503']])(
+    'substitutes 500 for an out-of-range statusCode %p',
+    (statusCode) => {
+      expect(ltrError(response, { statusCode, message: 'transport failure' }).statusCode).toBe(500);
+    }
+  );
+});
+
+describe('registerLtrRoutes', () => {
+  it('registers the listing and detail routes', () => {
+    const router = { get: jest.fn() } as any;
+
+    registerLtrRoutes(router);
+
+    expect(router.get).toHaveBeenCalledTimes(2);
+    expect(router.get.mock.calls.map((call: any[]) => call[0].path)).toEqual([
+      '/api/relevancy/ltr/models',
+      '/api/relevancy/ltr/models/{name}',
+    ]);
+  });
+});

--- a/server/routes/ltr_route_service.ts
+++ b/server/routes/ltr_route_service.ts
@@ -1,0 +1,172 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { schema } from '@osd/config-schema';
+import {
+  IOpenSearchDashboardsResponse,
+  IRouter,
+  OpenSearchDashboardsRequest,
+  OpenSearchDashboardsResponseFactory,
+  RequestHandlerContext,
+} from '../../../../src/core/server';
+import { LtrBackendEndpoints, ServiceEndpoints } from '../../common';
+
+/**
+ * Routes backing the Learning to Rank model registry.
+ *
+ * These proxy to the LTR plugin's own `_ltr/*` namespace rather than
+ * `_plugins/_search_relevance`. The `.ltrstore*` indices are registered system indices, so
+ * the plugin's REST endpoints are the only supported way to read them.
+ */
+export function registerLtrRoutes(router: IRouter): void {
+  router.get(
+    {
+      path: ServiceEndpoints.LtrModels,
+      validate: {
+        query: schema.object({
+          size: schema.maybe(schema.number({ min: 1 })),
+          from: schema.maybe(schema.number({ min: 0 })),
+          prefix: schema.maybe(schema.string()),
+          store: schema.maybe(schema.string()),
+        }),
+      },
+    },
+    listModels
+  );
+
+  router.get(
+    {
+      path: `${ServiceEndpoints.LtrModels}/{name}`,
+      validate: {
+        params: schema.object({
+          name: schema.string(),
+        }),
+        query: schema.object({
+          store: schema.maybe(schema.string()),
+        }),
+      },
+    },
+    getModel
+  );
+}
+
+const listModels = async (
+  context: RequestHandlerContext,
+  request: OpenSearchDashboardsRequest,
+  response: OpenSearchDashboardsResponseFactory
+): Promise<IOpenSearchDashboardsResponse<any>> => {
+  const { size, from, prefix, store } = request.query as {
+    size?: number;
+    from?: number;
+    prefix?: string;
+    store?: string;
+  };
+
+  try {
+    const caller = context.core.opensearch.legacy.client.callAsCurrentUser;
+    const result = await caller('transport.request', {
+      method: 'GET',
+      path: storePath(LtrBackendEndpoints.Models, store),
+      query: {
+        ...(size !== undefined ? { size } : {}),
+        ...(from !== undefined ? { from } : {}),
+        ...(prefix ? { prefix } : {}),
+      },
+    });
+
+    return response.ok({ body: result });
+  } catch (err) {
+    return ltrError(response, err);
+  }
+};
+
+const getModel = async (
+  context: RequestHandlerContext,
+  request: OpenSearchDashboardsRequest,
+  response: OpenSearchDashboardsResponseFactory
+): Promise<IOpenSearchDashboardsResponse<any>> => {
+  const { name } = request.params as { name: string };
+  const { store } = request.query as { store?: string };
+
+  try {
+    const caller = context.core.opensearch.legacy.client.callAsCurrentUser;
+    const result = await caller('transport.request', {
+      method: 'GET',
+      path: `${storePath(LtrBackendEndpoints.Models, store)}/${encodeURIComponent(name)}`,
+    });
+
+    return response.ok({ body: result });
+  } catch (err) {
+    return ltrError(response, err);
+  }
+};
+
+/**
+ * `_ltr/_model` reads the default store; `_ltr/{store}/_model` reads a named one. v1 always
+ * uses the default store, but the parameter is threaded through so a store selector is a UI
+ * change rather than a refactor.
+ *
+ * The store name is encoded: it arrives as an unconstrained query parameter, and left raw a
+ * value like `../../_cluster/settings` would traverse out of the `_ltr` namespace and address
+ * an unrelated API on the same cluster.
+ */
+export const storePath = (endpoint: string, store?: string): string => {
+  if (!store) {
+    return endpoint;
+  }
+  const [, ...rest] = endpoint.split('/').filter(Boolean);
+  return `/_ltr/${encodeURIComponent(store)}/${rest.join('/')}`;
+};
+
+/**
+ * Translates the two failure modes a fresh cluster actually hits into something the UI can
+ * act on, rather than surfacing a raw transport error.
+ */
+export const ltrError = (response: OpenSearchDashboardsResponseFactory, err: any) => {
+  // eslint-disable-next-line no-console
+  console.error('Failed to call Learning to Rank APIs', err);
+
+  // `response.customError` throws for anything outside 400-599, so an odd transport
+  // statusCode would turn a classified LTR error into an unhandled exception.
+  const rawStatusCode = err.statusCode;
+  const statusCode =
+    typeof rawStatusCode === 'number' && rawStatusCode >= 400 && rawStatusCode < 600
+      ? rawStatusCode
+      : 500;
+  const rawError = err.body?.error;
+  const reason: string =
+    (typeof rawError === 'object' && (rawError.reason || rawError.type)) ||
+    (typeof rawError === 'string' && rawError) ||
+    err.message ||
+    '';
+
+  // Classified on the response body alone, deliberately not on the status code. Verified
+  // against OpenSearch 3.3.0 with opensearch-ltr 3.3.0.0, these do not share a convention:
+  // a missing model and a missing store are both 404, an unknown route is 400, but a
+  // disabled plugin surfaces an illegal_state_exception as 500.
+  let ltrErrorType: string | undefined;
+  if (err.body?.found === false) {
+    // The store exists; this particular model name does not.
+    ltrErrorType = 'model_not_found';
+  } else if (/index_not_found|no such index/i.test(reason)) {
+    // LTR is installed but no feature store has been created yet.
+    ltrErrorType = 'store_not_found';
+  } else if (/LTR plugin is disabled/i.test(reason)) {
+    ltrErrorType = 'plugin_disabled';
+  } else if (/no handler found/i.test(reason)) {
+    ltrErrorType = 'plugin_not_installed';
+  }
+
+  return response.customError({
+    statusCode,
+    body: {
+      message: reason || 'Failed to call Learning to Rank APIs',
+      attributes: {
+        error: reason,
+        ltrErrorType,
+      },
+    },
+  });
+};


### PR DESCRIPTION
### Description

List and detail views for models in the LTR feature store, proxied through the plugin's `_ltr/*` endpoints. Read-only. No backend change and no new REST API.

Design doc and rationale: opensearch-project/search-relevance#582.

Shows an explicit "LTR is not installed" state when `GET /_ltr` fails. v1 uses the default store; the store parameter is threaded through the service layer for a later selector.

### Issues Resolved

None.

### Check List

- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`