### PR TITLE
Add LTR model upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 - Add "Reuse Existing Judgments" option in LLM judgment Advanced Settings to reuse ratings from up to 5 existing judgments, and add a retry action for failed documents in the judgment listing ([#525](https://github.com/opensearch-project/dashboards-search-relevance/issues/525))
 - Allow ratings on a completed LLM judgment to be edited in place, including assigning ratings to previously failed documents ([#525](https://github.com/opensearch-project/dashboards-search-relevance/issues/525))
+- Add a read-only Learning to Rank model registry listing ([#943](https://github.com/opensearch-project/dashboards-search-relevance/pull/943))
 
 ### Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add "Reuse Existing Judgments" option in LLM judgment Advanced Settings to reuse ratings from up to 5 existing judgments, and add a retry action for failed documents in the judgment listing ([#525](https://github.com/opensearch-project/dashboards-search-relevance/issues/525))
 - Allow ratings on a completed LLM judgment to be edited in place, including assigning ratings to previously failed documents ([#525](https://github.com/opensearch-project/dashboards-search-relevance/issues/525))
 - Add a read-only Learning to Rank model registry listing ([#943](https://github.com/opensearch-project/dashboards-search-relevance/pull/943))
+- Add a Learning to Rank model upload flow ([#944](https://github.com/opensearch-project/dashboards-search-relevance/pull/944))
 
 ### Enhancements
 

--- a/common/index.ts
+++ b/common/index.ts
@@ -29,6 +29,9 @@ export const ServiceEndpoints = Object.freeze({
   Experiments: `${SEARCH_RELEVANCE_WORKBENCH_BASE_PATH}/experiments`,
   ScheduledExperiments: `${SEARCH_RELEVANCE_WORKBENCH_BASE_PATH}/experiments/schedule`,
   ValidatePrompt: `${SEARCH_RELEVANCE_WORKBENCH_BASE_PATH}/judgments/validate_prompt`,
+
+  // Learning to Rank node APIs
+  LtrModels: `${SEARCH_RELEVANCE_WORKBENCH_BASE_PATH}/ltr/models`,
 } as const);
 
 const SEARCH_RELEVANCE_PLUGIN_BASE_PATH = '/_plugins/_search_relevance';
@@ -39,6 +42,18 @@ export const BackendEndpoints = Object.freeze({
   Experiments: `${SEARCH_RELEVANCE_PLUGIN_BASE_PATH}/experiments`,
   ScheduledExperiments: `${SEARCH_RELEVANCE_PLUGIN_BASE_PATH}/experiments/schedule`,
 } as const);
+
+// The Learning to Rank plugin owns its own REST namespace, separate from
+// _plugins/_search_relevance. The `.ltrstore*` indices are system indices, so these
+// plugin endpoints are the only supported way to read them.
+const LTR_PLUGIN_BASE_PATH = '/_ltr';
+export const LtrBackendEndpoints = Object.freeze({
+  Models: `${LTR_PLUGIN_BASE_PATH}/_model`,
+} as const);
+
+// `GET /_ltr/_model` defaults to size=20, which silently truncates the listing. We always
+// request explicitly and warn the user when the store holds more than we fetched.
+export const LTR_MODEL_FETCH_SIZE = 1000;
 
 const ML_COMMON_PLUGIN_BASE_PATH = '_plugins/_ml';
 export const ML_MODEL_ROUTE_PREFIX = `${ML_COMMON_PLUGIN_BASE_PATH}/models`;
@@ -81,6 +96,9 @@ export enum Routes {
   JudgmentView = '/judgment/view/:entityId',
   JudgmentViewPrefix = '/judgment/view',
   JudgmentCreate = '/judgment/create',
+  LtrModelListing = '/ltrModel',
+  LtrModelView = '/ltrModel/view/:entityId',
+  LtrModelViewPrefix = '/ltrModel/view',
 }
 
 export enum SavedObjectIds {

--- a/common/index.ts
+++ b/common/index.ts
@@ -32,6 +32,7 @@ export const ServiceEndpoints = Object.freeze({
 
   // Learning to Rank node APIs
   LtrModels: `${SEARCH_RELEVANCE_WORKBENCH_BASE_PATH}/ltr/models`,
+  LtrFeatureSets: `${SEARCH_RELEVANCE_WORKBENCH_BASE_PATH}/ltr/feature_sets`,
 } as const);
 
 const SEARCH_RELEVANCE_PLUGIN_BASE_PATH = '/_plugins/_search_relevance';
@@ -49,11 +50,24 @@ export const BackendEndpoints = Object.freeze({
 const LTR_PLUGIN_BASE_PATH = '/_ltr';
 export const LtrBackendEndpoints = Object.freeze({
   Models: `${LTR_PLUGIN_BASE_PATH}/_model`,
+  FeatureSets: `${LTR_PLUGIN_BASE_PATH}/_featureset`,
 } as const);
+
+/**
+ * A model is created against the feature set it scores, not against the model collection:
+ * `POST _ltr/_featureset/{name}/_createmodel`. The store has no update path -- a second
+ * create under the same name is rejected rather than overwriting.
+ */
+export const ltrCreateModelPath = (featureSetName: string): string =>
+  `${LtrBackendEndpoints.FeatureSets}/${encodeURIComponent(featureSetName)}/_createmodel`;
 
 // `GET /_ltr/_model` defaults to size=20, which silently truncates the listing. We always
 // request explicitly and warn the user when the store holds more than we fetched.
 export const LTR_MODEL_FETCH_SIZE = 1000;
+
+// `GET /_ltr/_featureset` has the same size=20 default, and the upload form's picker is
+// useless if it silently omits the feature set the user wants.
+export const LTR_FEATURE_SET_FETCH_SIZE = 1000;
 
 const ML_COMMON_PLUGIN_BASE_PATH = '_plugins/_ml';
 export const ML_MODEL_ROUTE_PREFIX = `${ML_COMMON_PLUGIN_BASE_PATH}/models`;
@@ -99,6 +113,7 @@ export enum Routes {
   LtrModelListing = '/ltrModel',
   LtrModelView = '/ltrModel/view/:entityId',
   LtrModelViewPrefix = '/ltrModel/view',
+  LtrModelCreate = '/ltrModel/create',
 }
 
 export enum SavedObjectIds {

--- a/public/components/app.tsx
+++ b/public/components/app.tsx
@@ -38,7 +38,7 @@ import {
   SearchConfigurationCreate,
 } from './search_configuration';
 import { JudgmentListing, JudgmentView, JudgmentCreate } from './judgment';
-import { LtrModelListing, LtrModelView } from './ltr_model';
+import { LtrModelListing, LtrModelUpload, LtrModelView } from './ltr_model';
 import { QuerySetView } from './query_set';
 import { QuerySetCreate } from './query_set';
 import { TemplateType, routeToTemplateType } from './experiment/configuration/types';
@@ -336,6 +336,13 @@ const SearchRelevancePage = ({
             render={(props) => {
               const { entityId } = props.match.params;
               return <LtrModelView http={http} id={decodeURIComponent(entityId)} />;
+            }}
+          />
+          <Route
+            path={Routes.LtrModelCreate}
+            exact
+            render={() => {
+              return <LtrModelUpload http={http} notifications={notifications} />;
             }}
           />
           <Route

--- a/public/components/app.tsx
+++ b/public/components/app.tsx
@@ -38,6 +38,7 @@ import {
   SearchConfigurationCreate,
 } from './search_configuration';
 import { JudgmentListing, JudgmentView, JudgmentCreate } from './judgment';
+import { LtrModelListing, LtrModelView } from './ltr_model';
 import { QuerySetView } from './query_set';
 import { QuerySetCreate } from './query_set';
 import { TemplateType, routeToTemplateType } from './experiment/configuration/types';
@@ -61,6 +62,7 @@ enum Navigation {
   QuerySets = 'Query Sets',
   SearchConfigurations = 'Search Configurations',
   Judgments = 'Judgments',
+  LtrModels = 'LTR Models',
 }
 
 interface SearchRelevanceAppDeps {
@@ -201,6 +203,14 @@ const SearchRelevancePage = ({
           },
           isSelected: location.pathname.startsWith(Routes.JudgmentListing),
         },
+        {
+          name: Navigation.LtrModels,
+          id: Navigation.LtrModels,
+          onClick: () => {
+            history.push(Routes.LtrModelListing);
+          },
+          isSelected: location.pathname.startsWith(Routes.LtrModelListing),
+        },
       ],
     },
   ];
@@ -311,6 +321,21 @@ const SearchRelevancePage = ({
             exact
             render={() => {
               return <JudgmentListing http={http} dataSourceId={dataSourceId} />;
+            }}
+          />
+          <Route
+            path={Routes.LtrModelListing}
+            exact
+            render={() => {
+              return <LtrModelListing http={http} />;
+            }}
+          />
+          <Route
+            path={Routes.LtrModelView}
+            exact
+            render={(props) => {
+              const { entityId } = props.match.params;
+              return <LtrModelView http={http} id={decodeURIComponent(entityId)} />;
             }}
           />
           <Route

--- a/public/components/ltr_model/__tests__/definition.test.ts
+++ b/public/components/ltr_model/__tests__/definition.test.ts
@@ -1,0 +1,53 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { isJsonModelType, parseDefinition } from '../utils/definition';
+
+describe('isJsonModelType', () => {
+  it('treats every parser but RankLib as JSON', () => {
+    expect(isJsonModelType('model/linear')).toBe(true);
+    expect(isJsonModelType('model/xgboost+json')).toBe(true);
+    expect(isJsonModelType('model/xgboost+json+raw')).toBe(true);
+    expect(isJsonModelType('model/ranklib')).toBe(false);
+  });
+
+  it('does not claim an unselected type is JSON', () => {
+    expect(isJsonModelType('')).toBe(false);
+  });
+});
+
+describe('parseDefinition', () => {
+  it('rejects an empty definition', () => {
+    expect(parseDefinition('model/linear', '   ').error).toBe('A model definition is required.');
+  });
+
+  it('sends a JSON definition parsed, not as a string', () => {
+    const { value, error } = parseDefinition('model/linear', '{"title_match": 0.4}');
+    expect(error).toBeUndefined();
+    // A string here would round-trip through the store as a quoted blob rather than the
+    // object curl would have written.
+    expect(value).toEqual({ title_match: 0.4 });
+  });
+
+  it('accepts a JSON array, which is what an xgboost dump is', () => {
+    const { value } = parseDefinition('model/xgboost+json', '[{"split": "title_match"}]');
+    expect(value).toEqual([{ split: 'title_match' }]);
+  });
+
+  it('reports invalid JSON against the type that required it', () => {
+    const { value, error } = parseDefinition('model/xgboost+json', '[{"split":');
+    expect(value).toBeUndefined();
+    expect(error).toMatch(/^model\/xgboost\+json definitions must be valid JSON\./);
+  });
+
+  it('passes a RankLib definition through verbatim, whitespace included', () => {
+    const ranklib = '## LambdaMART\n\n<ensemble>\n  <tree id="1" weight="0.1">\n';
+    expect(parseDefinition('model/ranklib', ranklib)).toEqual({ value: ranklib });
+  });
+
+  it('does not turn a RankLib definition that happens to parse into JSON', () => {
+    expect(parseDefinition('model/ranklib', '42')).toEqual({ value: '42' });
+  });
+});

--- a/public/components/ltr_model/__tests__/ltr_model_definition.test.tsx
+++ b/public/components/ltr_model/__tests__/ltr_model_definition.test.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { LtrModelDefinition, formatDefinition } from '../components/ltr_model_definition';
+
+describe('formatDefinition', () => {
+  it('shows a RankLib definition verbatim as text', () => {
+    const ranklib = '## LambdaMART\n## No. of trees = 1\n<ensemble>\n</ensemble>';
+    expect(formatDefinition(ranklib)).toEqual({ body: ranklib, language: 'text' });
+  });
+
+  it('pretty-prints a definition stored as embedded JSON', () => {
+    expect(formatDefinition({ feature1: 1.2 })).toEqual({
+      body: '{\n  "feature1": 1.2\n}',
+      language: 'json',
+    });
+  });
+
+  it('pretty-prints a JSON definition that arrives as a string', () => {
+    expect(formatDefinition('{"feature1":1.2}')).toEqual({
+      body: '{\n  "feature1": 1.2\n}',
+      language: 'json',
+    });
+  });
+
+  it('treats a bare numeric string as text rather than JSON', () => {
+    expect(formatDefinition('42')).toEqual({ body: '42', language: 'text' });
+  });
+
+  it('handles an absent definition', () => {
+    expect(formatDefinition(undefined)).toEqual({ body: '', language: 'text' });
+    expect(formatDefinition(null)).toEqual({ body: '', language: 'text' });
+  });
+});
+
+describe('LtrModelDefinition', () => {
+  it('renders a large definition without truncating it', () => {
+    // 500 trees worth of lines; the whole thing must survive to the DOM.
+    const lines = Array.from({ length: 500 }, (_, i) => `${i}:${i * 1.5}`);
+    const definition = `## LambdaMART\n${lines.join('\n')}`;
+
+    render(<LtrModelDefinition definition={definition} />);
+
+    const block = screen.getByTestId('ltrModelDefinition');
+    expect(block.textContent).toContain('0:0');
+    expect(block.textContent).toContain('499:748.5');
+    expect(block.textContent).toBe(definition);
+  });
+
+  it('explains an empty definition', () => {
+    render(<LtrModelDefinition definition={undefined} />);
+    expect(screen.getByText('This model has no stored definition.')).toBeInTheDocument();
+  });
+});

--- a/public/components/ltr_model/__tests__/ltr_model_listing.test.tsx
+++ b/public/components/ltr_model/__tests__/ltr_model_listing.test.tsx
@@ -4,7 +4,7 @@
  */
 
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { LtrModelListing } from '../views/ltr_model_listing';
 import { useLtrModelList } from '../hooks/use_ltr_model_list';
 
@@ -52,6 +52,15 @@ describe('LtrModelListing', () => {
     expect(screen.getByTestId('table-has-history')).toHaveTextContent('yes');
   });
 
+  it('routes the upload button to the upload form', () => {
+    mockUseLtrModelList.mockReturnValue(hookState() as any);
+
+    render(<LtrModelListing http={mockHttp} {...routeProps} />);
+    fireEvent.click(screen.getByTestId('createLtrModelButton'));
+
+    expect(routeProps.history.push).toHaveBeenCalledWith('/ltrModel/create');
+  });
+
   it('renders an error callout instead of the table when the fetch fails', () => {
     mockUseLtrModelList.mockReturnValue(hookState({ error: 'cluster is on fire' }) as any);
 
@@ -86,6 +95,8 @@ describe('LtrModelListing', () => {
     render(<LtrModelListing http={mockHttp} {...routeProps} />);
 
     expect(screen.getByText('Learning to Rank is not installed')).toBeInTheDocument();
+    // No reachable store means nothing to upload into.
+    expect(screen.queryByTestId('createLtrModelButton')).not.toBeInTheDocument();
   });
 
   it('warns alongside the table when the registry was truncated', () => {

--- a/public/components/ltr_model/__tests__/ltr_model_listing.test.tsx
+++ b/public/components/ltr_model/__tests__/ltr_model_listing.test.tsx
@@ -1,0 +1,100 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { LtrModelListing } from '../views/ltr_model_listing';
+import { useLtrModelList } from '../hooks/use_ltr_model_list';
+
+jest.mock('../hooks/use_ltr_model_list');
+jest.mock('../components/ltr_model_table', () => ({
+  LtrModelTable: ({ isLoading, history }: any) => (
+    <div data-test-subj="ltr-model-table">
+      {isLoading ? 'loading' : 'loaded'}
+      <span data-test-subj="table-has-history">{history ? 'yes' : 'no'}</span>
+    </div>
+  ),
+}));
+
+const mockUseLtrModelList = useLtrModelList as jest.MockedFunction<typeof useLtrModelList>;
+
+const mockHttp = { get: jest.fn() } as any;
+
+const routeProps: any = {
+  history: { push: jest.fn() },
+  location: { pathname: '/ltrModel', search: '', hash: '', state: undefined },
+  match: { params: {}, isExact: true, path: '/ltrModel', url: '/ltrModel' },
+};
+
+const hookState = (overrides: any = {}) => ({
+  isLoading: false,
+  error: null,
+  unavailableReason: null,
+  truncatedTotal: null,
+  findLtrModels: jest.fn(),
+  setError: jest.fn(),
+  ...overrides,
+});
+
+describe('LtrModelListing', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('renders the table by default', () => {
+    mockUseLtrModelList.mockReturnValue(hookState() as any);
+
+    render(<LtrModelListing http={mockHttp} {...routeProps} />);
+
+    expect(screen.getByText('LTR Models')).toBeInTheDocument();
+    expect(screen.getByTestId('ltr-model-table')).toBeInTheDocument();
+    // The table needs history to link names through to the detail view.
+    expect(screen.getByTestId('table-has-history')).toHaveTextContent('yes');
+  });
+
+  it('renders an error callout instead of the table when the fetch fails', () => {
+    mockUseLtrModelList.mockReturnValue(hookState({ error: 'cluster is on fire' }) as any);
+
+    render(<LtrModelListing http={mockHttp} {...routeProps} />);
+
+    expect(screen.getByText('cluster is on fire')).toBeInTheDocument();
+    expect(screen.queryByTestId('ltr-model-table')).not.toBeInTheDocument();
+  });
+
+  it('explains a missing feature store rather than showing an empty table', () => {
+    mockUseLtrModelList.mockReturnValue(hookState({ unavailableReason: 'store_not_found' }) as any);
+
+    render(<LtrModelListing http={mockHttp} {...routeProps} />);
+
+    expect(screen.getByText('No feature store found')).toBeInTheDocument();
+    expect(screen.queryByTestId('ltr-model-table')).not.toBeInTheDocument();
+  });
+
+  it('explains a disabled LTR plugin', () => {
+    mockUseLtrModelList.mockReturnValue(hookState({ unavailableReason: 'plugin_disabled' }) as any);
+
+    render(<LtrModelListing http={mockHttp} {...routeProps} />);
+
+    expect(screen.getByText('Learning to Rank is disabled')).toBeInTheDocument();
+  });
+
+  it('explains an uninstalled LTR plugin', () => {
+    mockUseLtrModelList.mockReturnValue(
+      hookState({ unavailableReason: 'plugin_not_installed' }) as any
+    );
+
+    render(<LtrModelListing http={mockHttp} {...routeProps} />);
+
+    expect(screen.getByText('Learning to Rank is not installed')).toBeInTheDocument();
+  });
+
+  it('warns alongside the table when the registry was truncated', () => {
+    mockUseLtrModelList.mockReturnValue(hookState({ truncatedTotal: 4200 }) as any);
+
+    render(<LtrModelListing http={mockHttp} {...routeProps} />);
+
+    expect(screen.getByText('Showing part of the registry')).toBeInTheDocument();
+    expect(screen.getByText(/4200 models/)).toBeInTheDocument();
+    expect(screen.getByTestId('ltr-model-table')).toBeInTheDocument();
+  });
+});

--- a/public/components/ltr_model/__tests__/ltr_model_service.test.ts
+++ b/public/components/ltr_model/__tests__/ltr_model_service.test.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { LtrModelService, mapLtrFeatureSetFields } from '../services/ltr_model_service';
+
+jest.mock('../../../../common', () => ({
+  ServiceEndpoints: {
+    LtrModels: '/api/relevancy/ltr/models',
+    LtrFeatureSets: '/api/relevancy/ltr/feature_sets',
+  },
+  LTR_FEATURE_SET_FETCH_SIZE: 1000,
+}));
+
+const mockHttp = { get: jest.fn(), post: jest.fn() } as any;
+
+const featureSetHit = (name: string, features: any[] = []) => ({
+  _id: `featureset-${name}`,
+  _source: { name, type: 'featureset', featureset: { name, features } },
+});
+
+describe('mapLtrFeatureSetFields', () => {
+  it('counts the features in the set', () => {
+    expect(mapLtrFeatureSetFields(featureSetHit('my_set', [{ name: 'a' }, { name: 'b' }]))).toEqual(
+      {
+        name: 'my_set',
+        featureCount: 2,
+      }
+    );
+  });
+
+  it('tolerates a set with no features array', () => {
+    expect(mapLtrFeatureSetFields({ _source: { name: 'empty' } })).toEqual({
+      name: 'empty',
+      featureCount: 0,
+    });
+  });
+});
+
+describe('LtrModelService', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('requests feature sets with an explicit size', async () => {
+    mockHttp.get.mockResolvedValue({ hits: { hits: [featureSetHit('my_set')] } });
+
+    const sets = await new LtrModelService(mockHttp).listFeatureSets();
+
+    // Without a size the LTR plugin caps the listing at 20, so the picker would quietly
+    // omit feature sets.
+    expect(mockHttp.get).toHaveBeenCalledWith('/api/relevancy/ltr/feature_sets', {
+      query: { size: 1000 },
+    });
+    expect(sets).toEqual([{ name: 'my_set', featureCount: 0 }]);
+  });
+
+  it('drops hits with no name, which cannot be selected anyway', async () => {
+    mockHttp.get.mockResolvedValue({
+      hits: { hits: [featureSetHit('my_set'), { _source: { type: 'featureset' } }] },
+    });
+
+    expect(await new LtrModelService(mockHttp).listFeatureSets()).toEqual([
+      { name: 'my_set', featureCount: 0 },
+    ]);
+  });
+
+  it('returns an empty list when the store has no feature sets', async () => {
+    mockHttp.get.mockResolvedValue({ hits: { hits: [] } });
+
+    expect(await new LtrModelService(mockHttp).listFeatureSets()).toEqual([]);
+  });
+
+  it('posts the flat model payload for the server to nest', async () => {
+    mockHttp.post.mockResolvedValue({ result: 'created' });
+    const model = {
+      name: 'my_model',
+      featureSetName: 'my_set',
+      modelType: 'model/linear',
+      definition: { title_match: 0.4 },
+    };
+
+    await new LtrModelService(mockHttp).createModel(model);
+
+    expect(mockHttp.post).toHaveBeenCalledWith('/api/relevancy/ltr/models', {
+      body: JSON.stringify(model),
+      headers: { 'Content-Type': 'application/json' },
+    });
+  });
+});

--- a/public/components/ltr_model/__tests__/ltr_model_table.test.tsx
+++ b/public/components/ltr_model/__tests__/ltr_model_table.test.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { LtrModelTable, shortModelType } from '../components/ltr_model_table';
+
+describe('shortModelType', () => {
+  it('drops the model/ prefix', () => {
+    expect(shortModelType('model/xgboost+json')).toBe('xgboost+json');
+  });
+
+  it('leaves an unprefixed type alone', () => {
+    expect(shortModelType('ranklib')).toBe('ranklib');
+  });
+});
+
+const mockHistory = {
+  push: jest.fn(),
+  createHref: jest.fn((location: any) => location.pathname),
+  location: { pathname: '/ltrModel', search: '', hash: '', state: undefined },
+} as any;
+
+describe('LtrModelTable', () => {
+  const items = [
+    { name: 'my_model', featureSetName: 'my_set', modelType: 'model/ranklib', featureCount: 2 },
+    {
+      name: 'other_model',
+      featureSetName: 'other_set',
+      modelType: 'model/xgboost+json',
+      featureCount: 7,
+    },
+  ];
+
+  it('renders a row per model with its feature set, type, and feature count', async () => {
+    const findItems = jest.fn().mockResolvedValue({ total: items.length, hits: items });
+
+    render(<LtrModelTable isLoading={false} findItems={findItems} history={mockHistory} />);
+
+    await waitFor(() => expect(screen.getByText('my_model')).toBeInTheDocument());
+    expect(screen.getByText('my_set')).toBeInTheDocument();
+    expect(screen.getByText('ranklib')).toBeInTheDocument();
+    expect(screen.getByText('other_model')).toBeInTheDocument();
+    expect(screen.getByText('xgboost+json')).toBeInTheDocument();
+    expect(screen.getByText('7')).toBeInTheDocument();
+  });
+
+  it('links each model name to its detail view', async () => {
+    const findItems = jest.fn().mockResolvedValue({ total: items.length, hits: items });
+
+    render(<LtrModelTable isLoading={false} findItems={findItems} history={mockHistory} />);
+
+    await waitFor(() => expect(screen.getByText('my_model')).toBeInTheDocument());
+    expect(screen.getByText('my_model').closest('a')).toHaveAttribute(
+      'href',
+      '/ltrModel/view/my_model'
+    );
+  });
+});

--- a/public/components/ltr_model/__tests__/ltr_model_upload.test.tsx
+++ b/public/components/ltr_model/__tests__/ltr_model_upload.test.tsx
@@ -1,0 +1,204 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { LtrModelUpload } from '../views/ltr_model_upload';
+import { useLtrFeatureSetList } from '../hooks/use_ltr_feature_set_list';
+import { useLtrModelUploadForm } from '../hooks/use_ltr_model_upload_form';
+import { LtrModelService } from '../services/ltr_model_service';
+
+jest.mock('../hooks/use_ltr_feature_set_list');
+jest.mock('../hooks/use_ltr_model_upload_form');
+jest.mock('../services/ltr_model_service');
+jest.mock('../components/ltr_model_upload_form', () => ({
+  // The fields themselves are plain EUI inputs; what matters here is that the view hands
+  // the form its state, its errors, and the feature sets to pick from.
+  LtrModelUploadForm: ({ errors, featureSets, isLoadingFeatureSets }: any) => (
+    <div data-test-subj="upload-form">
+      <span data-test-subj="form-feature-sets">
+        {featureSets.map((set: any) => set.name).join(',')}
+      </span>
+      <span data-test-subj="form-loading">{isLoadingFeatureSets ? 'yes' : 'no'}</span>
+      <span data-test-subj="form-errors">{JSON.stringify(errors)}</span>
+    </div>
+  ),
+}));
+
+const mockUseLtrFeatureSetList = useLtrFeatureSetList as jest.MockedFunction<
+  typeof useLtrFeatureSetList
+>;
+const mockUseLtrModelUploadForm = useLtrModelUploadForm as jest.MockedFunction<
+  typeof useLtrModelUploadForm
+>;
+const MockLtrModelService = LtrModelService as jest.MockedClass<typeof LtrModelService>;
+
+const mockHttp = { get: jest.fn(), post: jest.fn() } as any;
+const notifications = { toasts: { addSuccess: jest.fn(), addError: jest.fn() } } as any;
+const history = { push: jest.fn() };
+
+const routeProps: any = {
+  history,
+  location: { pathname: '/ltrModel/create', search: '', hash: '', state: undefined },
+  match: { params: {}, isExact: true, path: '/ltrModel/create', url: '/ltrModel/create' },
+};
+
+const model = {
+  name: 'my_model',
+  featureSetName: 'my_set',
+  modelType: 'model/linear',
+  definition: { title_match: 0.4 },
+};
+
+const featureSetState = (overrides: any = {}) => ({
+  featureSets: [{ name: 'my_set', featureCount: 3 }],
+  isLoading: false,
+  error: null,
+  unavailableReason: null,
+  ...overrides,
+});
+
+let createModel: jest.Mock;
+let setErrors: jest.Mock;
+let validate: jest.Mock;
+
+const formState = (overrides: any = {}) => ({
+  name: '',
+  setName: jest.fn(),
+  featureSetName: '',
+  setFeatureSetName: jest.fn(),
+  modelType: '',
+  setModelType: jest.fn(),
+  definitionText: '',
+  setDefinitionText: jest.fn(),
+  errors: {},
+  setErrors,
+  validate,
+  ...overrides,
+});
+
+const renderUpload = () =>
+  render(<LtrModelUpload http={mockHttp} notifications={notifications} {...routeProps} />);
+
+const submit = () => fireEvent.click(screen.getByTestId('uploadLtrModelButton'));
+
+const failWith = (attributes: any) =>
+  createModel.mockRejectedValue({ body: { message: 'nope', attributes } });
+
+describe('LtrModelUpload', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    createModel = jest.fn().mockResolvedValue({ result: 'created' });
+    setErrors = jest.fn();
+    validate = jest.fn().mockReturnValue(model);
+    MockLtrModelService.mockImplementation(() => ({ createModel } as any));
+    mockUseLtrFeatureSetList.mockReturnValue(featureSetState() as any);
+    mockUseLtrModelUploadForm.mockReturnValue(formState() as any);
+  });
+
+  it('renders the form with the feature sets available to build against', () => {
+    renderUpload();
+
+    expect(screen.getByText('Upload LTR Model')).toBeInTheDocument();
+    expect(screen.getByTestId('form-feature-sets')).toHaveTextContent('my_set');
+    expect(screen.getByTestId('form-loading')).toHaveTextContent('no');
+  });
+
+  it('uploads the validated model and lands on its detail view', async () => {
+    renderUpload();
+
+    submit();
+
+    await waitFor(() => expect(createModel).toHaveBeenCalledWith(model));
+    expect(notifications.toasts.addSuccess).toHaveBeenCalledWith(
+      'Model "my_model" uploaded successfully'
+    );
+    // The detail view reads the definition back out of the store, which is the only
+    // confirmation that what was pasted is what landed.
+    expect(history.push).toHaveBeenCalledWith('/ltrModel/view/my_model');
+  });
+
+  it('escapes a model name that is not URL-safe on its way to the detail view', async () => {
+    validate.mockReturnValue({ ...model, name: 'my model/v2' });
+
+    renderUpload();
+    submit();
+
+    await waitFor(() =>
+      expect(history.push).toHaveBeenCalledWith('/ltrModel/view/my%20model%2Fv2')
+    );
+  });
+
+  it('does not call the API when the form does not validate', async () => {
+    validate.mockReturnValue(null);
+
+    renderUpload();
+    submit();
+
+    await waitFor(() => expect(validate).toHaveBeenCalled());
+    expect(createModel).not.toHaveBeenCalled();
+    expect(history.push).not.toHaveBeenCalled();
+  });
+
+  // The store has no update path, so a collision is a fixable form error rather than a
+  // failure to report and walk away from.
+  it('turns a name collision into a form error instead of a toast', async () => {
+    failWith({ ltrErrorType: 'model_exists' });
+
+    renderUpload();
+    submit();
+
+    await waitFor(() => expect(setErrors).toHaveBeenCalled());
+    expect(setErrors.mock.calls[0][0].name).toMatch(/already exists/);
+    expect(notifications.toasts.addError).not.toHaveBeenCalled();
+    expect(history.push).not.toHaveBeenCalled();
+  });
+
+  it('blames the feature set field when the feature set has gone missing', async () => {
+    failWith({ ltrErrorType: 'featureset_not_found' });
+
+    renderUpload();
+    submit();
+
+    await waitFor(() => expect(setErrors).toHaveBeenCalled());
+    expect(setErrors.mock.calls[0][0].featureSetName).toMatch(/my_set/);
+    expect(notifications.toasts.addError).not.toHaveBeenCalled();
+  });
+
+  it('toasts a failure it cannot attribute to a field', async () => {
+    failWith({});
+
+    renderUpload();
+    submit();
+
+    await waitFor(() => expect(notifications.toasts.addError).toHaveBeenCalled());
+    expect(notifications.toasts.addError.mock.calls[0][1]).toEqual({
+      title: 'Failed to upload model',
+    });
+    expect(setErrors).not.toHaveBeenCalled();
+  });
+
+  it('replaces the form with an explanation when LTR is unavailable', () => {
+    mockUseLtrFeatureSetList.mockReturnValue(
+      featureSetState({ unavailableReason: 'plugin_not_installed' }) as any
+    );
+
+    renderUpload();
+
+    expect(screen.getByText('Learning to Rank is not installed')).toBeInTheDocument();
+    expect(screen.queryByTestId('upload-form')).not.toBeInTheDocument();
+    // Nothing to upload into, so there is nothing to submit either.
+    expect(screen.queryByTestId('uploadLtrModelButton')).not.toBeInTheDocument();
+  });
+
+  it('returns to the listing on cancel', () => {
+    renderUpload();
+
+    fireEvent.click(screen.getByTestId('cancelLtrModelUploadButton'));
+
+    expect(history.push).toHaveBeenCalledWith('/ltrModel');
+    expect(createModel).not.toHaveBeenCalled();
+  });
+});

--- a/public/components/ltr_model/__tests__/ltr_model_upload_form.test.tsx
+++ b/public/components/ltr_model/__tests__/ltr_model_upload_form.test.tsx
@@ -1,0 +1,122 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { LtrModelUploadForm } from '../components/ltr_model_upload_form';
+
+const setName = jest.fn();
+const setFeatureSetName = jest.fn();
+const setModelType = jest.fn();
+const setDefinitionText = jest.fn();
+
+const props = (overrides: any = {}) => ({
+  name: '',
+  setName,
+  featureSetName: '',
+  setFeatureSetName,
+  modelType: '',
+  setModelType,
+  definitionText: '',
+  setDefinitionText,
+  errors: {},
+  featureSets: [{ name: 'my_set', featureCount: 3 }],
+  isLoadingFeatureSets: false,
+  ...overrides,
+});
+
+describe('LtrModelUploadForm', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('offers only the model types the LTR plugin can parse', () => {
+    render(<LtrModelUploadForm {...props()} />);
+
+    const options = Array.from(
+      screen.getByTestId('ltrModelUploadType').querySelectorAll('option')
+    ).map((option) => option.getAttribute('value'));
+
+    expect(options).toEqual([
+      '',
+      'model/ranklib',
+      'model/linear',
+      'model/xgboost+json',
+      'model/xgboost+json+raw',
+    ]);
+  });
+
+  it('reports each field error against its own field', () => {
+    render(
+      <LtrModelUploadForm
+        {...props({
+          errors: {
+            name: 'A model name is required.',
+            featureSetName: 'Select the feature set this model was built from.',
+            definition: 'model/linear definitions must be valid JSON.',
+          },
+        })}
+      />
+    );
+
+    expect(screen.getByText('A model name is required.')).toBeInTheDocument();
+    expect(
+      screen.getByText('Select the feature set this model was built from.')
+    ).toBeInTheDocument();
+    expect(screen.getByText('model/linear definitions must be valid JSON.')).toBeInTheDocument();
+  });
+
+  it('propagates edits to the caller', () => {
+    render(<LtrModelUploadForm {...props()} />);
+
+    fireEvent.change(screen.getByTestId('ltrModelUploadName'), {
+      target: { value: 'my_model' },
+    });
+    fireEvent.change(screen.getByTestId('ltrModelUploadType'), {
+      target: { value: 'model/ranklib' },
+    });
+    fireEvent.change(screen.getByTestId('ltrModelUploadDefinition'), {
+      target: { value: '## LambdaMART' },
+    });
+
+    expect(setName).toHaveBeenCalledWith('my_model');
+    expect(setModelType).toHaveBeenCalledWith('model/ranklib');
+    expect(setDefinitionText).toHaveBeenCalledWith('## LambdaMART');
+  });
+
+  // The definition has to score the feature set's features, in order, so the count is the
+  // one thing worth surfacing next to the picker.
+  it('shows the selected feature set size', () => {
+    render(<LtrModelUploadForm {...props({ featureSetName: 'my_set' })} />);
+
+    expect(screen.getByText(/3 features/)).toBeInTheDocument();
+  });
+
+  it('says a JSON model type wants JSON', () => {
+    render(<LtrModelUploadForm {...props({ modelType: 'model/xgboost+json' })} />);
+
+    expect(screen.getByText('Paste the trained model as JSON.')).toBeInTheDocument();
+  });
+
+  it('does not ask for JSON for a RankLib model', () => {
+    render(<LtrModelUploadForm {...props({ modelType: 'model/ranklib' })} />);
+
+    expect(
+      screen.getByText('Paste the trained model exactly as the trainer emitted it.')
+    ).toBeInTheDocument();
+  });
+
+  // A model is created against an existing feature set and this plugin does not author
+  // them, so an empty picker is a dead end that has to say so.
+  it('explains an empty store rather than showing an empty picker', () => {
+    render(<LtrModelUploadForm {...props({ featureSets: [] })} />);
+
+    expect(screen.getByText('No feature sets in this store')).toBeInTheDocument();
+  });
+
+  it('stays quiet about an empty picker while the feature sets are still loading', () => {
+    render(<LtrModelUploadForm {...props({ featureSets: [], isLoadingFeatureSets: true })} />);
+
+    expect(screen.queryByText('No feature sets in this store')).not.toBeInTheDocument();
+  });
+});

--- a/public/components/ltr_model/__tests__/ltr_model_view.test.tsx
+++ b/public/components/ltr_model/__tests__/ltr_model_view.test.tsx
@@ -1,0 +1,98 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { LtrModelView } from '../views/ltr_model_view';
+import { useLtrModelView } from '../hooks/use_ltr_model_view';
+
+jest.mock('../hooks/use_ltr_model_view');
+
+const mockUseLtrModelView = useLtrModelView as jest.MockedFunction<typeof useLtrModelView>;
+const mockHttp = { get: jest.fn() } as any;
+
+const model = {
+  name: 'my_model',
+  featureSetName: 'my_set',
+  modelType: 'model/ranklib',
+  featureCount: 1,
+  features: [
+    {
+      name: 'feature1',
+      params: ['query_string'],
+      templateLanguage: 'mustache',
+      template: { match: { field_test: '{{query_string}}' } },
+    },
+  ],
+  definition: '## LambdaMART',
+};
+
+const hookState = (overrides: any = {}) => ({
+  model: null,
+  isLoading: false,
+  error: null,
+  notFound: false,
+  unavailableReason: null,
+  ...overrides,
+});
+
+describe('LtrModelView', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('renders the model metadata, its feature set, and its definition', () => {
+    mockUseLtrModelView.mockReturnValue(hookState({ model }) as any);
+
+    render(<LtrModelView http={mockHttp} id="my_model" />);
+
+    expect(screen.getByText('my_set')).toBeInTheDocument();
+    expect(screen.getByText('ranklib')).toBeInTheDocument();
+    // The feature set renders a real feature with its template.
+    expect(screen.getByText('feature1')).toBeInTheDocument();
+    expect(screen.getByText('query_string')).toBeInTheDocument();
+    expect(screen.getByTestId('ltrModelDefinition').textContent).toBe('## LambdaMART');
+  });
+
+  it('shows a spinner while loading', () => {
+    mockUseLtrModelView.mockReturnValue(hookState({ isLoading: true }) as any);
+
+    render(<LtrModelView http={mockHttp} id="my_model" />);
+
+    expect(screen.getByTestId('ltrModelViewLoading')).toBeInTheDocument();
+  });
+
+  it('distinguishes a missing model from a broken registry', () => {
+    mockUseLtrModelView.mockReturnValue(hookState({ notFound: true }) as any);
+
+    render(<LtrModelView http={mockHttp} id="ghost" />);
+
+    expect(screen.getByText('Model not found')).toBeInTheDocument();
+  });
+
+  it('explains a registry-level failure', () => {
+    mockUseLtrModelView.mockReturnValue(hookState({ unavailableReason: 'plugin_disabled' }) as any);
+
+    render(<LtrModelView http={mockHttp} id="my_model" />);
+
+    expect(screen.getByText('Learning to Rank is disabled')).toBeInTheDocument();
+  });
+
+  it('reports an unexpected error', () => {
+    mockUseLtrModelView.mockReturnValue(hookState({ error: 'cluster is on fire' }) as any);
+
+    render(<LtrModelView http={mockHttp} id="my_model" />);
+
+    expect(screen.getByText('cluster is on fire')).toBeInTheDocument();
+  });
+
+  it('renders a model whose feature set is empty', () => {
+    mockUseLtrModelView.mockReturnValue(
+      hookState({ model: { ...model, features: [], featureCount: 0 } }) as any
+    );
+
+    render(<LtrModelView http={mockHttp} id="my_model" />);
+
+    expect(screen.getByText("This model's feature set has no features.")).toBeInTheDocument();
+  });
+});

--- a/public/components/ltr_model/__tests__/use_ltr_feature_set_list.test.ts
+++ b/public/components/ltr_model/__tests__/use_ltr_feature_set_list.test.ts
@@ -1,0 +1,74 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { renderHook } from '@testing-library/react-hooks';
+import { useLtrFeatureSetList } from '../hooks/use_ltr_feature_set_list';
+import { LtrModelService } from '../services/ltr_model_service';
+
+jest.mock('../services/ltr_model_service');
+
+const MockLtrModelService = LtrModelService as jest.MockedClass<typeof LtrModelService>;
+const mockHttp = { get: jest.fn() } as any;
+
+const withListFeatureSets = (listFeatureSets: jest.Mock) =>
+  MockLtrModelService.mockImplementation(() => ({ listFeatureSets } as any));
+
+describe('useLtrFeatureSetList', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  it('loads the feature sets on mount', async () => {
+    const featureSets = [{ name: 'my_set', featureCount: 3 }];
+    withListFeatureSets(jest.fn().mockResolvedValue(featureSets));
+
+    const { result, waitForNextUpdate } = renderHook(() => useLtrFeatureSetList(mockHttp));
+
+    expect(result.current.isLoading).toBe(true);
+    await waitForNextUpdate();
+
+    expect(result.current.featureSets).toEqual(featureSets);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(result.current.unavailableReason).toBeNull();
+  });
+
+  // A store the user has not created yet is not an error to debug, and the upload view
+  // shows the plugin's own next step instead of the form.
+  it('surfaces an unavailable LTR plugin as a reason rather than an error', async () => {
+    withListFeatureSets(
+      jest.fn().mockRejectedValue({ body: { attributes: { ltrErrorType: 'store_not_found' } } })
+    );
+
+    const { result, waitForNextUpdate } = renderHook(() => useLtrFeatureSetList(mockHttp));
+    await waitForNextUpdate();
+
+    expect(result.current.unavailableReason).toBe('store_not_found');
+    expect(result.current.error).toBeNull();
+    expect(result.current.featureSets).toEqual([]);
+  });
+
+  it('surfaces an unclassified failure as an error', async () => {
+    withListFeatureSets(jest.fn().mockRejectedValue({ body: { message: 'circuit breaking' } }));
+
+    const { result, waitForNextUpdate } = renderHook(() => useLtrFeatureSetList(mockHttp));
+    await waitForNextUpdate();
+
+    expect(result.current.error).toBe('circuit breaking');
+    expect(result.current.unavailableReason).toBeNull();
+  });
+
+  it('falls back to a generic message when the failure carries none', async () => {
+    withListFeatureSets(jest.fn().mockRejectedValue(new Error('socket hang up')));
+
+    const { result, waitForNextUpdate } = renderHook(() => useLtrFeatureSetList(mockHttp));
+    await waitForNextUpdate();
+
+    expect(result.current.error).toBe('Failed to load feature sets due to an unknown error.');
+  });
+});

--- a/public/components/ltr_model/__tests__/use_ltr_model_list.test.ts
+++ b/public/components/ltr_model/__tests__/use_ltr_model_list.test.ts
@@ -1,0 +1,203 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { renderHook, act } from '@testing-library/react-hooks';
+import { mapLtrModelFields, useLtrModelList } from '../hooks/use_ltr_model_list';
+
+jest.mock('../../../../common', () => ({
+  ServiceEndpoints: {
+    LtrModels: '/api/relevancy/ltr/models',
+  },
+  LTR_MODEL_FETCH_SIZE: 1000,
+}));
+
+const mockHttp = {
+  get: jest.fn(),
+} as any;
+
+const hit = (name: string, overrides: any = {}) => ({
+  _source: {
+    name,
+    type: 'model',
+    model: {
+      feature_set: {
+        name: 'my_set',
+        features: [{ name: 'feature1' }, { name: 'feature2' }],
+      },
+      model: {
+        type: 'model/ranklib',
+        definition: '## LambdaMART',
+      },
+      ...overrides,
+    },
+  },
+});
+
+const searchResponse = (hits: any[], total?: number) => ({
+  hits: {
+    total: { value: total ?? hits.length },
+    hits,
+  },
+});
+
+describe('mapLtrModelFields', () => {
+  it('unwraps _source into a flat registry entry', () => {
+    expect(mapLtrModelFields(hit('my_model'))).toEqual({
+      name: 'my_model',
+      featureSetName: 'my_set',
+      modelType: 'model/ranklib',
+      featureCount: 2,
+    });
+  });
+
+  it('tolerates a model document missing its feature set', () => {
+    expect(mapLtrModelFields({ _source: { name: 'bare' } })).toEqual({
+      name: 'bare',
+      featureSetName: '',
+      modelType: '',
+      featureCount: 0,
+    });
+  });
+});
+
+describe('useLtrModelList', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('initializes with default state', () => {
+    const { result } = renderHook(() => useLtrModelList(mockHttp));
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBe(null);
+    expect(result.current.unavailableReason).toBe(null);
+    expect(result.current.truncatedTotal).toBe(null);
+  });
+
+  it('fetches models successfully', async () => {
+    mockHttp.get.mockResolvedValue(searchResponse([hit('my_model')]));
+
+    const { result } = renderHook(() => useLtrModelList(mockHttp));
+
+    let listResult;
+    await act(async () => {
+      listResult = await result.current.findLtrModels('');
+    });
+
+    expect(listResult).toEqual({
+      total: 1,
+      hits: [
+        {
+          name: 'my_model',
+          featureSetName: 'my_set',
+          modelType: 'model/ranklib',
+          featureCount: 2,
+        },
+      ],
+    });
+  });
+
+  it('requests an explicit size so the endpoint does not silently truncate at 20', async () => {
+    mockHttp.get.mockResolvedValue(searchResponse([]));
+
+    const { result } = renderHook(() => useLtrModelList(mockHttp));
+    await act(async () => {
+      await result.current.findLtrModels('');
+    });
+
+    expect(mockHttp.get).toHaveBeenCalledWith('/api/relevancy/ltr/models', {
+      query: { size: 1000 },
+    });
+  });
+
+  it('flags truncation when the store holds more models than were fetched', async () => {
+    mockHttp.get.mockResolvedValue(searchResponse([hit('a'), hit('b')], 4200));
+
+    const { result } = renderHook(() => useLtrModelList(mockHttp));
+    await act(async () => {
+      await result.current.findLtrModels('');
+    });
+
+    expect(result.current.truncatedTotal).toBe(4200);
+  });
+
+  // A cluster running with `rest_total_hits_as_int` returns `hits.total` as a bare number.
+  it('flags truncation when total comes back as a bare number', async () => {
+    mockHttp.get.mockResolvedValue({ hits: { hits: [hit('a'), hit('b')], total: 4200 } });
+
+    const { result } = renderHook(() => useLtrModelList(mockHttp));
+    await act(async () => {
+      await result.current.findLtrModels('');
+    });
+
+    expect(result.current.truncatedTotal).toBe(4200);
+  });
+
+  it('does not flag truncation when the whole store was returned', async () => {
+    mockHttp.get.mockResolvedValue(searchResponse([hit('a'), hit('b')]));
+
+    const { result } = renderHook(() => useLtrModelList(mockHttp));
+    await act(async () => {
+      await result.current.findLtrModels('');
+    });
+
+    expect(result.current.truncatedTotal).toBe(null);
+  });
+
+  it('filters by name', async () => {
+    mockHttp.get.mockResolvedValue(searchResponse([hit('alpha_model'), hit('beta_model')]));
+
+    const { result } = renderHook(() => useLtrModelList(mockHttp));
+
+    let listResult: any;
+    await act(async () => {
+      listResult = await result.current.findLtrModels('ALPHA');
+    });
+
+    expect(listResult.total).toBe(1);
+    expect(listResult.hits[0].name).toBe('alpha_model');
+  });
+
+  it.each([['store_not_found'], ['plugin_disabled'], ['plugin_not_installed']])(
+    'surfaces %s as an unavailable reason rather than an error',
+    async (reason) => {
+      mockHttp.get.mockRejectedValue({ body: { attributes: { ltrErrorType: reason } } });
+
+      const { result } = renderHook(() => useLtrModelList(mockHttp));
+
+      let listResult: any;
+      await act(async () => {
+        listResult = await result.current.findLtrModels('');
+      });
+
+      expect(result.current.unavailableReason).toBe(reason);
+      expect(result.current.error).toBe(null);
+      expect(listResult).toEqual({ total: 0, hits: [] });
+    }
+  );
+
+  it('reports an unexpected failure as an error', async () => {
+    mockHttp.get.mockRejectedValue({ body: { message: 'cluster is on fire' } });
+
+    const { result } = renderHook(() => useLtrModelList(mockHttp));
+    await act(async () => {
+      await result.current.findLtrModels('');
+    });
+
+    expect(result.current.error).toBe('cluster is on fire');
+    expect(result.current.unavailableReason).toBe(null);
+  });
+
+  it('falls back to a generic message when the failure carries no detail', async () => {
+    mockHttp.get.mockRejectedValue({});
+
+    const { result } = renderHook(() => useLtrModelList(mockHttp));
+    await act(async () => {
+      await result.current.findLtrModels('');
+    });
+
+    expect(result.current.error).toBe('Failed to load LTR models due to an unknown error.');
+  });
+});

--- a/public/components/ltr_model/__tests__/use_ltr_model_upload_form.test.ts
+++ b/public/components/ltr_model/__tests__/use_ltr_model_upload_form.test.ts
@@ -1,0 +1,106 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { act, renderHook } from '@testing-library/react-hooks';
+import { useLtrModelUploadForm, validateLtrModelUpload } from '../hooks/use_ltr_model_upload_form';
+
+const validForm = {
+  name: 'my_model',
+  featureSetName: 'my_featureset',
+  modelType: 'model/linear',
+  definitionText: '{"title_match": 0.4}',
+};
+
+describe('validateLtrModelUpload', () => {
+  it('accepts a complete form', () => {
+    expect(validateLtrModelUpload(validForm)).toEqual({});
+  });
+
+  it('requires a name', () => {
+    expect(validateLtrModelUpload({ ...validForm, name: '  ' }).name).toBe(
+      'A model name is required.'
+    );
+  });
+
+  it('rejects a name with surrounding whitespace rather than silently trimming it', () => {
+    expect(validateLtrModelUpload({ ...validForm, name: 'my_model ' }).name).toMatch(/whitespace/);
+  });
+
+  it('requires a feature set', () => {
+    expect(validateLtrModelUpload({ ...validForm, featureSetName: '' }).featureSetName).toBe(
+      'Select the feature set this model was built from.'
+    );
+  });
+
+  it('requires a model type', () => {
+    expect(validateLtrModelUpload({ ...validForm, modelType: '' }).modelType).toBe(
+      'Select a model type.'
+    );
+  });
+
+  // Without a type there is nothing to validate the definition against, so the type error
+  // stands alone rather than being joined by a misleading JSON complaint.
+  it('does not judge the definition until a type is selected', () => {
+    const errors = validateLtrModelUpload({ ...validForm, modelType: '', definitionText: 'x' });
+    expect(errors.definition).toBeUndefined();
+  });
+
+  it('rejects a JSON definition that does not parse', () => {
+    expect(validateLtrModelUpload({ ...validForm, definitionText: '{' }).definition).toMatch(
+      /must be valid JSON/
+    );
+  });
+});
+
+describe('useLtrModelUploadForm', () => {
+  it('returns the parsed payload once the form is complete', () => {
+    const { result } = renderHook(() => useLtrModelUploadForm());
+
+    act(() => {
+      result.current.setName(' my_model ');
+      result.current.setFeatureSetName('my_featureset');
+      result.current.setModelType('model/linear');
+      result.current.setDefinitionText('{"title_match": 0.4}');
+    });
+
+    let payload: any;
+    act(() => {
+      payload = result.current.validate();
+    });
+
+    // The name is rejected rather than trimmed, so nothing is silently renamed.
+    expect(payload).toBeNull();
+    expect(result.current.errors.name).toMatch(/whitespace/);
+
+    act(() => {
+      result.current.setName('my_model');
+    });
+    act(() => {
+      payload = result.current.validate();
+    });
+
+    expect(payload).toEqual({
+      name: 'my_model',
+      featureSetName: 'my_featureset',
+      modelType: 'model/linear',
+      definition: { title_match: 0.4 },
+    });
+    expect(result.current.errors).toEqual({});
+  });
+
+  it('reports errors and withholds the payload when the form is incomplete', () => {
+    const { result } = renderHook(() => useLtrModelUploadForm());
+
+    let payload: any = 'unset';
+    act(() => {
+      payload = result.current.validate();
+    });
+
+    expect(payload).toBeNull();
+    expect(result.current.errors.name).toBeDefined();
+    expect(result.current.errors.featureSetName).toBeDefined();
+    expect(result.current.errors.modelType).toBeDefined();
+  });
+});

--- a/public/components/ltr_model/__tests__/use_ltr_model_view.test.ts
+++ b/public/components/ltr_model/__tests__/use_ltr_model_view.test.ts
@@ -1,0 +1,121 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { renderHook } from '@testing-library/react-hooks';
+import { mapLtrModelDetail, useLtrModelView } from '../hooks/use_ltr_model_view';
+
+jest.mock('../../../../common', () => ({
+  ServiceEndpoints: {
+    LtrModels: '/api/relevancy/ltr/models',
+  },
+  LTR_MODEL_FETCH_SIZE: 1000,
+}));
+
+const mockHttp = { get: jest.fn() } as any;
+
+const documentResponse = {
+  _id: 'model-my_model',
+  found: true,
+  _source: {
+    name: 'my_model',
+    type: 'model',
+    model: {
+      feature_set: {
+        name: 'my_set',
+        features: [
+          {
+            name: 'feature1',
+            params: ['query_string'],
+            template_language: 'mustache',
+            template: { match: { field_test: '{{query_string}}' } },
+          },
+        ],
+      },
+      model: { type: 'model/ranklib', definition: '## LambdaMART\n0:1.2' },
+    },
+  },
+};
+
+describe('mapLtrModelDetail', () => {
+  it('maps shared fields, features, and the definition', () => {
+    expect(mapLtrModelDetail(documentResponse)).toEqual({
+      name: 'my_model',
+      featureSetName: 'my_set',
+      modelType: 'model/ranklib',
+      featureCount: 1,
+      features: [
+        {
+          name: 'feature1',
+          params: ['query_string'],
+          templateLanguage: 'mustache',
+          template: { match: { field_test: '{{query_string}}' } },
+        },
+      ],
+      definition: '## LambdaMART\n0:1.2',
+    });
+  });
+
+  it('tolerates a model with no feature set', () => {
+    const detail = mapLtrModelDetail({ _source: { name: 'bare' } });
+    expect(detail.features).toEqual([]);
+    expect(detail.definition).toBeUndefined();
+  });
+});
+
+describe('useLtrModelView', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('fetches the model by name', async () => {
+    mockHttp.get.mockResolvedValue(documentResponse);
+
+    const { result, waitForNextUpdate } = renderHook(() => useLtrModelView(mockHttp, 'my_model'));
+    await waitForNextUpdate();
+
+    expect(mockHttp.get).toHaveBeenCalledWith('/api/relevancy/ltr/models/my_model');
+    expect(result.current.model?.name).toBe('my_model');
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBe(null);
+  });
+
+  it('encodes a name that needs escaping', async () => {
+    mockHttp.get.mockResolvedValue(documentResponse);
+
+    const { waitForNextUpdate } = renderHook(() => useLtrModelView(mockHttp, 'my model/v2'));
+    await waitForNextUpdate();
+
+    expect(mockHttp.get).toHaveBeenCalledWith('/api/relevancy/ltr/models/my%20model%2Fv2');
+  });
+
+  it('reports a missing model separately from a broken registry', async () => {
+    mockHttp.get.mockRejectedValue({ body: { attributes: { ltrErrorType: 'model_not_found' } } });
+
+    const { result, waitForNextUpdate } = renderHook(() => useLtrModelView(mockHttp, 'ghost'));
+    await waitForNextUpdate();
+
+    expect(result.current.notFound).toBe(true);
+    expect(result.current.unavailableReason).toBe(null);
+    expect(result.current.error).toBe(null);
+    expect(result.current.model).toBe(null);
+  });
+
+  it('surfaces a registry-level reason', async () => {
+    mockHttp.get.mockRejectedValue({ body: { attributes: { ltrErrorType: 'plugin_disabled' } } });
+
+    const { result, waitForNextUpdate } = renderHook(() => useLtrModelView(mockHttp, 'my_model'));
+    await waitForNextUpdate();
+
+    expect(result.current.unavailableReason).toBe('plugin_disabled');
+    expect(result.current.notFound).toBe(false);
+  });
+
+  it('reports an unexpected failure as an error', async () => {
+    mockHttp.get.mockRejectedValue({ body: { message: 'cluster is on fire' } });
+
+    const { result, waitForNextUpdate } = renderHook(() => useLtrModelView(mockHttp, 'my_model'));
+    await waitForNextUpdate();
+
+    expect(result.current.error).toBe('cluster is on fire');
+  });
+});

--- a/public/components/ltr_model/components/ltr_feature_table.tsx
+++ b/public/components/ltr_model/components/ltr_feature_table.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { EuiBasicTable, EuiCode, EuiCodeBlock, EuiText } from '@elastic/eui';
+import { LtrFeature } from '../types';
+
+interface LtrFeatureTableProps {
+  features: LtrFeature[];
+}
+
+/**
+ * The feature set a model was built from. Templates are shown in full rather than
+ * summarized — knowing which query a feature actually runs is the reason to open this view.
+ */
+export const LtrFeatureTable: React.FC<LtrFeatureTableProps> = ({ features }) => {
+  if (!features.length) {
+    return <EuiText size="s">This model&apos;s feature set has no features.</EuiText>;
+  }
+
+  const columns = [
+    {
+      field: 'name',
+      name: 'Feature',
+      width: '25%',
+      render: (name: string) => <EuiText size="s">{name}</EuiText>,
+    },
+    {
+      field: 'params',
+      name: 'Parameters',
+      width: '20%',
+      render: (params: string[]) =>
+        params.length ? (
+          <EuiText size="s">
+            {params.map((param) => (
+              <EuiCode key={param}>{param}</EuiCode>
+            ))}
+          </EuiText>
+        ) : (
+          <EuiText size="s">&mdash;</EuiText>
+        ),
+    },
+    {
+      field: 'template',
+      name: 'Template',
+      render: (template: any) => (
+        <EuiCodeBlock language="json" fontSize="s" paddingSize="s" isCopyable={true}>
+          {JSON.stringify(template, null, 2)}
+        </EuiCodeBlock>
+      ),
+    },
+  ];
+
+  return (
+    <EuiBasicTable
+      items={features}
+      columns={columns}
+      tableLayout="auto"
+      data-test-subj="ltrFeatureTable"
+    />
+  );
+};

--- a/public/components/ltr_model/components/ltr_model_definition.tsx
+++ b/public/components/ltr_model/components/ltr_model_definition.tsx
@@ -1,0 +1,58 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { EuiCodeBlock, EuiText } from '@elastic/eui';
+
+/**
+ * The LTR store writes a model definition either as a raw string (RankLib) or as embedded
+ * JSON (linear, XGBoost), so the detail view has to render both without mangling either.
+ * A string that happens to hold JSON is pretty-printed; anything else is shown verbatim.
+ */
+export const formatDefinition = (definition: any): { body: string; language: 'json' | 'text' } => {
+  if (definition === null || definition === undefined) {
+    return { body: '', language: 'text' };
+  }
+
+  if (typeof definition === 'string') {
+    try {
+      const parsed = JSON.parse(definition);
+      if (parsed !== null && typeof parsed === 'object') {
+        return { body: JSON.stringify(parsed, null, 2), language: 'json' };
+      }
+    } catch (e) {
+      // Not JSON — a RankLib definition, which must be shown exactly as stored.
+    }
+    return { body: definition, language: 'text' };
+  }
+
+  return { body: JSON.stringify(definition, null, 2), language: 'json' };
+};
+
+interface LtrModelDefinitionProps {
+  definition: any;
+}
+
+export const LtrModelDefinition: React.FC<LtrModelDefinitionProps> = ({ definition }) => {
+  const { body, language } = formatDefinition(definition);
+
+  if (!body) {
+    return <EuiText size="s">This model has no stored definition.</EuiText>;
+  }
+
+  return (
+    // No overflowHeight: the definition is the point of this view, so it is never truncated.
+    <EuiCodeBlock
+      language={language}
+      fontSize="m"
+      paddingSize="m"
+      isCopyable={true}
+      whiteSpace="pre"
+      data-test-subj="ltrModelDefinition"
+    >
+      {body}
+    </EuiCodeBlock>
+  );
+};

--- a/public/components/ltr_model/components/ltr_model_table.tsx
+++ b/public/components/ltr_model/components/ltr_model_table.tsx
@@ -1,0 +1,95 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { EuiBadge, EuiButtonEmpty, EuiText } from '@elastic/eui';
+import { RouteComponentProps } from 'react-router-dom';
+import {
+  reactRouterNavigate,
+  TableListView,
+} from '../../../../../../src/plugins/opensearch_dashboards_react/public';
+import { Routes } from '../../../../common';
+import { LtrModelListItem } from '../types';
+
+interface LtrModelTableProps {
+  isLoading: boolean;
+  findItems: (search: any) => Promise<{ total: number; hits: LtrModelListItem[] }>;
+  history: RouteComponentProps['history'];
+}
+
+/** `model/xgboost+json` reads better in a table as `xgboost+json`. */
+export const shortModelType = (modelType: string): string =>
+  modelType?.startsWith('model/') ? modelType.slice('model/'.length) : modelType;
+
+export const LtrModelTable: React.FC<LtrModelTableProps> = ({ isLoading, findItems, history }) => {
+  const tableColumns = [
+    {
+      field: 'name',
+      name: 'Name',
+      dataType: 'string',
+      sortable: true,
+      // Model names are unique per store, so the name is the detail view's identifier.
+      render: (name: string) => (
+        <EuiButtonEmpty
+          size="xs"
+          {...reactRouterNavigate(
+            history,
+            `${Routes.LtrModelViewPrefix}/${encodeURIComponent(name)}`
+          )}
+        >
+          {name}
+        </EuiButtonEmpty>
+      ),
+    },
+    {
+      field: 'featureSetName',
+      name: 'Feature Set',
+      dataType: 'string',
+      sortable: true,
+      render: (featureSetName: string) => <EuiText size="s">{featureSetName}</EuiText>,
+    },
+    {
+      field: 'modelType',
+      name: 'Type',
+      dataType: 'string',
+      sortable: true,
+      render: (modelType: string) =>
+        modelType ? <EuiBadge color="hollow">{shortModelType(modelType)}</EuiBadge> : null,
+    },
+    {
+      field: 'featureCount',
+      name: 'Features',
+      dataType: 'number',
+      width: '15%',
+      sortable: true,
+      render: (featureCount: number) => <EuiText size="s">{featureCount}</EuiText>,
+    },
+  ];
+
+  return (
+    <TableListView
+      headingId="ltrModelListingHeading"
+      entityName="Model"
+      entityNamePlural="Models"
+      tableColumns={tableColumns}
+      findItems={findItems}
+      loading={isLoading}
+      initialPageSize={10}
+      search={{
+        box: {
+          incremental: true,
+          placeholder: 'Search models...',
+          schema: true,
+        },
+      }}
+      sorting={{
+        sort: {
+          field: 'name',
+          direction: 'asc',
+        },
+      }}
+    />
+  );
+};

--- a/public/components/ltr_model/components/ltr_model_upload_form.tsx
+++ b/public/components/ltr_model/components/ltr_model_upload_form.tsx
@@ -1,0 +1,148 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import {
+  EuiCallOut,
+  EuiComboBox,
+  EuiFieldText,
+  EuiForm,
+  EuiFormRow,
+  EuiSelect,
+  EuiSpacer,
+  EuiTextArea,
+} from '@elastic/eui';
+import { LtrFeatureSetSummary, LTR_MODEL_TYPES } from '../types';
+import { isJsonModelType } from '../utils/definition';
+import { LtrModelUploadErrors } from '../hooks/use_ltr_model_upload_form';
+
+interface LtrModelUploadFormProps {
+  name: string;
+  setName: (name: string) => void;
+  featureSetName: string;
+  setFeatureSetName: (featureSetName: string) => void;
+  modelType: string;
+  setModelType: (modelType: string) => void;
+  definitionText: string;
+  setDefinitionText: (definition: string) => void;
+  errors: LtrModelUploadErrors;
+  featureSets: LtrFeatureSetSummary[];
+  isLoadingFeatureSets: boolean;
+}
+
+const MODEL_TYPE_OPTIONS = [
+  { value: '', text: 'Select a model type' },
+  ...LTR_MODEL_TYPES.map((type) => ({ value: type, text: type })),
+];
+
+export const LtrModelUploadForm: React.FC<LtrModelUploadFormProps> = ({
+  name,
+  setName,
+  featureSetName,
+  setFeatureSetName,
+  modelType,
+  setModelType,
+  definitionText,
+  setDefinitionText,
+  errors,
+  featureSets,
+  isLoadingFeatureSets,
+}) => {
+  const featureSetOptions = featureSets.map((set) => ({
+    label: set.name,
+    value: set.name,
+  }));
+
+  const selectedFeatureSet = featureSets.find((set) => set.name === featureSetName);
+
+  return (
+    <EuiForm component="form">
+      <EuiFormRow
+        label="Model name"
+        helpText="Used to reference the model in an sltr query. Names are unique per store and cannot be changed or reused."
+        isInvalid={!!errors.name}
+        error={errors.name}
+      >
+        <EuiFieldText
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          isInvalid={!!errors.name}
+          data-test-subj="ltrModelUploadName"
+        />
+      </EuiFormRow>
+
+      <EuiFormRow
+        label="Feature set"
+        helpText={
+          selectedFeatureSet
+            ? `${selectedFeatureSet.featureCount} features. The definition must score exactly these, in this order.`
+            : 'The feature set the model was trained against.'
+        }
+        isInvalid={!!errors.featureSetName}
+        error={errors.featureSetName}
+      >
+        <EuiComboBox
+          singleSelection={{ asPlainText: true }}
+          options={featureSetOptions}
+          selectedOptions={featureSetName ? [{ label: featureSetName }] : []}
+          onChange={(selected) => setFeatureSetName(selected[0]?.label ?? '')}
+          isLoading={isLoadingFeatureSets}
+          isInvalid={!!errors.featureSetName}
+          isClearable={true}
+          placeholder="Select a feature set"
+          data-test-subj="ltrModelUploadFeatureSet"
+        />
+      </EuiFormRow>
+
+      <EuiFormRow
+        label="Model type"
+        helpText="The parser the LTR plugin uses to read the definition below."
+        isInvalid={!!errors.modelType}
+        error={errors.modelType}
+      >
+        <EuiSelect
+          options={MODEL_TYPE_OPTIONS}
+          value={modelType}
+          onChange={(e) => setModelType(e.target.value)}
+          isInvalid={!!errors.modelType}
+          data-test-subj="ltrModelUploadType"
+        />
+      </EuiFormRow>
+
+      <EuiFormRow
+        label="Model definition"
+        helpText={
+          isJsonModelType(modelType)
+            ? 'Paste the trained model as JSON.'
+            : 'Paste the trained model exactly as the trainer emitted it.'
+        }
+        isInvalid={!!errors.definition}
+        error={errors.definition}
+        fullWidth
+      >
+        <EuiTextArea
+          value={definitionText}
+          onChange={(e) => setDefinitionText(e.target.value)}
+          isInvalid={!!errors.definition}
+          rows={16}
+          fullWidth
+          data-test-subj="ltrModelUploadDefinition"
+        />
+      </EuiFormRow>
+
+      {!isLoadingFeatureSets && featureSets.length === 0 && (
+        <>
+          <EuiSpacer size="m" />
+          <EuiCallOut title="No feature sets in this store" color="warning" iconType="alert">
+            <p>
+              A model is created against a feature set, and this store has none. Create one with
+              POST _ltr/_featureset/&#123;name&#125; before uploading a model.
+            </p>
+          </EuiCallOut>
+        </>
+      )}
+    </EuiForm>
+  );
+};

--- a/public/components/ltr_model/hooks/use_ltr_feature_set_list.ts
+++ b/public/components/ltr_model/hooks/use_ltr_feature_set_list.ts
@@ -1,0 +1,49 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { CoreStart } from '../../../../../../src/core/public';
+import { LtrModelService } from '../services/ltr_model_service';
+import { LtrFeatureSetSummary, LtrUnavailableReason } from '../types';
+
+/**
+ * Backs the upload form's feature set picker. A model is created against a feature set that
+ * already exists in the store -- this plugin does not author feature sets -- so an empty
+ * list is a dead end the form has to say something about rather than an error.
+ */
+export const useLtrFeatureSetList = (http: CoreStart['http']) => {
+  const service = useMemo(() => new LtrModelService(http), [http]);
+  const [featureSets, setFeatureSets] = useState<LtrFeatureSetSummary[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [unavailableReason, setUnavailableReason] = useState<LtrUnavailableReason | null>(null);
+
+  const fetchFeatureSets = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    setUnavailableReason(null);
+    try {
+      setFeatureSets(await service.listFeatureSets());
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error('Failed to load LTR feature sets', err);
+      setFeatureSets([]);
+      const reason = err?.body?.attributes?.ltrErrorType as LtrUnavailableReason | undefined;
+      if (reason) {
+        setUnavailableReason(reason);
+      } else {
+        setError(err?.body?.message || 'Failed to load feature sets due to an unknown error.');
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }, [service]);
+
+  useEffect(() => {
+    fetchFeatureSets();
+  }, [fetchFeatureSets]);
+
+  return { featureSets, isLoading, error, unavailableReason };
+};

--- a/public/components/ltr_model/hooks/use_ltr_model_list.ts
+++ b/public/components/ltr_model/hooks/use_ltr_model_list.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useState } from 'react';
+import { CoreStart } from '../../../../../../src/core/public';
+import { LTR_MODEL_FETCH_SIZE, ServiceEndpoints } from '../../../../common';
+import { LtrModelListItem, LtrUnavailableReason } from '../types';
+
+/**
+ * `GET /_ltr/_model` returns a raw OpenSearch search response rather than the flat list the
+ * neighbouring Search Relevance resources return, so entries are unwrapped from
+ * `hits.hits[]._source`.
+ */
+export const mapLtrModelFields = (hit: any): LtrModelListItem => {
+  const source = hit?._source ?? {};
+  const featureSet = source.model?.feature_set ?? {};
+  return {
+    name: source.name,
+    featureSetName: featureSet.name ?? '',
+    modelType: source.model?.model?.type ?? '',
+    featureCount: Array.isArray(featureSet.features) ? featureSet.features.length : 0,
+  };
+};
+
+export const useLtrModelList = (http: CoreStart['http']) => {
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [unavailableReason, setUnavailableReason] = useState<LtrUnavailableReason | null>(null);
+  // Set when the store holds more models than a single fetch returned, so the listing can say
+  // so rather than silently showing a partial registry.
+  const [truncatedTotal, setTruncatedTotal] = useState<number | null>(null);
+
+  const findLtrModels = async (search?: string) => {
+    setIsLoading(true);
+    setError(null);
+    setUnavailableReason(null);
+    setTruncatedTotal(null);
+    try {
+      const response = await http.get(ServiceEndpoints.LtrModels, {
+        query: { size: LTR_MODEL_FETCH_SIZE },
+      });
+
+      const hits = response?.hits?.hits ?? [];
+      const list = hits.map(mapLtrModelFields);
+
+      // `hits.total` is an object on a normal response but a bare number when the cluster
+      // runs with `rest_total_hits_as_int`; reading only `.value` would miss truncation there.
+      const rawTotal = response?.hits?.total;
+      const total = (typeof rawTotal === 'number' ? rawTotal : rawTotal?.value) ?? list.length;
+      if (total > list.length) {
+        setTruncatedTotal(total);
+      }
+
+      const filteredList = search
+        ? list.filter((item: LtrModelListItem) =>
+            item.name?.toLowerCase().includes(search.toLowerCase())
+          )
+        : list;
+
+      return {
+        total: filteredList.length,
+        hits: filteredList,
+      };
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error('Failed to load LTR models', err);
+      const reason = err?.body?.attributes?.ltrErrorType as LtrUnavailableReason | undefined;
+      if (reason) {
+        // Not an error the user needs to debug — the registry just has nothing to show yet.
+        setUnavailableReason(reason);
+      } else {
+        setError(err?.body?.message || 'Failed to load LTR models due to an unknown error.');
+      }
+      return {
+        total: 0,
+        hits: [],
+      };
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return {
+    isLoading,
+    error,
+    unavailableReason,
+    truncatedTotal,
+    findLtrModels,
+    setError,
+  };
+};

--- a/public/components/ltr_model/hooks/use_ltr_model_upload_form.ts
+++ b/public/components/ltr_model/hooks/use_ltr_model_upload_form.ts
@@ -1,0 +1,98 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useCallback, useState } from 'react';
+import { LtrModelUpload } from '../types';
+import { parseDefinition } from '../utils/definition';
+
+export interface LtrModelUploadErrors {
+  name?: string;
+  featureSetName?: string;
+  modelType?: string;
+  definition?: string;
+}
+
+export interface LtrModelUploadFormState {
+  name: string;
+  featureSetName: string;
+  modelType: string;
+  definitionText: string;
+}
+
+/**
+ * The store rejects a duplicate name rather than overwriting, and there is no update path,
+ * so a name collision can only be reported after the fact -- see the upload view. What can
+ * be checked up front is checked here.
+ */
+export const validateLtrModelUpload = (form: LtrModelUploadFormState): LtrModelUploadErrors => {
+  const errors: LtrModelUploadErrors = {};
+
+  if (!form.name.trim()) {
+    errors.name = 'A model name is required.';
+  } else if (form.name !== form.name.trim()) {
+    // The name becomes the store document id and goes into an sltr query verbatim, where
+    // surrounding whitespace is invisible and impossible to debug.
+    errors.name = 'A model name cannot start or end with whitespace.';
+  }
+
+  if (!form.featureSetName.trim()) {
+    errors.featureSetName = 'Select the feature set this model was built from.';
+  }
+
+  if (!form.modelType) {
+    errors.modelType = 'Select a model type.';
+  } else {
+    const { error } = parseDefinition(form.modelType, form.definitionText);
+    if (error) {
+      errors.definition = error;
+    }
+  }
+
+  return errors;
+};
+
+export const useLtrModelUploadForm = () => {
+  const [name, setName] = useState('');
+  const [featureSetName, setFeatureSetName] = useState('');
+  const [modelType, setModelType] = useState<string>('');
+  const [definitionText, setDefinitionText] = useState('');
+  const [errors, setErrors] = useState<LtrModelUploadErrors>({});
+
+  /**
+   * Validates and returns the payload, or null with `errors` populated. Errors only appear
+   * once the user has tried to submit; nothing is flagged while the form is still being
+   * filled in.
+   */
+  const validate = useCallback((): LtrModelUpload | null => {
+    const form = { name, featureSetName, modelType, definitionText };
+    const found = validateLtrModelUpload(form);
+    setErrors(found);
+
+    if (Object.keys(found).length > 0) {
+      return null;
+    }
+
+    return {
+      name: name.trim(),
+      featureSetName: featureSetName.trim(),
+      modelType,
+      definition: parseDefinition(modelType, definitionText).value,
+    };
+  }, [name, featureSetName, modelType, definitionText]);
+
+  return {
+    name,
+    setName,
+    featureSetName,
+    setFeatureSetName,
+    modelType,
+    setModelType,
+    definitionText,
+    setDefinitionText,
+    errors,
+    setErrors,
+    validate,
+  };
+};

--- a/public/components/ltr_model/hooks/use_ltr_model_view.ts
+++ b/public/components/ltr_model/hooks/use_ltr_model_view.ts
@@ -1,0 +1,71 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+import { CoreStart } from '../../../../../../src/core/public';
+import { ServiceEndpoints } from '../../../../common';
+import { LtrFeature, LtrModelDetail, LtrUnavailableReason } from '../types';
+import { mapLtrModelFields } from './use_ltr_model_list';
+
+const mapFeature = (feature: any): LtrFeature => ({
+  name: feature?.name ?? '',
+  params: Array.isArray(feature?.params) ? feature.params : [],
+  templateLanguage: feature?.template_language ?? '',
+  template: feature?.template,
+});
+
+/**
+ * `GET /_ltr/_model/{name}` returns a document response, so the model itself is under
+ * `_source` exactly as it is in a listing hit — the listing mapper is reused for the shared
+ * fields.
+ */
+export const mapLtrModelDetail = (response: any): LtrModelDetail => {
+  const source = response?._source ?? {};
+  const features = source.model?.feature_set?.features;
+  return {
+    ...mapLtrModelFields(response),
+    features: Array.isArray(features) ? features.map(mapFeature) : [],
+    definition: source.model?.model?.definition,
+  };
+};
+
+export const useLtrModelView = (http: CoreStart['http'], name: string) => {
+  const [model, setModel] = useState<LtrModelDetail | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [notFound, setNotFound] = useState(false);
+  const [unavailableReason, setUnavailableReason] = useState<LtrUnavailableReason | null>(null);
+
+  const fetchModel = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    setNotFound(false);
+    setUnavailableReason(null);
+    try {
+      const response = await http.get(`${ServiceEndpoints.LtrModels}/${encodeURIComponent(name)}`);
+      setModel(mapLtrModelDetail(response));
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error('Failed to load LTR model', err);
+      setModel(null);
+      const reason = err?.body?.attributes?.ltrErrorType;
+      if (reason === 'model_not_found') {
+        setNotFound(true);
+      } else if (reason) {
+        setUnavailableReason(reason as LtrUnavailableReason);
+      } else {
+        setError(err?.body?.message || 'Failed to load the model due to an unknown error.');
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  }, [http, name]);
+
+  useEffect(() => {
+    fetchModel();
+  }, [fetchModel]);
+
+  return { model, isLoading, error, notFound, unavailableReason };
+};

--- a/public/components/ltr_model/index.ts
+++ b/public/components/ltr_model/index.ts
@@ -5,9 +5,15 @@
 
 export { LtrModelListingWithRoute as LtrModelListing } from './views/ltr_model_listing';
 export { LtrModelView } from './views/ltr_model_view';
+export { LtrModelUploadWithRouter as LtrModelUpload } from './views/ltr_model_upload';
 export { LtrModelTable } from './components/ltr_model_table';
 export { LtrModelDefinition, formatDefinition } from './components/ltr_model_definition';
 export { LtrFeatureTable } from './components/ltr_feature_table';
+export { LtrModelUploadForm } from './components/ltr_model_upload_form';
 export { useLtrModelList } from './hooks/use_ltr_model_list';
 export { useLtrModelView } from './hooks/use_ltr_model_view';
+export { useLtrFeatureSetList } from './hooks/use_ltr_feature_set_list';
+export { useLtrModelUploadForm, validateLtrModelUpload } from './hooks/use_ltr_model_upload_form';
+export { LtrModelService } from './services/ltr_model_service';
+export { isJsonModelType, parseDefinition } from './utils/definition';
 export * from './types';

--- a/public/components/ltr_model/index.ts
+++ b/public/components/ltr_model/index.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { LtrModelListingWithRoute as LtrModelListing } from './views/ltr_model_listing';
+export { LtrModelView } from './views/ltr_model_view';
+export { LtrModelTable } from './components/ltr_model_table';
+export { LtrModelDefinition, formatDefinition } from './components/ltr_model_definition';
+export { LtrFeatureTable } from './components/ltr_feature_table';
+export { useLtrModelList } from './hooks/use_ltr_model_list';
+export { useLtrModelView } from './hooks/use_ltr_model_view';
+export * from './types';

--- a/public/components/ltr_model/services/ltr_model_service.ts
+++ b/public/components/ltr_model/services/ltr_model_service.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { CoreStart } from '../../../../../../src/core/public';
+import { LTR_FEATURE_SET_FETCH_SIZE, ServiceEndpoints } from '../../../../common';
+import { LtrFeatureSetSummary, LtrModelUpload } from '../types';
+
+/** Feature set documents carry their contents under `featureset`, mirroring model hits. */
+export const mapLtrFeatureSetFields = (hit: any): LtrFeatureSetSummary => {
+  const source = hit?._source ?? {};
+  const features = source.featureset?.features;
+  return {
+    name: source.name,
+    featureCount: Array.isArray(features) ? features.length : 0,
+  };
+};
+
+export class LtrModelService {
+  constructor(private http: CoreStart['http']) {}
+
+  /**
+   * Feature sets exist only so the upload form can offer the ones a model can be built
+   * against. The registry does not otherwise show them.
+   */
+  async listFeatureSets(): Promise<LtrFeatureSetSummary[]> {
+    const response = await this.http.get(ServiceEndpoints.LtrFeatureSets, {
+      query: { size: LTR_FEATURE_SET_FETCH_SIZE },
+    });
+    const hits = response?.hits?.hits ?? [];
+    return hits.map(mapLtrFeatureSetFields).filter((set: LtrFeatureSetSummary) => set.name);
+  }
+
+  async createModel(model: LtrModelUpload): Promise<any> {
+    return this.http.post(ServiceEndpoints.LtrModels, {
+      body: JSON.stringify(model),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    });
+  }
+}

--- a/public/components/ltr_model/types.ts
+++ b/public/components/ltr_model/types.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * A registry entry as it exists in the LTR feature store today.
+ *
+ * The store's index mapping is `dynamic: strict` and holds only name, type, feature,
+ * featureset, and model — there is no creation timestamp to show, so the registry does not
+ * claim one. Versioning and lineage are likewise absent by design until the training and
+ * A/B stages put real requirements on the schema.
+ */
+export interface LtrModelListItem {
+  /** Store document name; unique per store and immutable once created. */
+  name: string;
+  /** The feature set the model was built from. */
+  featureSetName: string;
+  /** Parser type, e.g. model/ranklib, model/linear, model/xgboost+json. */
+  modelType: string;
+  /** Number of features in the attached feature set. */
+  featureCount: number;
+}
+
+/** Why a listing came back empty, when the reason is actionable. */
+export type LtrUnavailableReason = 'store_not_found' | 'plugin_disabled' | 'plugin_not_installed';
+
+/** A single feature in the feature set a model was built from. */
+export interface LtrFeature {
+  name: string;
+  params: string[];
+  templateLanguage: string;
+  template: any;
+}
+
+/**
+ * A model as shown on the detail view.
+ *
+ * `definition` is deliberately left as `any`: the LTR store writes it either as a raw string
+ * (RankLib) or as embedded JSON (linear, XGBoost), depending on how the model was created.
+ * See StoredLtrModel#toXContent.
+ */
+export interface LtrModelDetail extends LtrModelListItem {
+  features: LtrFeature[];
+  definition: any;
+}

--- a/public/components/ltr_model/types.ts
+++ b/public/components/ltr_model/types.ts
@@ -44,3 +44,31 @@ export interface LtrModelDetail extends LtrModelListItem {
   features: LtrFeature[];
   definition: any;
 }
+
+/**
+ * The model parsers the LTR plugin registers. The store accepts any string as a type but
+ * rejects the model at query time if nothing can parse it, so the upload form offers only
+ * the four types that exist.
+ */
+export const LTR_MODEL_TYPES = [
+  'model/ranklib',
+  'model/linear',
+  'model/xgboost+json',
+  'model/xgboost+json+raw',
+] as const;
+
+export type LtrModelType = typeof LTR_MODEL_TYPES[number];
+
+/** A feature set as listed for the upload form's picker. */
+export interface LtrFeatureSetSummary {
+  name: string;
+  featureCount: number;
+}
+
+/** The upload form's payload, flat; the server nests it for `_createmodel`. */
+export interface LtrModelUpload {
+  name: string;
+  featureSetName: string;
+  modelType: string;
+  definition: any;
+}

--- a/public/components/ltr_model/unavailable_copy.ts
+++ b/public/components/ltr_model/unavailable_copy.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { LtrUnavailableReason } from './types';
+
+/**
+ * The registry is only as available as the LTR plugin behind it, and this plugin ships
+ * independently of it. Each reason gets its own next step instead of a generic failure.
+ */
+export const LTR_UNAVAILABLE_COPY: Record<LtrUnavailableReason, { title: string; body: string }> = {
+  store_not_found: {
+    title: 'No feature store found',
+    body:
+      'The Learning to Rank plugin is running, but no feature store exists yet. Create one with ' +
+      'PUT _ltr, then add a feature set and a model.',
+  },
+  plugin_disabled: {
+    title: 'Learning to Rank is disabled',
+    body:
+      'The Learning to Rank plugin is installed but turned off. Set ltr.plugin.enabled to true in ' +
+      'the cluster settings to use the model registry.',
+  },
+  plugin_not_installed: {
+    title: 'Learning to Rank is not installed',
+    body:
+      'This cluster has no Learning to Rank plugin, so there are no models to show. Install ' +
+      'opensearch-learning-to-rank-base to use the model registry.',
+  },
+};

--- a/public/components/ltr_model/utils/definition.ts
+++ b/public/components/ltr_model/utils/definition.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * RankLib models are a plain-text format; the other three parsers all take JSON. The store
+ * itself accepts either shape for any type -- `definition` is declared
+ * OBJECT_ARRAY_OR_STRING -- so nothing rejects a RankLib model pasted as JSON or an XGBoost
+ * model pasted as a quoted string. That leniency is what makes a typo silent until query
+ * time, so the upload form holds the line here instead.
+ */
+export const isJsonModelType = (modelType: string): boolean =>
+  Boolean(modelType) && modelType !== 'model/ranklib';
+
+export interface ParsedDefinition {
+  /** The value to send, already in the shape `_createmodel` should store. */
+  value?: any;
+  /** Set when the text cannot be sent as the given type. */
+  error?: string;
+}
+
+/**
+ * Turns the pasted text into what goes on the wire: parsed JSON for the JSON model types,
+ * the text verbatim for RankLib. Sending parsed JSON rather than a string keeps a model
+ * uploaded here byte-identical in the store to the same model created with curl.
+ */
+export const parseDefinition = (modelType: string, text: string): ParsedDefinition => {
+  const trimmed = text?.trim() ?? '';
+  if (!trimmed) {
+    return { error: 'A model definition is required.' };
+  }
+
+  if (!isJsonModelType(modelType)) {
+    // Verbatim, not trimmed: RankLib definitions are whitespace-significant.
+    return { value: text };
+  }
+
+  try {
+    return { value: JSON.parse(trimmed) };
+  } catch (err) {
+    return { error: `${modelType} definitions must be valid JSON. ${(err as Error).message}` };
+  }
+};

--- a/public/components/ltr_model/views/ltr_model_listing.tsx
+++ b/public/components/ltr_model/views/ltr_model_listing.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { EuiCallOut, EuiFlexItem, EuiPageHeader, EuiPageTemplate, EuiSpacer } from '@elastic/eui';
+import { RouteComponentProps, withRouter } from 'react-router-dom';
+import { CoreStart } from '../../../../../../src/core/public';
+import { LTR_MODEL_FETCH_SIZE } from '../../../../common';
+import { LtrModelTable } from '../components/ltr_model_table';
+import { useLtrModelList } from '../hooks/use_ltr_model_list';
+import { LTR_UNAVAILABLE_COPY } from '../unavailable_copy';
+
+interface LtrModelListingProps extends RouteComponentProps {
+  http: CoreStart['http'];
+}
+
+export const LtrModelListing: React.FC<LtrModelListingProps> = ({ http, history }) => {
+  const { isLoading, error, unavailableReason, truncatedTotal, findLtrModels } = useLtrModelList(
+    http
+  );
+
+  const renderBody = () => {
+    if (error) {
+      return (
+        <EuiCallOut title="Error" color="danger">
+          <p>{error}</p>
+        </EuiCallOut>
+      );
+    }
+
+    if (unavailableReason) {
+      const { title, body } = LTR_UNAVAILABLE_COPY[unavailableReason];
+      return (
+        <EuiCallOut title={title} color="primary" iconType="iInCircle">
+          <p>{body}</p>
+        </EuiCallOut>
+      );
+    }
+
+    return (
+      <>
+        {truncatedTotal !== null && (
+          <>
+            <EuiCallOut title="Showing part of the registry" color="warning" iconType="alert">
+              <p>
+                This store holds {truncatedTotal} models. Showing the first {LTR_MODEL_FETCH_SIZE}.
+              </p>
+            </EuiCallOut>
+            <EuiSpacer size="m" />
+          </>
+        )}
+        <LtrModelTable isLoading={isLoading} findItems={findLtrModels} history={history} />
+      </>
+    );
+  };
+
+  return (
+    <EuiPageTemplate paddingSize="l" restrictWidth="100%">
+      <EuiPageHeader
+        pageTitle="LTR Models"
+        description="Learning to Rank models stored in this cluster's feature store."
+      />
+      <EuiFlexItem>{renderBody()}</EuiFlexItem>
+    </EuiPageTemplate>
+  );
+};
+
+export const LtrModelListingWithRoute = withRouter(LtrModelListing);

--- a/public/components/ltr_model/views/ltr_model_listing.tsx
+++ b/public/components/ltr_model/views/ltr_model_listing.tsx
@@ -4,10 +4,17 @@
  */
 
 import React from 'react';
-import { EuiCallOut, EuiFlexItem, EuiPageHeader, EuiPageTemplate, EuiSpacer } from '@elastic/eui';
+import {
+  EuiButton,
+  EuiCallOut,
+  EuiFlexItem,
+  EuiPageHeader,
+  EuiPageTemplate,
+  EuiSpacer,
+} from '@elastic/eui';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { CoreStart } from '../../../../../../src/core/public';
-import { LTR_MODEL_FETCH_SIZE } from '../../../../common';
+import { LTR_MODEL_FETCH_SIZE, Routes } from '../../../../common';
 import { LtrModelTable } from '../components/ltr_model_table';
 import { useLtrModelList } from '../hooks/use_ltr_model_list';
 import { LTR_UNAVAILABLE_COPY } from '../unavailable_copy';
@@ -61,6 +68,24 @@ export const LtrModelListing: React.FC<LtrModelListingProps> = ({ http, history 
       <EuiPageHeader
         pageTitle="LTR Models"
         description="Learning to Rank models stored in this cluster's feature store."
+        // Hidden when the registry itself is unavailable: with no reachable store there is
+        // nothing to upload into.
+        rightSideItems={
+          unavailableReason
+            ? []
+            : [
+                <EuiButton
+                  onClick={() => history.push(Routes.LtrModelCreate)}
+                  fill
+                  size="s"
+                  iconType="plusInCircle"
+                  color="primary"
+                  data-test-subj="createLtrModelButton"
+                >
+                  Upload Model
+                </EuiButton>,
+              ]
+        }
       />
       <EuiFlexItem>{renderBody()}</EuiFlexItem>
     </EuiPageTemplate>

--- a/public/components/ltr_model/views/ltr_model_upload.tsx
+++ b/public/components/ltr_model/views/ltr_model_upload.tsx
@@ -1,0 +1,145 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useCallback, useMemo, useState } from 'react';
+import {
+  EuiButton,
+  EuiButtonEmpty,
+  EuiCallOut,
+  EuiFlexItem,
+  EuiPageHeader,
+  EuiPageTemplate,
+  EuiPanel,
+  EuiSpacer,
+} from '@elastic/eui';
+import { RouteComponentProps, withRouter } from 'react-router-dom';
+import { CoreStart, NotificationsStart } from '../../../../../../src/core/public';
+import { Routes } from '../../../../common';
+import { LtrModelUploadForm } from '../components/ltr_model_upload_form';
+import { useLtrFeatureSetList } from '../hooks/use_ltr_feature_set_list';
+import { useLtrModelUploadForm } from '../hooks/use_ltr_model_upload_form';
+import { LtrModelService } from '../services/ltr_model_service';
+import { LTR_UNAVAILABLE_COPY } from '../unavailable_copy';
+
+interface LtrModelUploadProps extends RouteComponentProps {
+  http: CoreStart['http'];
+  notifications: NotificationsStart;
+}
+
+export const LtrModelUpload: React.FC<LtrModelUploadProps> = ({ http, notifications, history }) => {
+  const form = useLtrModelUploadForm();
+  const service = useMemo(() => new LtrModelService(http), [http]);
+  const { featureSets, isLoading, unavailableReason } = useLtrFeatureSetList(http);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleCancel = useCallback(() => {
+    history.push(Routes.LtrModelListing);
+  }, [history]);
+
+  const uploadModel = useCallback(async () => {
+    const model = form.validate();
+    if (!model) {
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      await service.createModel(model);
+      notifications.toasts.addSuccess(`Model "${model.name}" uploaded successfully`);
+      // Straight to the detail view: it renders the definition back out of the store, which
+      // is the only confirmation that what was pasted is what landed.
+      history.push(`${Routes.LtrModelViewPrefix}/${encodeURIComponent(model.name)}`);
+    } catch (err) {
+      const reason = err?.body?.attributes?.ltrErrorType;
+
+      // The store has no update path, so a collision is a form error the user can fix by
+      // renaming -- not a failure to report and walk away from.
+      if (reason === 'model_exists') {
+        form.setErrors({
+          name: `A model named "${model.name}" already exists. Models cannot be replaced, so choose a different name.`,
+        });
+      } else if (reason === 'featureset_not_found') {
+        form.setErrors({
+          featureSetName: `Feature set "${model.featureSetName}" is no longer in the store.`,
+        });
+      } else {
+        notifications.toasts.addError(err?.body || err, {
+          title: 'Failed to upload model',
+        });
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [form, service, notifications.toasts, history]);
+
+  const renderBody = () => {
+    if (unavailableReason) {
+      const { title, body } = LTR_UNAVAILABLE_COPY[unavailableReason];
+      return (
+        <EuiCallOut title={title} color="primary" iconType="iInCircle">
+          <p>{body}</p>
+        </EuiCallOut>
+      );
+    }
+
+    return (
+      <EuiPanel hasBorder={true}>
+        <EuiFlexItem>
+          <LtrModelUploadForm
+            name={form.name}
+            setName={form.setName}
+            featureSetName={form.featureSetName}
+            setFeatureSetName={form.setFeatureSetName}
+            modelType={form.modelType}
+            setModelType={form.setModelType}
+            definitionText={form.definitionText}
+            setDefinitionText={form.setDefinitionText}
+            errors={form.errors}
+            featureSets={featureSets}
+            isLoadingFeatureSets={isLoading}
+          />
+        </EuiFlexItem>
+      </EuiPanel>
+    );
+  };
+
+  return (
+    <EuiPageTemplate paddingSize="l" restrictWidth="100%">
+      <EuiPageHeader
+        pageTitle="Upload LTR Model"
+        description="Deploy a model trained outside the cluster into this cluster's feature store."
+        rightSideItems={
+          unavailableReason
+            ? []
+            : [
+                <EuiButtonEmpty
+                  onClick={handleCancel}
+                  iconType="cross"
+                  size="s"
+                  data-test-subj="cancelLtrModelUploadButton"
+                >
+                  Cancel
+                </EuiButtonEmpty>,
+                <EuiButton
+                  onClick={uploadModel}
+                  fill
+                  size="s"
+                  iconType="check"
+                  color="primary"
+                  isLoading={isSubmitting}
+                  data-test-subj="uploadLtrModelButton"
+                >
+                  Upload Model
+                </EuiButton>,
+              ]
+        }
+      />
+      <EuiSpacer size="s" />
+      {renderBody()}
+    </EuiPageTemplate>
+  );
+};
+
+export const LtrModelUploadWithRouter = withRouter(LtrModelUpload);

--- a/public/components/ltr_model/views/ltr_model_view.tsx
+++ b/public/components/ltr_model/views/ltr_model_view.tsx
@@ -1,0 +1,123 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import {
+  EuiBadge,
+  EuiCallOut,
+  EuiDescriptionList,
+  EuiDescriptionListDescription,
+  EuiDescriptionListTitle,
+  EuiLoadingSpinner,
+  EuiPageHeader,
+  EuiPageTemplate,
+  EuiPanel,
+  EuiSpacer,
+  EuiTitle,
+} from '@elastic/eui';
+import { CoreStart } from '../../../../../../src/core/public';
+import { LtrFeatureTable } from '../components/ltr_feature_table';
+import { LtrModelDefinition } from '../components/ltr_model_definition';
+import { shortModelType } from '../components/ltr_model_table';
+import { useLtrModelView } from '../hooks/use_ltr_model_view';
+import { LTR_UNAVAILABLE_COPY } from '../unavailable_copy';
+
+interface LtrModelViewProps {
+  http: CoreStart['http'];
+  id: string;
+}
+
+export const LtrModelView: React.FC<LtrModelViewProps> = ({ http, id }) => {
+  const { model, isLoading, error, notFound, unavailableReason } = useLtrModelView(http, id);
+
+  const renderBody = () => {
+    if (isLoading) {
+      return <EuiLoadingSpinner size="xl" data-test-subj="ltrModelViewLoading" />;
+    }
+
+    if (notFound) {
+      return (
+        <EuiCallOut title="Model not found" color="warning" iconType="alert">
+          <p>
+            No model named <strong>{id}</strong> exists in the feature store. It may have been
+            deleted.
+          </p>
+        </EuiCallOut>
+      );
+    }
+
+    if (unavailableReason) {
+      const { title, body } = LTR_UNAVAILABLE_COPY[unavailableReason];
+      return (
+        <EuiCallOut title={title} color="primary" iconType="iInCircle">
+          <p>{body}</p>
+        </EuiCallOut>
+      );
+    }
+
+    if (error || !model) {
+      return (
+        <EuiCallOut title="Error" color="danger">
+          <p>{error || 'Failed to load the model.'}</p>
+        </EuiCallOut>
+      );
+    }
+
+    return (
+      <>
+        <EuiPanel>
+          <EuiDescriptionList type="column" compressed>
+            <EuiDescriptionListTitle>Feature Set</EuiDescriptionListTitle>
+            <EuiDescriptionListDescription>
+              {model.featureSetName || <>&mdash;</>}
+            </EuiDescriptionListDescription>
+
+            <EuiDescriptionListTitle>Model Type</EuiDescriptionListTitle>
+            <EuiDescriptionListDescription>
+              {model.modelType ? (
+                <EuiBadge color="hollow">{shortModelType(model.modelType)}</EuiBadge>
+              ) : (
+                <>&mdash;</>
+              )}
+            </EuiDescriptionListDescription>
+
+            <EuiDescriptionListTitle>Features</EuiDescriptionListTitle>
+            <EuiDescriptionListDescription>{model.featureCount}</EuiDescriptionListDescription>
+          </EuiDescriptionList>
+        </EuiPanel>
+
+        <EuiSpacer size="l" />
+
+        <EuiPanel>
+          <EuiTitle size="s">
+            <h2>Feature Set</h2>
+          </EuiTitle>
+          <EuiSpacer size="m" />
+          <LtrFeatureTable features={model.features} />
+        </EuiPanel>
+
+        <EuiSpacer size="l" />
+
+        <EuiPanel>
+          <EuiTitle size="s">
+            <h2>Model Definition</h2>
+          </EuiTitle>
+          <EuiSpacer size="m" />
+          <LtrModelDefinition definition={model.definition} />
+        </EuiPanel>
+      </>
+    );
+  };
+
+  return (
+    <EuiPageTemplate paddingSize="l" restrictWidth="100%">
+      <EuiPageHeader
+        pageTitle={id}
+        description="A Learning to Rank model stored in this cluster's feature store."
+      />
+      {renderBody()}
+    </EuiPageTemplate>
+  );
+};

--- a/server/plugin.test.ts
+++ b/server/plugin.test.ts
@@ -9,6 +9,7 @@ import { SearchRelevancePlugin } from './plugin';
 jest.mock('./routes', () => ({
   defineRoutes: jest.fn(),
   registerSearchRelevanceRoutes: jest.fn(),
+  registerLtrRoutes: jest.fn(),
 }));
 
 jest.mock('./routes/ml_route_service', () => ({

--- a/server/plugin.ts
+++ b/server/plugin.ts
@@ -15,7 +15,7 @@ import {
   Plugin,
   PluginInitializerContext,
 } from '../../../src/core/server';
-import { defineRoutes, registerSearchRelevanceRoutes } from './routes';
+import { defineRoutes, registerLtrRoutes, registerSearchRelevanceRoutes } from './routes';
 
 import { DataSourcePluginSetup } from '../../../src/plugins/data_source/server/types';
 import { DataSourceManagementPlugin } from '../../../src/plugins/data_source_management/public/plugin';
@@ -134,6 +134,7 @@ export class SearchRelevancePlugin
     // Register server side APIs
     defineRoutes(router, core.opensearch, dataSourceEnabled);
     registerSearchRelevanceRoutes(router, dataSourceEnabled);
+    registerLtrRoutes(router);
     registerMLRoutes(router, dataSourceEnabled);
 
     // Add UBI sample data if home plugin is available

--- a/server/routes/index.ts
+++ b/server/routes/index.ts
@@ -17,3 +17,4 @@ export function defineRoutes(
 }
 
 export * from './search_relevance_route_service';
+export * from './ltr_route_service';

--- a/server/routes/ltr_route_service.test.ts
+++ b/server/routes/ltr_route_service.test.ts
@@ -1,0 +1,122 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { ltrError, registerLtrRoutes, storePath } from './ltr_route_service';
+
+describe('storePath', () => {
+  it('reads the default store when no store is named', () => {
+    expect(storePath('/_ltr/_model')).toBe('/_ltr/_model');
+  });
+
+  it('qualifies the path with a named store', () => {
+    expect(storePath('/_ltr/_model', 'my_store')).toBe('/_ltr/my_store/_model');
+  });
+
+  it('keeps the deeper feature set paths intact', () => {
+    expect(storePath('/_ltr/_featureset', 'my_store')).toBe('/_ltr/my_store/_featureset');
+    expect(storePath('/_ltr/_featureset/movies', 'my_store')).toBe(
+      '/_ltr/my_store/_featureset/movies'
+    );
+  });
+
+  it('encodes a store name so it cannot traverse out of the _ltr namespace', () => {
+    expect(storePath('/_ltr/_model', '../../_cluster/settings')).toBe(
+      '/_ltr/..%2F..%2F_cluster%2Fsettings/_model'
+    );
+  });
+});
+
+describe('ltrError', () => {
+  const response = { customError: jest.fn((arg) => arg) } as any;
+
+  beforeEach(() => jest.clearAllMocks());
+
+  const attributesOf = (err: any) => ltrError(response, err).body.attributes;
+
+  // Bodies below are verbatim from OpenSearch 3.3.0 / opensearch-ltr 3.3.0.0.
+  it('classifies a missing model separately from a missing store', () => {
+    const err = {
+      statusCode: 404,
+      body: { _index: '.ltrstore', _id: 'model-ghost', found: false },
+    };
+    expect(attributesOf(err).ltrErrorType).toBe('model_not_found');
+  });
+
+  it('classifies a missing feature store', () => {
+    const err = {
+      statusCode: 404,
+      body: {
+        error: {
+          type: 'index_not_found_exception',
+          reason: 'no such index [.ltrstore_nosuchstore]',
+        },
+      },
+    };
+    expect(attributesOf(err).ltrErrorType).toBe('store_not_found');
+  });
+
+  // A disabled plugin is an illegal_state_exception, which surfaces as 500 rather than the
+  // 4xx the other cases use -- hence classification on the body rather than the status.
+  it('classifies a disabled LTR plugin despite its 500 status', () => {
+    const err = {
+      statusCode: 500,
+      body: {
+        error: {
+          type: 'illegal_state_exception',
+          reason: 'LTR plugin is disabled. To enable, update ltr.plugin.enabled to true',
+        },
+        status: 500,
+      },
+    };
+    expect(attributesOf(err).ltrErrorType).toBe('plugin_disabled');
+  });
+
+  // An unknown route returns error as a bare string, not an object.
+  it('classifies an uninstalled LTR plugin from a string error body', () => {
+    const err = {
+      statusCode: 400,
+      body: { error: 'no handler found for uri [/_ltr/_model] and method [GET]' },
+    };
+    expect(attributesOf(err).ltrErrorType).toBe('plugin_not_installed');
+  });
+
+  it('leaves an unrecognized failure unclassified', () => {
+    const err = { statusCode: 500, body: { error: { reason: 'circuit_breaking_exception' } } };
+    const attributes = attributesOf(err);
+    expect(attributes.ltrErrorType).toBeUndefined();
+    expect(attributes.error).toBe('circuit_breaking_exception');
+  });
+
+  it('falls back to the raw message when there is no structured error body', () => {
+    expect(ltrError(response, { message: 'socket hang up' }).body.message).toBe('socket hang up');
+  });
+
+  it('passes a real error status through', () => {
+    expect(ltrError(response, { statusCode: 404, body: { found: false } }).statusCode).toBe(404);
+  });
+
+  // `response.customError` throws outside 400-599, which would replace the classified error
+  // with an unhandled exception.
+  it.each([[0], [200], [302], [600], [undefined], ['503']])(
+    'substitutes 500 for an out-of-range statusCode %p',
+    (statusCode) => {
+      expect(ltrError(response, { statusCode, message: 'transport failure' }).statusCode).toBe(500);
+    }
+  );
+});
+
+describe('registerLtrRoutes', () => {
+  it('registers the listing and detail routes', () => {
+    const router = { get: jest.fn() } as any;
+
+    registerLtrRoutes(router);
+
+    expect(router.get).toHaveBeenCalledTimes(2);
+    expect(router.get.mock.calls.map((call: any[]) => call[0].path)).toEqual([
+      '/api/relevancy/ltr/models',
+      '/api/relevancy/ltr/models/{name}',
+    ]);
+  });
+});

--- a/server/routes/ltr_route_service.test.ts
+++ b/server/routes/ltr_route_service.test.ts
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { ltrError, registerLtrRoutes, storePath } from './ltr_route_service';
+import { createModelBody, ltrError, registerLtrRoutes, storePath } from './ltr_route_service';
 
 describe('storePath', () => {
   it('reads the default store when no store is named', () => {
@@ -18,6 +18,12 @@ describe('storePath', () => {
     expect(storePath('/_ltr/_featureset', 'my_store')).toBe('/_ltr/my_store/_featureset');
     expect(storePath('/_ltr/_featureset/movies', 'my_store')).toBe(
       '/_ltr/my_store/_featureset/movies'
+    );
+  });
+
+  it('qualifies a create path, which carries segments after the collection', () => {
+    expect(storePath('/_ltr/_featureset/my_set/_createmodel', 'my_store')).toBe(
+      '/_ltr/my_store/_featureset/my_set/_createmodel'
     );
   });
 
@@ -82,6 +88,49 @@ describe('ltrError', () => {
     expect(attributesOf(err).ltrErrorType).toBe('plugin_not_installed');
   });
 
+  // _createmodel checks for the store itself and raises an illegal_argument rather than
+  // letting the read 404, so the same condition arrives worded differently.
+  it('classifies a missing store reported by _createmodel', () => {
+    const err = {
+      statusCode: 400,
+      body: {
+        error: {
+          type: 'illegal_argument_exception',
+          reason: 'Store [_default_] does not exist, please create it first.',
+        },
+      },
+    };
+    expect(attributesOf(err).ltrErrorType).toBe('store_not_found');
+  });
+
+  it('classifies an upload against a feature set that is not in the store', () => {
+    const err = {
+      statusCode: 400,
+      body: {
+        error: {
+          type: 'illegal_argument_exception',
+          reason: 'Stored feature set [my_set] does not exist',
+        },
+      },
+    };
+    expect(attributesOf(err).ltrErrorType).toBe('featureset_not_found');
+  });
+
+  // The store has no update path: a version conflict is reported as a 405 telling the user
+  // to pick another name, which is a form error rather than a transport failure.
+  it('classifies a duplicate model name', () => {
+    const err = {
+      statusCode: 405,
+      body: {
+        error: {
+          type: 'illegal_argument_exception',
+          reason: 'Element of type [model] are not updatable, please create a new one instead.',
+        },
+      },
+    };
+    expect(attributesOf(err).ltrErrorType).toBe('model_exists');
+  });
+
   it('leaves an unrecognized failure unclassified', () => {
     const err = { statusCode: 500, body: { error: { reason: 'circuit_breaking_exception' } } };
     const attributes = attributesOf(err);
@@ -108,15 +157,55 @@ describe('ltrError', () => {
 });
 
 describe('registerLtrRoutes', () => {
-  it('registers the listing and detail routes', () => {
-    const router = { get: jest.fn() } as any;
-
+  const register = () => {
+    const router = { get: jest.fn(), post: jest.fn() } as any;
     registerLtrRoutes(router);
+    return router;
+  };
 
-    expect(router.get).toHaveBeenCalledTimes(2);
+  it('registers the listing, detail, and feature set routes', () => {
+    const router = register();
+
+    expect(router.get).toHaveBeenCalledTimes(3);
     expect(router.get.mock.calls.map((call: any[]) => call[0].path)).toEqual([
       '/api/relevancy/ltr/models',
       '/api/relevancy/ltr/models/{name}',
+      '/api/relevancy/ltr/feature_sets',
     ]);
+  });
+
+  it('registers the upload route', () => {
+    const router = register();
+
+    expect(router.post).toHaveBeenCalledTimes(1);
+    expect(router.post.mock.calls[0][0].path).toBe('/api/relevancy/ltr/models');
+  });
+
+  it('accepts both definition shapes the store stores', () => {
+    const router = register();
+    const { body } = router.post.mock.calls[0][0].validate;
+    const model = {
+      name: 'my_model',
+      featureSetName: 'my_set',
+      modelType: 'model/linear',
+    };
+
+    // Constraining `definition` would reject one of the two valid forms outright.
+    expect(() => body.validate({ ...model, definition: '## LambdaMART' })).not.toThrow();
+    expect(() => body.validate({ ...model, definition: { title_match: 0.4 } })).not.toThrow();
+  });
+
+  it('rejects an upload with no name', () => {
+    const router = register();
+    const { body } = router.post.mock.calls[0][0].validate;
+
+    expect(() =>
+      body.validate({
+        name: '',
+        featureSetName: 'my_set',
+        modelType: 'model/linear',
+        definition: '{}',
+      })
+    ).toThrow();
   });
 });

--- a/server/routes/ltr_route_service.ts
+++ b/server/routes/ltr_route_service.ts
@@ -11,14 +11,16 @@ import {
   OpenSearchDashboardsResponseFactory,
   RequestHandlerContext,
 } from '../../../../src/core/server';
-import { LtrBackendEndpoints, ServiceEndpoints } from '../../common';
+import { LtrBackendEndpoints, ltrCreateModelPath, ServiceEndpoints } from '../../common';
 
 /**
  * Routes backing the Learning to Rank model registry.
  *
  * These proxy to the LTR plugin's own `_ltr/*` namespace rather than
  * `_plugins/_search_relevance`. The `.ltrstore*` indices are registered system indices, so
- * the plugin's REST endpoints are the only supported way to read them.
+ * the plugin's REST endpoints are the only supported way to read or write them. Requests
+ * carry the calling user's credentials, so authorization stays with the LTR and security
+ * plugins.
  */
 export function registerLtrRoutes(router: IRouter): void {
   router.get(
@@ -49,6 +51,42 @@ export function registerLtrRoutes(router: IRouter): void {
       },
     },
     getModel
+  );
+
+  router.get(
+    {
+      path: ServiceEndpoints.LtrFeatureSets,
+      validate: {
+        query: schema.object({
+          size: schema.maybe(schema.number({ min: 1 })),
+          from: schema.maybe(schema.number({ min: 0 })),
+          prefix: schema.maybe(schema.string()),
+          store: schema.maybe(schema.string()),
+        }),
+      },
+    },
+    listFeatureSets
+  );
+
+  router.post(
+    {
+      path: ServiceEndpoints.LtrModels,
+      validate: {
+        // `definition` is deliberately unconstrained: the LTR store accepts either a raw
+        // string (RankLib) or embedded JSON (linear, XGBoost) and stores whichever it is
+        // given. Narrowing it here would reject valid models.
+        body: schema.object({
+          name: schema.string({ minLength: 1 }),
+          featureSetName: schema.string({ minLength: 1 }),
+          modelType: schema.string({ minLength: 1 }),
+          definition: schema.any(),
+        }),
+        query: schema.object({
+          store: schema.maybe(schema.string()),
+        }),
+      },
+    },
+    createModel
   );
 }
 
@@ -95,6 +133,77 @@ const getModel = async (
     const result = await caller('transport.request', {
       method: 'GET',
       path: `${storePath(LtrBackendEndpoints.Models, store)}/${encodeURIComponent(name)}`,
+    });
+
+    return response.ok({ body: result });
+  } catch (err) {
+    return ltrError(response, err);
+  }
+};
+
+const listFeatureSets = async (
+  context: RequestHandlerContext,
+  request: OpenSearchDashboardsRequest,
+  response: OpenSearchDashboardsResponseFactory
+): Promise<IOpenSearchDashboardsResponse<any>> => {
+  const { size, from, prefix, store } = request.query as {
+    size?: number;
+    from?: number;
+    prefix?: string;
+    store?: string;
+  };
+
+  try {
+    const caller = context.core.opensearch.legacy.client.callAsCurrentUser;
+    const result = await caller('transport.request', {
+      method: 'GET',
+      path: storePath(LtrBackendEndpoints.FeatureSets, store),
+      query: {
+        ...(size !== undefined ? { size } : {}),
+        ...(from !== undefined ? { from } : {}),
+        ...(prefix ? { prefix } : {}),
+      },
+    });
+
+    return response.ok({ body: result });
+  } catch (err) {
+    return ltrError(response, err);
+  }
+};
+
+/**
+ * Wraps the flat form payload in the nesting `_createmodel` expects. Keeping this on the
+ * server means the browser never has to know the store's document shape.
+ */
+export const createModelBody = (model: { name: string; modelType: string; definition: any }) => ({
+  model: {
+    name: model.name,
+    model: {
+      type: model.modelType,
+      definition: model.definition,
+    },
+  },
+});
+
+const createModel = async (
+  context: RequestHandlerContext,
+  request: OpenSearchDashboardsRequest,
+  response: OpenSearchDashboardsResponseFactory
+): Promise<IOpenSearchDashboardsResponse<any>> => {
+  const { name, featureSetName, modelType, definition } = request.body as {
+    name: string;
+    featureSetName: string;
+    modelType: string;
+    definition: any;
+  };
+  const { store } = request.query as { store?: string };
+
+  try {
+    const caller = context.core.opensearch.legacy.client.callAsCurrentUser;
+    const result = await caller('transport.request', {
+      method: 'POST',
+      path: storePath(ltrCreateModelPath(featureSetName), store),
+      body: createModelBody({ name, modelType, definition }),
     });
 
     return response.ok({ body: result });
@@ -153,6 +262,17 @@ export const ltrError = (response: OpenSearchDashboardsResponseFactory, err: any
   } else if (/index_not_found|no such index/i.test(reason)) {
     // LTR is installed but no feature store has been created yet.
     ltrErrorType = 'store_not_found';
+  } else if (/does not exist, please create it first/i.test(reason)) {
+    // Same condition as above, reported differently: _createmodel checks for the store
+    // itself and raises an illegal_argument rather than letting the read 404.
+    ltrErrorType = 'store_not_found';
+  } else if (/Stored feature set \[.*\] does not exist/i.test(reason)) {
+    // The upload named a feature set that is not in the store.
+    ltrErrorType = 'featureset_not_found';
+  } else if (/are not updatable, please create a new one instead/i.test(reason)) {
+    // The store has no update path, so a duplicate name is a name collision, not a
+    // transport failure. Surfaces as 405 by way of a version conflict.
+    ltrErrorType = 'model_exists';
   } else if (/LTR plugin is disabled/i.test(reason)) {
     ltrErrorType = 'plugin_disabled';
   } else if (/no handler found/i.test(reason)) {

--- a/server/routes/ltr_route_service.ts
+++ b/server/routes/ltr_route_service.ts
@@ -1,0 +1,172 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { schema } from '@osd/config-schema';
+import {
+  IOpenSearchDashboardsResponse,
+  IRouter,
+  OpenSearchDashboardsRequest,
+  OpenSearchDashboardsResponseFactory,
+  RequestHandlerContext,
+} from '../../../../src/core/server';
+import { LtrBackendEndpoints, ServiceEndpoints } from '../../common';
+
+/**
+ * Routes backing the Learning to Rank model registry.
+ *
+ * These proxy to the LTR plugin's own `_ltr/*` namespace rather than
+ * `_plugins/_search_relevance`. The `.ltrstore*` indices are registered system indices, so
+ * the plugin's REST endpoints are the only supported way to read them.
+ */
+export function registerLtrRoutes(router: IRouter): void {
+  router.get(
+    {
+      path: ServiceEndpoints.LtrModels,
+      validate: {
+        query: schema.object({
+          size: schema.maybe(schema.number({ min: 1 })),
+          from: schema.maybe(schema.number({ min: 0 })),
+          prefix: schema.maybe(schema.string()),
+          store: schema.maybe(schema.string()),
+        }),
+      },
+    },
+    listModels
+  );
+
+  router.get(
+    {
+      path: `${ServiceEndpoints.LtrModels}/{name}`,
+      validate: {
+        params: schema.object({
+          name: schema.string(),
+        }),
+        query: schema.object({
+          store: schema.maybe(schema.string()),
+        }),
+      },
+    },
+    getModel
+  );
+}
+
+const listModels = async (
+  context: RequestHandlerContext,
+  request: OpenSearchDashboardsRequest,
+  response: OpenSearchDashboardsResponseFactory
+): Promise<IOpenSearchDashboardsResponse<any>> => {
+  const { size, from, prefix, store } = request.query as {
+    size?: number;
+    from?: number;
+    prefix?: string;
+    store?: string;
+  };
+
+  try {
+    const caller = context.core.opensearch.legacy.client.callAsCurrentUser;
+    const result = await caller('transport.request', {
+      method: 'GET',
+      path: storePath(LtrBackendEndpoints.Models, store),
+      query: {
+        ...(size !== undefined ? { size } : {}),
+        ...(from !== undefined ? { from } : {}),
+        ...(prefix ? { prefix } : {}),
+      },
+    });
+
+    return response.ok({ body: result });
+  } catch (err) {
+    return ltrError(response, err);
+  }
+};
+
+const getModel = async (
+  context: RequestHandlerContext,
+  request: OpenSearchDashboardsRequest,
+  response: OpenSearchDashboardsResponseFactory
+): Promise<IOpenSearchDashboardsResponse<any>> => {
+  const { name } = request.params as { name: string };
+  const { store } = request.query as { store?: string };
+
+  try {
+    const caller = context.core.opensearch.legacy.client.callAsCurrentUser;
+    const result = await caller('transport.request', {
+      method: 'GET',
+      path: `${storePath(LtrBackendEndpoints.Models, store)}/${encodeURIComponent(name)}`,
+    });
+
+    return response.ok({ body: result });
+  } catch (err) {
+    return ltrError(response, err);
+  }
+};
+
+/**
+ * `_ltr/_model` reads the default store; `_ltr/{store}/_model` reads a named one. v1 always
+ * uses the default store, but the parameter is threaded through so a store selector is a UI
+ * change rather than a refactor.
+ *
+ * The store name is encoded: it arrives as an unconstrained query parameter, and left raw a
+ * value like `../../_cluster/settings` would traverse out of the `_ltr` namespace and address
+ * an unrelated API on the same cluster.
+ */
+export const storePath = (endpoint: string, store?: string): string => {
+  if (!store) {
+    return endpoint;
+  }
+  const [, ...rest] = endpoint.split('/').filter(Boolean);
+  return `/_ltr/${encodeURIComponent(store)}/${rest.join('/')}`;
+};
+
+/**
+ * Translates the two failure modes a fresh cluster actually hits into something the UI can
+ * act on, rather than surfacing a raw transport error.
+ */
+export const ltrError = (response: OpenSearchDashboardsResponseFactory, err: any) => {
+  // eslint-disable-next-line no-console
+  console.error('Failed to call Learning to Rank APIs', err);
+
+  // `response.customError` throws for anything outside 400-599, so an odd transport
+  // statusCode would turn a classified LTR error into an unhandled exception.
+  const rawStatusCode = err.statusCode;
+  const statusCode =
+    typeof rawStatusCode === 'number' && rawStatusCode >= 400 && rawStatusCode < 600
+      ? rawStatusCode
+      : 500;
+  const rawError = err.body?.error;
+  const reason: string =
+    (typeof rawError === 'object' && (rawError.reason || rawError.type)) ||
+    (typeof rawError === 'string' && rawError) ||
+    err.message ||
+    '';
+
+  // Classified on the response body alone, deliberately not on the status code. Verified
+  // against OpenSearch 3.3.0 with opensearch-ltr 3.3.0.0, these do not share a convention:
+  // a missing model and a missing store are both 404, an unknown route is 400, but a
+  // disabled plugin surfaces an illegal_state_exception as 500.
+  let ltrErrorType: string | undefined;
+  if (err.body?.found === false) {
+    // The store exists; this particular model name does not.
+    ltrErrorType = 'model_not_found';
+  } else if (/index_not_found|no such index/i.test(reason)) {
+    // LTR is installed but no feature store has been created yet.
+    ltrErrorType = 'store_not_found';
+  } else if (/LTR plugin is disabled/i.test(reason)) {
+    ltrErrorType = 'plugin_disabled';
+  } else if (/no handler found/i.test(reason)) {
+    ltrErrorType = 'plugin_not_installed';
+  }
+
+  return response.customError({
+    statusCode,
+    body: {
+      message: reason || 'Failed to call Learning to Rank APIs',
+      attributes: {
+        error: reason,
+        ltrErrorType,
+      },
+    },
+  });
+};


### PR DESCRIPTION
### Description

Wraps `_createmodel` in a form: model name, feature set picker, model type, and definition. Definitions go to the store parsed for the JSON model types and verbatim for RankLib. Duplicate names and missing feature sets come back as field errors.

Design doc and rationale: opensearch-project/search-relevance#582.

Stacked on #943 and contains its commit. Review after that one merges, and this diff will shrink to the upload commit alone. (Cross-fork stacked PRs aren't supported, so the base can't point at #943.)

### Issues Resolved

None.

### Check List

- [x] New functionality includes testing.
  - [x] All tests pass, including unit test, integration test
- [x] New functionality has been documented.
- [x] Commits are signed per the DCO using `--signoff`